### PR TITLE
Implement cost manager for cost model calling

### DIFF
--- a/process/main.py
+++ b/process/main.py
@@ -567,7 +567,7 @@ class CostsProtocol(Protocol):
         """write model output"""
 
 
-class CostManager(CostsProtocol):
+class CostManager:
     def __init__(self, models):
         """
         :param models: a reference to the PROCESS Models


### PR DESCRIPTION
## Description

Calls the cost models via a manager that will allow the resolving of the concrete cost model to be deferred until the caller first makes a call to the model/ another model calls the costs. This is relevant to making sure the Stellarator can take a reference to the cost model. 

This code does make the cost model calling and resolution a little bit complex but seems to be the best solution to allow flexible cost models.

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
