### PR TITLE
Fix inequality constraint residual output in once-through runs

### DIFF
--- a/source/fortran/final_module.f90
+++ b/source/fortran/final_module.f90
@@ -67,7 +67,7 @@ module final_module
       do inn = neqns+1,neqns+nineqns
         write(nout,140) inn,lablcc(icc(inn)),sym(inn),con2(inn), &
         lab(inn), err(inn), lab(inn)
-        call ovarre(mfile,lablcc(icc(inn)),'(ineq_con'//int_to_string3(icc(inn))//')',rcm(inn))
+        call ovarre(mfile,lablcc(icc(inn)),'(ineq_con'//int_to_string3(icc(inn))//')',con1(inn))
       end do
     end if
   end subroutine no_optimisation


### PR DESCRIPTION
Correct silly typo to get non-zero inequality constraint residuals in mfiles for once-through runs again.