### PR TITLE
Make default install editable

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -91,7 +91,8 @@ jobs:
           name: process-build-artifacts
           path: process/
       - name: Install PROCESS
-        run: pip install .
+        # Editable install to match default install
+        run: pip install -e .
       - name: Run unit tests
         run: pytest --cov=process tests/unit -v
       - name: Archive unit test coverage data
@@ -116,7 +117,7 @@ jobs:
   #         name: process-build-artifacts
   #         path: process/
   #     - name: Install PROCESS
-  #       run: pip install .
+  #       run: pip install -e .
   #     - name: Run integration tests
   #       run: pytest tests/integration/ -n auto -v
 
@@ -137,7 +138,7 @@ jobs:
           name: process-build-artifacts
           path: process/
       - name: Install PROCESS
-        run: pip install .
+        run: pip install -e .
       - name: Run regression tests
         run: pytest tests/regression -v --reg-tolerance=0
 
@@ -158,7 +159,7 @@ jobs:
           name: process-build-artifacts
           path: process/
       - name: Install PROCESS
-        run: pip install .
+        run: pip install -e .
       - name: Run regression tests
         run: pytest tests/regression
 
@@ -179,7 +180,7 @@ jobs:
           name: process-build-artifacts
           path: process/
       - name: Install PROCESS
-        run: pip install .
+        run: pip install -e .
       - name: Run large tokamak
         run: |
           process -i tests/regression/scenarios/large-tokamak/IN.DAT
@@ -234,7 +235,7 @@ jobs:
           name: process-build-artifacts
           path: process/
       - name: Install PROCESS
-        run: pip install .
+        run: pip install -e .
       - name: Setup SSH identity
         uses: webfactory/ssh-agent@v0.7.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ ADD_CUSTOM_TARGET(coverage_cleanup
 
 # Run the Pip Install
 ADD_CUSTOM_TARGET(install_process ALL
-    COMMAND ${Python3_EXECUTABLE} -m pip install --no-cache-dir ${CMAKE_SOURCE_DIR}
+    COMMAND ${Python3_EXECUTABLE} -m pip install --no-cache-dir -e ${CMAKE_SOURCE_DIR}
 )
 
 ADD_DEPENDENCIES(install_process ${PIP_NAME} f2py ${FORD_NAME} ${GFORTLIB_NAME} ${DICTS_NAME} coverage_cleanup)

--- a/documentation/proc-pages/development/testing.md
+++ b/documentation/proc-pages/development/testing.md
@@ -127,13 +127,7 @@ runs just the regression tests on all available cores.
 ## Test coverage
 
 Test coverage (in Python only) is provided in a badge on the repository homepage. A report can 
-also be generated locally. First, ensure a development install is being used:
-
-```bash
-pip install -e .
-```
-
-This ensures that `pytest` and `pytest-cov` will use the same installed location of Process. Then:
+also be generated locally. A development (editable) pip installation (which is run by default by the `cmake` build script) ensures that `pytest` and `pytest-cov` will use the same installed location of Process. Then:
 
 ```bash
 pytest --cov=process tests/unit/

--- a/documentation/proc-pages/installation/installation-ubuntu.md
+++ b/documentation/proc-pages/installation/installation-ubuntu.md
@@ -83,7 +83,7 @@ the PROCESS Python package is then automatically installed using `pip` and shoul
 on Linux. If the installation was successful the command `process` should be available on the command line.
 
 To rebuild, for example after making a change to the Fortran source, run `cmake --build build` again. 
-Python-only changes can be installed using `pip install .` when in the PROCESS root directory.
+Python-only changes are reflected immediately, as the `cmake` build script performs a development (editable) installation by default.
 
 The PROCESS test suite provides through tests that can be used to confirm a successful installation; 
 the tests can then be used to verify changes you make have not affected the wider codebase.


### PR DESCRIPTION
Default installation should be editable, as most users are also developers.