### PR TITLE
Lock numpy and scipy versions to avoid build crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ mkdocs-material>=4.6.3
 mkdocs-git-revision-date-localized-plugin >= 1.2
 mkdocs-glightbox >= 0.3.4
 pymdown-extensions>=6.3
-numpy>=1.19.0,<=1.21.5
-scipy>=0.19.1
+numpy>=1.19.0,!=1.22,!=1.24,>=1.23.0
+scipy>=0.19.1,<1.11
 matplotlib>=2.1.1
 pillow>=5.1.0
 Markdown>=3.2.2,<3.4

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup_kwargs = {
     },
     "test_suite": "pytest",
     "install_requires": [
-        "numpy>=1.19.0,<1.22.1",
-        "scipy>=0.19.1",
+        "numpy>=1.19.0,!=1.22,!=1.24,>=1.23.0",
+        "scipy>=0.19.1,<1.11",
         "importlib-resources ; python_version<'3.9'",
         "pandas",
         "tables",


### PR DESCRIPTION
## Description

Locks numpy and scipy versions to those which do not cause a build system crash (Mac)

## Checklist

I confirm that I have completed the following checks:

- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
