### PR TITLE
Fix physics index error for H factors

### DIFF
--- a/process/physics.py
+++ b/process/physics.py
@@ -4236,7 +4236,7 @@ class Physics:
 
         po.ocmmnt(
             self.outfile,
-            f"Confinement scaling law: { physics_variables.tauscl[physics_variables.isc-1]}",
+            f"Confinement scaling law: {f2py_compatible_to_string(physics_variables.tauscl[physics_variables.isc-1])}",
         )
 
         po.ovarrf(

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -394,7 +394,7 @@ module physics_variables
   integer :: isc
   !! switch for energy confinement time scaling law (see description in `tauscl`)
 
-  character(len=24), parameter, dimension(ipnlaws) :: tauscl = (/ &
+  character*24, parameter, dimension(ipnlaws) :: tauscl = (/ &
     'Neo-Alcator      (ohmic)', &
     'Mirnov               (H)', &
     'Merezkhin-Muhkovatov (L)', &


### PR DESCRIPTION
## Description

In some versions of numpy, as noted in [f2py standards](https://ukaea.github.io/PROCESS/development/f2py-standards/), character **arrays** need to use the old fortran syntax to avoid indexing errors when indexed in Python. 