### PR TITLE
Remove scaling of net electric to allow negative net electric

### DIFF
--- a/process/power.py
+++ b/process/power.py
@@ -922,17 +922,6 @@ class Power:
                 heat_transport_variables.pgrossmw - heat_transport_variables.precircmw
             )
 
-            #  Scaling to prevent negative heat_transport_variables.pnetelmw
-            # Do NOT rescale if this is the last run through.
-            if (
-                (heat_transport_variables.pnetelmw < 1.0e0)
-                and (cost_variables.ipnet == 0)
-                and (not output)
-            ):
-                heat_transport_variables.pnetelmw = 1.0e0 / (
-                    1.0e0 + abs(heat_transport_variables.pnetelmw - 1.0e0)
-                )
-
             #  Recirculating power fraction
             cirpowfr = (
                 heat_transport_variables.pgrossmw - heat_transport_variables.pnetelmw

--- a/source/fortran/ife.f90
+++ b/source/fortran/ife.f90
@@ -2087,11 +2087,6 @@ contains
       !  Net electric power
       pnetelmw = pgrossmw - precircmw
 
-      !  Scaling to prevent negative pnetelmw
-      if ( (pnetelmw < 1.0D0).and.(ipnet == 0) ) then
-        pnetelmw = 1.0D0 / ( 1.0D0 + abs(pnetelmw-1.0D0))
-      end if
-
     end if
 
     if (iprint == 0) return


### PR DESCRIPTION
## Description

Remove the scaling of net electric as negative net electric is physically meaningful

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
