### PR TITLE
Fix python version discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,22 @@
 # CMake file for Pythonic PROCESS
-# Author  :   K. Zarebski (UKAEA)
-# Date    :   last modified 2020-11-09
+# Author  :   PROCESS Team (UKAEA)
+# Date    :   last modified 2023-07-24
 
 # Specify the minimum version for CMake
 # 3.12 is required due to use of list TRANSFORM commands
-CMAKE_MINIMUM_REQUIRED(VERSION 3.13)
+# 3.15 for cmake policy CMP0094
+CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 
 # Set project name
 PROJECT(process LANGUAGES Fortran)
+
+cmake_policy(SET CMP0094 NEW)
 
 # Ensure python3 interpreter is used
 if(CMAKE_HOST_APPLE)
     SET(CMAKE_FIND_FRAMEWORK NEVER)
     set(CMAKE_MACOSX_RPATH ON)
 endif()
-
-SET(Python3_FIND_VIRTUALENV FIRST)
 
 # Python 3.8 or greater
 find_package(Python3 3.8 COMPONENTS Interpreter Development)


### PR DESCRIPTION
Closes #2832 
This does a couple of small things, the main one is set the cmake policy to CMP0094 (https://cmake.org/cmake/help/latest/policy/CMP0094.html#policy:CMP0094). 

This set a few new defaults the first is `SET(Python3_FIND_VIRTUALENV FIRST)` which was being used anyway.

Secondly it sets `SET(Python3_FIND_STRATEGY LOCATION)` (see https://cmake.org/cmake/help/latest/module/FindPython3.html#hints) which is the fix to find the first python in your path (eg the activated environment) if it fulfills all the other conditions (eg min version).

I have changed the minimum cmake version which was was actually already required for `SET(Python3_FIND_VIRTUALENV FIRST)`

I've tested locally while fiddling with getting process updated for bluemira.