### PR TITLE
updated error message for obsolete vars

### DIFF
--- a/process/main.py
+++ b/process/main.py
@@ -504,7 +504,6 @@ class SingleRun:
         """Checks the input IN.DAT file for any obsolete variables in the OBS_VARS dict contained
         within obsolete_variables.py.
         Then will print out what the used obsolete variables are (if any) before continuing the proces run.
-        #TODO: add a feature to stop 1 and force the variable to be updated if it is now obsolete.
         """
 
         obsolete_variables = ov.OBS_VARS
@@ -522,18 +521,20 @@ class SingleRun:
                     variables = line.strip().split(sep, 1)[0]
                     variables_in_in_dat.append(variables)
 
-        obs_vars_keys = []
-        for k in obsolete_variables:
-            obs_vars_keys.append(k)
+        obs_vars = []
+        replace_hints = []
+        for var in variables_in_in_dat:
+            new_var = obsolete_variables.get(var)
+            if new_var:
+                obs_vars.append(var)
+                replace_hints.append(new_var)
 
-        variable_check = any(i in variables_in_in_dat for i in obs_vars_keys)
-
-        if variable_check:
+        if len(replace_hints) > 0:
             print(
                 "The IN.DAT file contains obsolete variables from the OBS_VARS dictionary."
             )
             print(
-                f"The obsolete variables in your IN.DAT file are: {set(obs_vars_keys) & set(variables_in_in_dat)}. Please change them to the corresponding new variable(s) before continuing."
+                f"The obsolete variables in your IN.DAT file are: {obs_vars}. Please change them to the following corresponding new variable(s) before continuing: {replace_hints}."
             )
         else:
             print("The IN.DAT file does not contain any obsolete variables.")


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
Added to the error message for obsolete variables in the input file to state what their new variable name is from `obsolete_vars.py` as previously this was not output.
## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
