### PR TITLE
fix bug in output filename calculation in plot_radial_build.py

### DIFF
--- a/process/io/plot_radial_build.py
+++ b/process/io/plot_radial_build.py
@@ -460,7 +460,7 @@ def main(args=None):
     plt.xlabel("Radius [m]")
     plt.tight_layout()
     plt.savefig(
-        f"{args.outputdir}/{args.input[:-10]}_radial_build.{save_format}",
+        f"{args.outputdir}/{Path(args.input).stem}_radial_build.{save_format}",
         bbox_inches="tight",
     )
 


### PR DESCRIPTION
## Description

Filename calculation in `plot_radial_build.py` is done taking the last 10 characters of the input file path.
This behaviour is not safe and can lead to `NotFoundError` to be thrown or cause path traversal in the worst case.

The fix replaces the unsafe part picking up the basename of the file (without extension) and prepending it to `_radial_build.{save_format}` static part.

This also fixes `test_plot_radial_build` run is some environments.

## Checklist

I confirm that I have completed the following checks:

- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
