### PR TITLE
stop overwriting value of emult

### DIFF
--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -49,9 +49,6 @@ class CCFE_HCPB:
         fwbs_variables.coolwh = 1
         # Note that the first wall coolant is now input separately.
 
-        # Energy multiplication
-        fwbs_variables.emult = 1.269
-
         # Calculate blanket, shield, vacuum vessel and cryostat volumes
         blanket_library.component_volumes()
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
Closes #1594 
Stops value of `emult` being overwritten with hard-coded value in hcpb.py

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
