### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+
+<!---A clear and concise description of what the bug is.--->
+
+## Steps to reproduce
+
+<!---
+Steps to reproduce the behaviour including any input files
+--->
+
+## Expected behaviour
+
+<!--- A clear and concise description of what you expected to happen. --->
+
+## Evidence
+<!--- Tracebacks or screenshots. --->
+
+## Environment
+
+- OS: <!-- [e.g. Ubuntu 18.04] -->
+- Version: <!-- [e.g. 3.0.0] -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Please see the CONTRIBUTING.MD guide before creating feature requests.
+-->
+
+## Description of issue / requirement to address
+
+<!-- A clear and concise description of what the problem is. Please attach any references to papers for model introduction/change requests. -->
+
+## Proposed solution
+
+<!-- A clear and concise description of what you want to happen. -->

--- a/.github/ISSUE_TEMPLATE/other-issues.md
+++ b/.github/ISSUE_TEMPLATE/other-issues.md
@@ -1,0 +1,10 @@
+---
+name: Other issues
+about: For issues that are not bug reports or feature requests
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--- Please consider whether this issue will be better suited to the Discussion section of this GitHub repository --->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,17 +6,8 @@
 
 I confirm that I have completed the following checks:
 
-**Testing**
-- [ ] If I have changed any of the Python or Fortran code, I have rebuilt and run the tests locally and they have passed.
-- [ ] I have addressed any differences in the regression tests caused by this pull request in the comments.
+- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
 - [ ] I have added new tests where appropriate for the changes I have made.
 - [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
-
-**Quality**
-- [ ] I have ensured my changes are formatted correctly and conform to PROCESS' quality standards.
 - [ ] If I have made documentation changes, I have checked they render correctly.
-
-**Miscellaneous**
-- [ ] I have created a changelog entry for my change, if appropriate.
 - [ ] I have added documentation for my change, if appropriate.
-- [ ] **I confirm my contribution is made to PROCESS under an MIT license**.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Description
+
+<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
+
+## Checklist
+
+I confirm that I have completed the following checks:
+
+**Testing**
+- [ ] If I have changed any of the Python or Fortran code, I have rebuilt and run the tests locally and they have passed.
+- [ ] I have addressed any differences in the regression tests caused by this pull request in the comments.
+- [ ] I have added new tests where appropriate for the changes I have made.
+- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
+
+**Quality**
+- [ ] I have ensured my changes are formatted correctly and conform to PROCESS' quality standards.
+- [ ] If I have made documentation changes, I have checked they render correctly.
+
+**Miscellaneous**
+- [ ] I have created a changelog entry for my change, if appropriate.
+- [ ] I have added documentation for my change, if appropriate.
+- [ ] **I confirm my contribution is made to PROCESS under an MIT license**.


### PR DESCRIPTION
I think having issue templates will be a good QOL change for this repository pre-open-source. These issue templates are mostly taken from [bluemira](https://github.com/Fusion-Power-Plant-Framework/bluemira).

We should also add a PR template that reflects the proposed format of #2892.