### PR TITLE
Added check to see if fimp(2) deviates from default value, if it does…

### DIFF
--- a/source/fortran/initial.f90
+++ b/source/fortran/initial.f90
@@ -347,6 +347,11 @@ subroutine check
         trithtmw = 0.0D0
     end if
 
+    if (fimp(2) .ne. 0.1D0) then
+        write(*,*)'The thermal alpha/electron density ratio should be controlled using ralpne (itv 109) and not fimp(2).'
+        write(*,*)'fimp(2) will be ignored.'
+    end if
+
     !  Impurity fractions
     do imp = 1,nimp
         impurity_arr_frac(imp) = fimp(imp)

--- a/source/fortran/initial.f90
+++ b/source/fortran/initial.f90
@@ -349,7 +349,8 @@ subroutine check
 
     if (fimp(2) .ne. 0.1D0) then
         write(*,*)'The thermal alpha/electron density ratio should be controlled using ralpne (itv 109) and not fimp(2).'
-        write(*,*)'fimp(2) will be ignored.'
+        write(*,*)'fimp(2) should be removed from the input file, or set to the default value 0.1D0.'
+        stop 1
     end if
 
     !  Impurity fractions


### PR DESCRIPTION
… write a warning message to use ralpne instead.

## Description

This value is controlled by ralpne , in fact changing fimp(2) does not change the value of the parameter. It also doesn't make sense that a user would set these two parameters to different values in the first place.

However, as fimp(2) is part of the fimp array, it's not straight forward to remove it as an input variable. All members of fimp(1:13) are inputs, and all of them are output (and still used by other parts of the code). A generic fortran function loop for looping through arrays is used to set them as inputs. It doesn't seem elegant to add a specific exception to this function.

I have added a warning and stop to the user when they change fimp(2) from the default value, and they are told to use ralpne instead.

## Checklist

I confirm that I have completed the following checks:

- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
