### PR TITLE
Expand bounds of fhfac to reduce chance power balance cannot be found

### DIFF
--- a/process/physics.py
+++ b/process/physics.py
@@ -4731,7 +4731,7 @@ class Physics:
         """
         physics_module.iscz = is_
 
-        return root_scalar(self.fhz, bracket=(0.01, 100), xtol=0.003).root
+        return root_scalar(self.fhz, bracket=(0.01, 150), xtol=0.003).root
 
     def fhz(self, hhh):
         """Function used to find power balance


### PR DESCRIPTION
## Description

Changed the bounds when trying to find the zero of `fhz` to reduce the chance there is no 0 point within the bounds (current `[0.01, 100]`
