### PR TITLE
736 warnings for function ncore

### DIFF
--- a/documentation/proc-pages/physics-models/plasma.md
+++ b/documentation/proc-pages/physics-models/plasma.md
@@ -267,6 +267,11 @@ simulations.
 If `ipedestal` = 1 or 2 then the pedestal density `neped` is set as a fraction `fgwped` of the 
 Greenwald density (providing `fgwped` >= 0).  The default value of `fgwped` is 0.8[^7]. 
 
+!!! warning " Un-realistic profiles"
+
+    If `ipedestal >= 1` it is highly recommended to use constraint equation 81 (icc=81). This enforces solutions in which $n_0$ has to be greater than $n_{ped}$. 
+    Negative $n_0$ values can also arise during iteration, so it is important to be weary on how low the lower bound for $n_e (\mathtt{dene})$ is set.
+
 ## Beta Limit
 
 The plasma beta limit[^7] is given by 

--- a/process/profiles.py
+++ b/process/profiles.py
@@ -157,6 +157,7 @@ class NProfile(Profile):
             # Allows solver to continue and
             # warns the user to raise the lower bound on dene if the run did not converge
             error_handling.report_error(282)
+            ncore = 1.0e-6
         return ncore
 
     def set_physics_variables(self):

--- a/process/profiles.py
+++ b/process/profiles.py
@@ -154,9 +154,8 @@ class NProfile(Profile):
         )
 
         if ncore < 0.0:
-            # Prevent ncore from going negative (and terminating the optimisation) by
-            # kludging to small positive value. Allows solver to continue and
-            # hopefully be constrained away from this point (e.g. constraint 81, ne0 > neped)
+            # Allows solver to continue and
+            # warns the user to raise the lower bound on dene if the run did not converge
             error_handling.report_error(282)
         return ncore
 

--- a/process/profiles.py
+++ b/process/profiles.py
@@ -3,10 +3,7 @@ import logging
 from scipy import integrate
 from abc import ABC, abstractmethod
 
-from process.fortran import (
-    maths_library,
-    physics_variables,
-)
+from process.fortran import maths_library, physics_variables, error_handling
 
 logger = logging.getLogger(__name__)
 # Logging handler for console output
@@ -159,12 +156,9 @@ class NProfile(Profile):
             # Prevent ncore from going negative (and terminating the optimisation) by
             # kludging to small positive value. Allows solver to continue and
             # hopefully be constrained away from this point (e.g. constraint 81, ne0 > neped)
-            logger.exception("ncore is negative. Kludging to 1e-6.")
-            ncore = 1.0e-6
-            # raise ValueError(
-            #     f"Core density is negative: {ncore}. {nped = }, {nsep = }, {nav = }"
-            # )
-        return ncore
+            print("hello")
+            error_handling.report_error(252)
+        return
 
     def set_physics_variables(self):
         """_summary_

--- a/process/profiles.py
+++ b/process/profiles.py
@@ -124,7 +124,9 @@ class NProfile(Profile):
         )
 
     @staticmethod
-    def ncore(rhopedn, nped, nsep, nav, alphan):
+    def ncore(
+        rhopedn: float, nped: float, nsep: float, nav: float, alphan: float
+    ) -> float:
         """This routine calculates the core denesity of a pedestalised profile.
 
         :param rhopedn: normalised minor radius pedestal position
@@ -156,8 +158,9 @@ class NProfile(Profile):
             # Prevent ncore from going negative (and terminating the optimisation) by
             # kludging to small positive value. Allows solver to continue and
             # hopefully be constrained away from this point (e.g. constraint 81, ne0 > neped)
-            print("hello")
             error_handling.report_error(282)
+
+        return ncore
 
     def set_physics_variables(self):
         """_summary_

--- a/process/profiles.py
+++ b/process/profiles.py
@@ -152,13 +152,12 @@ class NProfile(Profile):
             )
         )
 
-        if ncore < 0:
+        if ncore < 0.0:
             # Prevent ncore from going negative (and terminating the optimisation) by
             # kludging to small positive value. Allows solver to continue and
             # hopefully be constrained away from this point (e.g. constraint 81, ne0 > neped)
             print("hello")
-            error_handling.report_error(252)
-        return
+            error_handling.report_error(282)
 
     def set_physics_variables(self):
         """_summary_

--- a/process/profiles.py
+++ b/process/profiles.py
@@ -137,11 +137,10 @@ class NProfile(Profile):
         :type nsep: float
         :param nav: electron density (/m3)
         :type nav: float
-        :param alphan: _description_
         :param alphan: density peaking parameter
         :type alphan: float
         :return: Core density
-        :rtype: numpy.array
+        :type: float
         """
 
         ncore = (
@@ -159,7 +158,6 @@ class NProfile(Profile):
             # kludging to small positive value. Allows solver to continue and
             # hopefully be constrained away from this point (e.g. constraint 81, ne0 > neped)
             error_handling.report_error(282)
-
         return ncore
 
     def set_physics_variables(self):

--- a/process/utilities/errorlist.json
+++ b/process/utilities/errorlist.json
@@ -1417,8 +1417,8 @@
     },
     {
       "no": 282,
-      "level": 3,
-      "message": "CHECK: ncore is going negative when solving. Please raise the value of dene and/or its lower limit."
+      "level": 2,
+      "message": "CHECK: ncore is going negative when solving. Please raise the value of dene and or its lower limit."
     }
   ]
 }

--- a/process/utilities/errorlist.json
+++ b/process/utilities/errorlist.json
@@ -8,7 +8,7 @@
   "comment2": [
     "Increment n_errortypes if an error is added to this list"
   ],
-  "n_errortypes": 281,
+  "n_errortypes": 282,
   "errors": [
     {
       "no": 1,
@@ -1414,6 +1414,11 @@
       "no": 281,
       "level": 3,
       "message": "CHECK: Cannot have i_tf_bucking >= 2 when tf_in_cs = 1"
+    },
+    {
+      "no": 282,
+      "level": 3,
+      "message": "CHECK: ncore is going negative when solving. Please raise the value of dene and/or its lower limit."
     }
   ]
 }

--- a/source/fortran/iteration_variables.f90
+++ b/source/fortran/iteration_variables.f90
@@ -3245,7 +3245,7 @@ contains
     implicit none
     lablxc(145) = 'fgwped        '
     boundl(145) = 0.100D0
-    boundu(145) = 0.75D0
+    boundu(145) = 0.9D0
   end subroutine init_itv_145
 
   real(kind(1.d0)) function itv_145()
@@ -3377,7 +3377,7 @@ contains
     implicit none
     lablxc(152) = 'fgwsep        '
     boundl(152) = 0.001D0
-    boundu(152) = 0.1D0
+    boundu(152) = 0.5D0
   end subroutine init_itv_152
 
   real(kind(1.d0)) function itv_152()

--- a/source/fortran/iteration_variables.f90
+++ b/source/fortran/iteration_variables.f90
@@ -148,7 +148,7 @@ contains
     use numerics, only: lablxc, boundl, boundu
     implicit none
     lablxc(6) = 'dene          '
-    boundl(6) = 1.00D19
+    boundl(6) = 2.00D19
     boundu(6) = 1.00D21
   end subroutine init_itv_6
 
@@ -3244,8 +3244,8 @@ contains
     use numerics, only: lablxc, boundl, boundu
     implicit none
     lablxc(145) = 'fgwped        '
-    boundl(145) = 0.500D0
-    boundu(145) = 1.000D0
+    boundl(145) = 0.100D0
+    boundu(145) = 0.75D0
   end subroutine init_itv_145
 
   real(kind(1.d0)) function itv_145()
@@ -3377,7 +3377,7 @@ contains
     implicit none
     lablxc(152) = 'fgwsep        '
     boundl(152) = 0.001D0
-    boundu(152) = 1.000D0
+    boundu(152) = 0.1D0
   end subroutine init_itv_152
 
   real(kind(1.d0)) function itv_152()


### PR DESCRIPTION
## Description
The logging of the ncore error to the terminal during iterations has been removed and replaced with a level 2 error that is shown at the end of the run. This warns the user to raise the lower bound of dene to prevent VMCON going near negative calculated values of n0. This is only shown when the run is finished. 

Documentation has been added warning the user to use constraint 81 to prevent un-realistic profiles and to be weary about setting the lower bound of dene too low. 

The bounds in `iteration_variables.f90`  for `fgwped, fgwsep & dene` have been varied to represent the values found in realistic solutions.

Long term solution is being discussed in #3059 

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
