### PR TITLE
fix image displaying in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ PROCESS is the reactor systems code at the [UK Atomic Energy Authority](https://
 PROCESS was originally a Fortran code, but is currently a mixture of Python and Python-wrapped Fortran; the eventual aim is to have an entirely Python code base. In order to use PROCESS, the Fortran must be compiled and a Python-Fortran interface generated for the Python to import. Once built, it can be installed and run as a Python package.
 
 
-<figure markdown>
-![BlenderProcessImage](documentation/proc-pages/images/blender images/initial_collage.png){ width="100%"}
-<figcaption>Split view of DEMO-like reactor (generated using fusrr-pipeline).</figcaption>
-</figure>
+
+![BlenderImage](<documentation/proc-pages/images/blender images/initial_collage.png>)
+<center>Split view of DEMO-like reactor (generated using fusrr-pipeline).</center>
+
 
 ## Getting Started
 Please see the [installation guide](https://ukaea.github.io/PROCESS/installation/introduction/) and the [usage guide](https://ukaea.github.io/PROCESS/usage/running-process/). Once installed, the `examples` directory provides Jupyter notebooks for interactively demonstrating usage of PROCESS, which is a good place to start. The `examples/README.md` provides more help.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
Blender image was not displaying in readme on github, have fixed this now so it does display as expected

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
