### PR TITLE
1541 calling of avail from stellaratorife does not take into account iavail

### DIFF
--- a/process/ife.py
+++ b/process/ife.py
@@ -48,8 +48,6 @@ class IFE:
             self.costs.costs(output=True)
 
             # Plant availability
-            # TODO: should availability.run be called
-            # rather than availability.avail?
             self.availability.avail(output=True)
 
             # IFE physics

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -108,9 +108,7 @@ class Stellarator:
 
         if output:
             self.costs.costs(output=True)
-            # TODO: should availability.run be called
-            # rather than availability.avail?
-            self.availability.avail(output=True)
+            self.availability.run(output=True)
             ph.outplas(self.outfile)
             self.stigma()
             self.stheat(True)


### PR DESCRIPTION
## Description

As per discussion in !601, IFE/Stellarator call the availability model. However, they both call the avail subroutine without taking into account the iavail flag. However, other calls to availability models take into account the iavail flag:
```
if cv.iavail > 1:
    self.avail_2(output)  # Morris model (2015)
else:
    self.avail(output)  # Taylor and Ward model (1999)
```
Upon further inspection it has been seen that `avail` is specifcally for IFE use so has not been changed.
Though for the stellarator model any of the avaialbility models can be used as the same components are used between the model (tokamak) and the stellarator.
The stellarator module now runs `availability.run(output=True)` to allow the user to specify the `avail` switch for their preferred model.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
