### PR TITLE
2986 rebco critical current adjustment for type of cable

### DIFF
--- a/process/superconductors.py
+++ b/process/superconductors.py
@@ -486,13 +486,13 @@ def hijc_rebco(thelium, bmax, strain, bc20max, t_c0):
     jcrit = (A_t / bmax) * bcrit**b * (bmax / bcrit) ** p * (1 - bmax / bcrit) ** q
 
     # Jc times HTS area: default area is width 4mm times HTS layer thickness 1 um,
-    # divided by the tape area to provide engineering Jc per tape, then multiplied by fraction 0.4
-    # to reach the level of current density expected in the space where the tapes are wound in A/m^2!
+    # divided by the tape area to provide engineering Jc per tape,!
+    # A scaling factor of 0.4 used to be applied below to assume the difference
+    # between tape stacks and CORC cable layouts.
     jcrit = (
         jcrit
         * (rebco_variables.tape_width * rebco_variables.rebco_thickness)
         / (rebco_variables.tape_width * rebco_variables.tape_thickness)
-        * 0.4
     )
 
     return jcrit, bcrit, tcrit

--- a/process/superconductors.py
+++ b/process/superconductors.py
@@ -456,6 +456,10 @@ def hijc_rebco(thelium, bmax, strain, bc20max, t_c0):
     considering A(4.2 K) = 2.2e8, A(20 K) = 2.3e8 and A(65 K) = 3.5e8. These values were
     selected manually. A good fit to the pubished data can be seen in the 4-10 T range
     but the fit deviates at very low or very high field.
+
+    A scaling factor of 0.4 was originally applied to jcrit to accomodate the models
+    original purpose of being used with CORC cables, which PROCESS did not model as it
+    assumed a stacked tape block design
     """
 
     a = 1.4

--- a/process/superconductors.py
+++ b/process/superconductors.py
@@ -457,9 +457,10 @@ def hijc_rebco(thelium, bmax, strain, bc20max, t_c0):
     selected manually. A good fit to the pubished data can be seen in the 4-10 T range
     but the fit deviates at very low or very high field.
 
+    C. Ashe 2/11/23
     A scaling factor of 0.4 was originally applied to jcrit to accomodate the models
     original purpose of being used with CORC cables, which PROCESS did not model as it
-    assumed a stacked tape block design
+    assumed a stacked tape block design.
     """
 
     a = 1.4

--- a/tests/unit/test_superconductors.py
+++ b/tests/unit/test_superconductors.py
@@ -187,6 +187,6 @@ def test_gl_rebco():
 def test_hijc_rebco():
     jcrit, bcrit, tcrit = superconductors.hijc_rebco(4.75, 7.0, 2, 30.0, 25.0)
 
-    assert jcrit == pytest.approx(44418407.919617616)
+    assert jcrit == pytest.approx(111046017.5)
     assert bcrit == pytest.approx(22.335736687814954)
     assert tcrit == pytest.approx(24.999125)


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
A correction factor of 0.4 has been removed from the `jcrit` calculation as it was implemented assuming a CORC style cable which PROCESS does not model.
It has now been removed.
`test_hijc_rebco` unit test values adjusted.

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
