### PR TITLE
Corrected number of days in year in annual cost calculation

### DIFF
--- a/process/costs_2015.py
+++ b/process/costs_2015.py
@@ -142,7 +142,7 @@ class Costs2015:
         self.mean_electric_output = (
             heat_transport_variables.pnetelmw * cost_variables.cpfact
         )
-        self.annual_electric_output = self.mean_electric_output * 24.0e0 * 265.25e0
+        self.annual_electric_output = self.mean_electric_output * 24.0e0 * 365.25e0
 
         # Annual maintenance cost.
         self.maintenance = (


### PR DESCRIPTION
## Description

This corrects an annual cost calculation in `costs_2015.py` where the number of days in a year was incorrectly given as 265.25. This has been corrected to 365.25.

Closes #2949 

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments. (N/A)
- [x] I have added new tests where appropriate for the changes I have made. (N/A)
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments. (N/A)
- [x] If I have made documentation changes, I have checked they render correctly. (N/A)
- [x] I have added documentation for my change, if appropriate. (N/A)
