### PR TITLE
Add warning when to fully rebuild in docs

### DIFF
--- a/documentation/proc-pages/installation/installation-ubuntu.md
+++ b/documentation/proc-pages/installation/installation-ubuntu.md
@@ -85,6 +85,14 @@ on Linux. If the installation was successful the command `process` should be ava
 To rebuild, for example after making a change to the Fortran source, run `cmake --build build` again. 
 Python-only changes can be installed using `pip install .` when in the PROCESS root directory.
 
+!!! warning "Users of multiple branches"
+    For users of PROCESS that run on multiple branches, it is recommended that each time you switch branches you **fully rebuild** PROCESS:
+    ```bash
+    rm -r build
+    cmake -S . -B build
+    cmake --build build
+    ```
+
 The PROCESS test suite provides through tests that can be used to confirm a successful installation; 
 the tests can then be used to verify changes you make have not affected the wider codebase.
 


### PR DESCRIPTION
## Description

Added a section to the installation documentation explaining that when switching branches you should fully rebuild. 

The issue was originally created because changes in the wrapped source files would not take effect unless a full rebuild was done (even if `cmake --build build` was run) but this has already been fixed.

