### PR TITLE
Flush convergence callback

### DIFF
--- a/process/solver.py
+++ b/process/solver.py
@@ -169,7 +169,11 @@ class Vmcon(_Solver):
             B = np.identity(numerics.nvar) * self.b
 
         def _solver_callback(i: int, _x, _result, convergence_param: float):
-            print(f"{i+1} | Convergence Parameter: {convergence_param:.3E}", end="\r")
+            print(
+                f"{i+1} | Convergence Parameter: {convergence_param:.3E}",
+                end="\r",
+                flush=True,
+            )
 
         try:
             x, _, _, res = solve(


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
The implemented convergence callback for pyvmcon doesnt flush the print statement therefore in some situations the printing won't appear on stdout until a while later.
This enforces flushing after every update. 

I have no idea how you would test this so I haven't.

## Checklist

I confirm that I have completed the following checks:

- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
