### PR TITLE
Display iteration variable names in solver error message 

### DIFF
--- a/process/solver.py
+++ b/process/solver.py
@@ -2,6 +2,7 @@
 
 import logging
 from process.fortran import numerics, global_variables
+from process.utilities.f2py_string_patch import f2py_compatible_to_string
 import numpy as np
 from process.evaluators import Evaluators
 from abc import ABC, abstractmethod
@@ -204,9 +205,12 @@ class Vmcon(_Solver):
             res = e.result
 
         except ValueError as e:
-            logger.warning(
-                f"Active iteration variables are : {list(enumerate(numerics.ixc[:numerics.nvar]))}"
-            )
+            itervar_name_list = ""
+            for count, iter_var in enumerate(numerics.ixc[: numerics.nvar]):
+                itervar_name = f2py_compatible_to_string(numerics.lablxc[iter_var - 1])
+                itervar_name_list += f"{count}: {itervar_name} \n"
+
+            logger.warning(f"Active iteration variables are : \n{itervar_name_list}")
             raise e
 
         else:


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

Improve error message when x is initially in an infeasible region to explicitly state the variable names of the iteration variables  instead of just their number to help with debugging

## Checklist

I confirm that I have completed the following checks:

- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
