### PR TITLE
Add actual constraint numbers to mfile

### DIFF
--- a/source/fortran/final_module.f90
+++ b/source/fortran/final_module.f90
@@ -51,7 +51,7 @@ module final_module
       write(nout,140) inn,lablcc(icc(inn)),sym(inn),con2(inn), &
       lab(inn),err(inn),lab(inn),con1(inn)
       call ovarre(mfile,lablcc(icc(inn))//' normalised residue', &
-      '(normres'//int_to_string3(inn)//')',con1(inn))
+      '(eq_con'//int_to_string3(icc(inn))//')',con1(inn))
     end do
 
     140 format(t2,i4,t8,a33,t46,a1,t47,1pe12.4,t60,a10,t71,1pe12.4,t84,a10,t98,1pe12.4)
@@ -63,7 +63,7 @@ module final_module
       do inn = neqns+1,neqns+nineqns
         write(nout,140) inn,lablcc(icc(inn)),sym(inn),con2(inn), &
         lab(inn), err(inn), lab(inn)
-        call ovarre(mfile,lablcc(icc(inn)),'(constr'//int_to_string3(inn)//')',rcm(inn))
+        call ovarre(mfile,lablcc(icc(inn)),'(ineq_con'//int_to_string3(icc(inn))//')',rcm(inn))
       end do
     end if
   end subroutine no_optimisation

--- a/source/fortran/scan.f90
+++ b/source/fortran/scan.f90
@@ -1086,7 +1086,7 @@ contains
      write(nout,110) inn,lablcc(icc(inn)),sym(inn),con2(inn), &
           lab(inn),err(inn),lab(inn),con1(inn)
      call ovarre(mfile,lablcc(icc(inn))//' normalised residue', &
-          '(normres'//int_to_string3(inn)//')',con1(inn))
+          '(eq_con'//int_to_string3(icc(inn))//')',con1(inn))
   end do
 110 format(t2,i4,t8,a33,t46,a1,t47,1pe12.4,t60,a10,t71,1pe12.4,t84,a10,t98,1pe12.4)
 
@@ -1098,7 +1098,7 @@ contains
         !write(nout,120) inn,lablcc(icc(inn)),rcm(inn),vlam(inn)
         write(nout,110) inn,lablcc(icc(inn)),sym(inn),con2(inn), &
                         lab(inn), err(inn), lab(inn)
-        call ovarre(mfile,lablcc(icc(inn)),'(constr'//int_to_string3(inn)//')',rcm(inn))
+        call ovarre(mfile,lablcc(icc(inn)),'(ineq_con'//int_to_string3(icc(inn))//')',rcm(inn))
      end do
   end if
 


### PR DESCRIPTION
Enables identification of constraints: rather than having `normres001, normres002, ..., constr007, constr008`, use the actual constraint numbers, e.g. `eq_constr001, eq_constr007, ..., ineq_constr010, ineq_constr009`. This allows the constraint to be identified from the `MFILE.DAT` alone, instead of needing to cross-check with the `IN.DAT` to find that `constr007` is actually constraint number 10. This also preserves the order in which the constraints are defined in the `IN.DAT`.


