### PR TITLE
Correct nviter and convergence_parameter reporting in output

### DIFF
--- a/process/solver.py
+++ b/process/solver.py
@@ -169,7 +169,9 @@ class Vmcon(_Solver):
         if self.b is not None:
             B = np.identity(numerics.nvar) * self.b
 
-        def _solver_callback(i: int, _x, _result, convergence_param: float):
+        def _solver_callback(i: int, _result, _x, convergence_param: float):
+            numerics.nviter = i + 1
+            global_variables.convergence_parameter = convergence_param
             print(
                 f"{i+1} | Convergence Parameter: {convergence_param:.3E}",
                 end="\r",

--- a/tests/regression/scenario.py
+++ b/tests/regression/scenario.py
@@ -1,4 +1,5 @@
 """Scenario class for an individual regression test case."""
+
 import logging
 import sys
 import os
@@ -31,6 +32,7 @@ EXCLUSIONS = {
     "sig_tf_r_max(1)",
     "sqsumsq",
     "ric(nohc)",
+    "nviter",
 }
 EXCLUSION_PATTERNS = [
     r"normres\d{3}",  # normres and 3 digits


### PR DESCRIPTION
## Description

PyVMCON interface in PROCESS now updates the `nviter` and `convergence_parameter` values so they can be correctly reported in the OUT.DAT and MFILE.DAT

I have also corrected the dummy variables in the `_solver_callback` because they were the wrong way around.

And, I have removed `nviter` from the regression test comparison because it does not make much sense to fail if the number of iterations has changed (we should only care about the solution).
