### PR TITLE
Replace `q` with just `q95`

### DIFF
--- a/examples/data/csv_output_large_tokamak_MFILE.DAT
+++ b/examples/data/csv_output_large_tokamak_MFILE.DAT
@@ -1425,7 +1425,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/examples/data/large_tokamak_1_MFILE.DAT
+++ b/examples/data/large_tokamak_1_MFILE.DAT
@@ -1419,7 +1419,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/examples/data/large_tokamak_2_MFILE.DAT
+++ b/examples/data/large_tokamak_2_MFILE.DAT
@@ -1419,7 +1419,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/examples/data/large_tokamak_3_MFILE.DAT
+++ b/examples/data/large_tokamak_3_MFILE.DAT
@@ -1419,7 +1419,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/examples/data/large_tokamak_4_MFILE.DAT
+++ b/examples/data/large_tokamak_4_MFILE.DAT
@@ -1419,7 +1419,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/examples/data/large_tokamak_IN.DAT
+++ b/examples/data/large_tokamak_IN.DAT
@@ -226,10 +226,10 @@ ixc = 16
 boundl(16) = 0.3
 dr_cs = 0.5
 
-* q
+* q95
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/examples/data/scan_MFILE.DAT
+++ b/examples/data/scan_MFILE.DAT
@@ -9259,7 +9259,7 @@ i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: u
 *kappa = 1.7808
 kappa = 1.848
 triang   = 0.5 * Plasma separatrix triangularity (calculated if i_plasma_geometry=1; 3 or 4)
-q        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
+q95        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
 q0       = 1.0 * Safety factor on axis
 rmajor   = 9.072 * Plasma major radius (m) (iteration variable 3)
 i_single_null    = 1 * Switch for single null / double null plasma;
@@ -9323,7 +9323,7 @@ t_burn    = 1.0d4 * Burn time (s) (calculated if i_pulsed_plant=1)
                      dr_tf_inboard          =  1.2080E+00
                      fwalld         =  1.3100E-01
                      dr_cs          =  5.5242E-01
-                     q              =  3.5000E+00
+                     q95              =  3.5000E+00
                      dr_bore           =  2.3322E+00
                      fbeta_max       =  4.8251E-01
                      coheof         =  2.0726E+07

--- a/examples/data/scan_example_file_IN.DAT
+++ b/examples/data/scan_example_file_IN.DAT
@@ -226,10 +226,10 @@ ixc = 16
 boundl(16) = 0.3
 dr_cs = 0.5
 
-* Safety factor near plasma edge
+* Safety factor at 95% flux surface 
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/process/divertor.py
+++ b/process/divertor.py
@@ -116,15 +116,15 @@ class Divertor:
         #  (2.5 factor comes from normalization to ITER 1990)
 
         tconl = (
-            2.5e0 * pv.rmajor * pv.q * (1.0e0 + 1.0e0 / (pv.q * pv.aspect) ** 2) ** 0.5
+            2.5e0 * pv.rmajor * pv.q95 * (1.0e0 + 1.0e0 / (pv.q95 * pv.aspect) ** 2) ** 0.5
         )
         dtheta = plsep / pv.rminor
         dconl = (
             2.5e0
             * bv.rspo
-            * pv.q
+            * pv.q95
             * dtheta
-            * (1.0e0 + 1.0e0 / (pv.q * pv.aspect) ** 2) ** 0.5
+            * (1.0e0 + 1.0e0 / (pv.q95 * pv.aspect) ** 2) ** 0.5
         )
         rconl = dconl / tconl
 

--- a/process/divertor.py
+++ b/process/divertor.py
@@ -116,7 +116,10 @@ class Divertor:
         #  (2.5 factor comes from normalization to ITER 1990)
 
         tconl = (
-            2.5e0 * pv.rmajor * pv.q95 * (1.0e0 + 1.0e0 / (pv.q95 * pv.aspect) ** 2) ** 0.5
+            2.5e0
+            * pv.rmajor
+            * pv.q95
+            * (1.0e0 + 1.0e0 / (pv.q95 * pv.aspect) ** 2) ** 0.5
         )
         dtheta = plsep / pv.rminor
         dconl = (

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -201,6 +201,7 @@ OBS_VARS = {
     "rli": "ind_plasma_internal_norm",
     "gamma": "ejima_coeff",
     "lpulse": "i_pulsed_plant",
+    "q": "q95",
 }
 
 OBS_VARS_HELP = {

--- a/process/physics.py
+++ b/process/physics.py
@@ -1545,8 +1545,6 @@ class Physics:
           https://inis.iaea.org/search/search.aspx?orig_q=RN:45031642
         """
 
-        physics_variables.q95 = physics_variables.q
-
         # Calculate plasma composition
         # Issue #261 Remove old radiation model (imprad_model=0)
         self.plasma_composition()
@@ -1583,7 +1581,7 @@ class Physics:
             physics_variables.p0,
             physics_variables.len_plasma_poloidal,
             physics_variables.q0,
-            physics_variables.q,
+            physics_variables.q95,
             physics_variables.ind_plasma_internal_norm,
             physics_variables.rmajor,
             physics_variables.rminor,
@@ -3215,7 +3213,7 @@ class Physics:
                 9 = FIESTA ST scaling
             iprofile (int): Switch for current profile consistency.
                 0: Use input values for alphaj, ind_plasma_internal_norm, beta_norm_max.
-                1: Make these consistent with input q, q_0 values.
+                1: Make these consistent with input q95, q_0 values.
                 2: Use input values for alphaj, ind_plasma_internal_norm. Scale beta_norm_max with aspect ratio (original scaling).
                 3: Use input values for alphaj, ind_plasma_internal_norm. Scale beta_norm_max with aspect ratio (Menard scaling).
                 4: Use input values for alphaj, beta_norm_max. Set ind_plasma_internal_norm from elongation (Menard scaling).
@@ -3679,12 +3677,12 @@ class Physics:
                 if physics_variables.iprofile == 1:
                     po.ocmmnt(
                         self.outfile,
-                        "Consistency between q0,q,alphaj,ind_plasma_internal_norm,beta_norm_max is enforced",
+                        "Consistency between q0,q95,alphaj,ind_plasma_internal_norm,beta_norm_max is enforced",
                     )
                 else:
                     po.ocmmnt(
                         self.outfile,
-                        "Consistency between q0,q,alphaj,ind_plasma_internal_norm,beta_norm_max is not enforced",
+                        "Consistency between q0,q95,alphaj,ind_plasma_internal_norm,beta_norm_max is not enforced",
                     )
 
                 po.oblnkl(self.outfile)
@@ -3769,7 +3767,10 @@ class Physics:
 
             if physics_variables.i_plasma_current == 2:
                 po.ovarrf(
-                    self.outfile, "Mean edge safety factor", "(q)", physics_variables.q
+                    self.outfile,
+                    "Mean edge safety factor",
+                    "(q95)",
+                    physics_variables.q95,
                 )
 
             po.ovarrf(
@@ -3790,7 +3791,7 @@ class Physics:
             if physics_variables.i_plasma_geometry == 1:
                 po.ovarrf(
                     self.outfile,
-                    "Lower limit for edge safety factor q",
+                    "Lower limit for edge safety factor q95",
                     "(q95_min)",
                     physics_variables.q95_min,
                     "OP ",
@@ -5891,7 +5892,7 @@ class Physics:
                 physics_variables.rminor,
                 physics_variables.ten,
                 physics_variables.tin,
-                physics_variables.q,
+                physics_variables.q95,
                 physics_variables.qstar,
                 physics_variables.vol_plasma,
                 physics_variables.zeff,
@@ -6210,7 +6211,8 @@ class Physics:
         # inverse_q = 1/safety factor
         # Parabolic q profile assumed
         inverse_q = 1 / (
-            physics_variables.q0 + (physics_variables.q - physics_variables.q0) * roa**2
+            physics_variables.q0
+            + (physics_variables.q95 - physics_variables.q0) * roa**2
         )
         # Create new array of average mass of fuel portion of ions
         amain = np.full_like(inverse_q, physics_variables.m_fuel_amu)
@@ -6690,7 +6692,7 @@ class Physics:
                 physics_variables.rminor,
                 physics_variables.ten,
                 physics_variables.tin,
-                physics_variables.q,
+                physics_variables.q95,
                 physics_variables.qstar,
                 physics_variables.vol_plasma,
                 physics_variables.zeff,
@@ -6745,7 +6747,7 @@ class Physics:
         rminor: float,
         ten: float,
         tin: float,
-        q: float,
+        q95: float,
         qstar: float,
         vol_plasma: float,
         zeff: float,
@@ -6770,7 +6772,7 @@ class Physics:
         :param pinjmw: Auxiliary power to ions and electrons (MW)
         :param plasma_current: Plasma current (A)
         :param pcoreradpv: Total core radiation power (MW/m3)
-        :param q: Edge safety factor (tokamaks), or rotational transform iotabar (stellarators)
+        :param q95: Edge safety factor (tokamaks), or rotational transform iotabar (stellarators)
         :param qstar: Equivalent cylindrical edge safety factor
         :param rmajor: Plasma major radius (m)
         :param rminor: Plasma minor radius (m)
@@ -7129,7 +7131,7 @@ class Physics:
                     dnla20,
                     bt,
                     p_plasma_loss_mw,
-                    q,
+                    q95,
                 )
             )
 
@@ -7324,7 +7326,9 @@ class Physics:
 
         # ISS95 stellarator scaling
         elif i_confinement_time == 37:
-            iotabar = q  # dummy argument q is actual argument iotabar for stellarators
+            iotabar = (
+                q95  # dummy argument q95 is actual argument iotabar for stellarators
+            )
             t_electron_confinement = confinement.iss95_stellarator_confinement_time(
                 rminor,
                 rmajor,
@@ -7338,7 +7342,9 @@ class Physics:
 
         # ISS04 stellarator scaling
         elif i_confinement_time == 38:
-            iotabar = q  # dummy argument q is actual argument iotabar for stellarators
+            iotabar = (
+                q95  # dummy argument q95 is actual argument iotabar for stellarators
+            )
             t_electron_confinement = confinement.iss04_stellarator_confinement_time(
                 rminor,
                 rmajor,
@@ -7401,7 +7407,7 @@ class Physics:
                 p_plasma_loss_mw,
                 rmajor,
                 rminor,
-                q,
+                q95,
                 qstar,
                 aspect,
                 m_fuel_amu,

--- a/process/physics.py
+++ b/process/physics.py
@@ -7326,9 +7326,8 @@ class Physics:
 
         # ISS95 stellarator scaling
         elif i_confinement_time == 37:
-            iotabar = (
-                q95  # dummy argument q95 is actual argument iotabar for stellarators
-            )
+            # dummy argument q95 is actual argument iotabar for stellarators
+            iotabar = q95
             t_electron_confinement = confinement.iss95_stellarator_confinement_time(
                 rminor,
                 rmajor,
@@ -7342,9 +7341,8 @@ class Physics:
 
         # ISS04 stellarator scaling
         elif i_confinement_time == 38:
-            iotabar = (
-                q95  # dummy argument q95 is actual argument iotabar for stellarators
-            )
+            # dummy argument q95 is actual argument iotabar for stellarators
+            iotabar = q95
             t_electron_confinement = confinement.iss04_stellarator_confinement_time(
                 rminor,
                 rmajor,

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -4121,8 +4121,6 @@ class Stellarator:
             * physics_variables.rmajor
         )
 
-        physics_variables.q95 = physics_variables.q
-
         #  Calculate poloidal field using rotation transform
         physics_variables.bp = (
             physics_variables.rminor

--- a/source/fortran/constraint_equations.f90
+++ b/source/fortran/constraint_equations.f90
@@ -1981,14 +1981,14 @@ contains
       !! and hence also optional here.
       !! Logic change during pre-factoring: err, symbol, units will be assigned only if present.
       !! fq : input real : f-value for edge safety factor
-      !! q : safety factor 'near' plasma edge: equal to q95
+      !! q95 : safety factor 'near' plasma edge
       !! (unless i_plasma_current = 2 (ST current scaling), in which case q = mean edge safety factor qbar)
       !! q95_min : input real :  lower limit for edge safety factor
       !! itart : input integer : switch for spherical tokamak (ST) models:<UL>
       !! <LI> = 0 use conventional aspect ratio models;
       !! <LI> = 1 use spherical tokamak models</UL>
       use constraint_variables, only: fq
-      use physics_variables, only: q, q95_min, itart
+      use physics_variables, only: q95, q95_min, itart
       implicit none
             real(dp), intent(out) :: tmp_cc
       real(dp), intent(out) :: tmp_con
@@ -1998,7 +1998,7 @@ contains
 
       ! if the machine isn't a ST then report error
       if (itart == 0) call report_error(9)
-      tmp_cc =   1.0D0 - fq * q/q95_min
+      tmp_cc =   1.0D0 - fq * q95/q95_min
       tmp_con = q95_min * (1.0D0 - tmp_cc)
       tmp_err = q95_min * tmp_cc
       tmp_symbol = '<'

--- a/source/fortran/input.f90
+++ b/source/fortran/input.f90
@@ -705,7 +705,7 @@ contains
                'For backwards compatibility only, q95 can be entered using the symbol q.')
       case ('q95')
          call parse_real_variable('q', q, 1.00D0, 50.0D0, &
-               'Safety factor at 95% flux surface')        
+               'Safety factor at 95% flux surface')
        case ('q0')
           call parse_real_variable('q0', q0, 0.01D0, 20.0D0, &
                'Safety factor on axis')

--- a/source/fortran/input.f90
+++ b/source/fortran/input.f90
@@ -308,7 +308,7 @@ contains
       fpdivlim, beta_poloidal_eps_max, i_confinement_time, kappa95, aspect, f_r_conducting_wall, nesep, c_beta, csawth, dene, &
       ftar, plasma_res_factor, f_sync_reflect, f_nd_beam_electron, beta, neped, hfact, beta_norm_max, &
       fgwsep, rhopedn, tratio, q0, i_plasma_geometry, i_plasma_shape, fne0, ignite, f_tritium, &
-      i_beta_fast_alpha, tauee_in, alphaj, alphat, i_plasma_current, q, ti, tesep, ind_plasma_internal_norm, triang, &
+      i_beta_fast_alpha, tauee_in, alphaj, alphat, i_plasma_current, q, q95, ti, tesep, ind_plasma_internal_norm, triang, &
       itart, f_nd_alpha_electron, iprofile, triang95, rad_fraction_sol, betbm0, f_nd_protium_electrons, &
       teped, f_helium3, iwalld, ejima_coeff, f_alpha_plasma, fgwped, tbeta, i_bootstrap_current, &
       i_rad_loss, te, alphan, rmajor, plasma_square, kappa, fkzohm, beamfus0, &
@@ -702,7 +702,10 @@ contains
                'Plasma resistivity pre-factor')
        case ('q')
           call parse_real_variable('q', q, 1.00D0, 50.0D0, &
-               'Safety factor near plasma edge')
+               'For backwards compatibility only, q95 can be entered using the symbol q.')
+      case ('q95')
+         call parse_real_variable('q', q, 1.00D0, 50.0D0, &
+               'Safety factor at 95% flux surface')        
        case ('q0')
           call parse_real_variable('q0', q0, 0.01D0, 20.0D0, &
                'Safety factor on axis')

--- a/source/fortran/input.f90
+++ b/source/fortran/input.f90
@@ -308,7 +308,7 @@ contains
       fpdivlim, beta_poloidal_eps_max, i_confinement_time, kappa95, aspect, f_r_conducting_wall, nesep, c_beta, csawth, dene, &
       ftar, plasma_res_factor, f_sync_reflect, f_nd_beam_electron, beta, neped, hfact, beta_norm_max, &
       fgwsep, rhopedn, tratio, q0, i_plasma_geometry, i_plasma_shape, fne0, ignite, f_tritium, &
-      i_beta_fast_alpha, tauee_in, alphaj, alphat, i_plasma_current, q, q95, ti, tesep, ind_plasma_internal_norm, triang, &
+      i_beta_fast_alpha, tauee_in, alphaj, alphat, i_plasma_current, q95, ti, tesep, ind_plasma_internal_norm, triang, &
       itart, f_nd_alpha_electron, iprofile, triang95, rad_fraction_sol, betbm0, f_nd_protium_electrons, &
       teped, f_helium3, iwalld, ejima_coeff, f_alpha_plasma, fgwped, tbeta, i_bootstrap_current, &
       i_rad_loss, te, alphan, rmajor, plasma_square, kappa, fkzohm, beamfus0, &
@@ -700,11 +700,8 @@ contains
        case ('plasma_res_factor')
           call parse_real_variable('plasma_res_factor', plasma_res_factor, 0.0D0, 1.0D0, &
                'Plasma resistivity pre-factor')
-       case ('q')
-          call parse_real_variable('q', q, 1.00D0, 50.0D0, &
-               'For backwards compatibility only, q95 can be entered using the symbol q.')
       case ('q95')
-         call parse_real_variable('q', q, 1.00D0, 50.0D0, &
+         call parse_real_variable('q95', q95, 1.00D0, 50.0D0, &
                'Safety factor at 95% flux surface')
        case ('q0')
           call parse_real_variable('q0', q0, 0.01D0, 20.0D0, &

--- a/source/fortran/iteration_variables.f90
+++ b/source/fortran/iteration_variables.f90
@@ -437,25 +437,25 @@ contains
   !---------------------------------
 
   subroutine init_itv_18
-    !! <LI> (18) q
+    !! <LI> (18) q95
     use numerics, only: lablxc, boundl, boundu
     implicit none
-    lablxc(18) = 'q             '
+    lablxc(18) = 'q95             '
     boundl(18) = 2.000D0
     boundu(18) = 50.00D0
   end subroutine init_itv_18
 
   real(kind(1.d0)) function itv_18()
-    use physics_variables, only: q
+    use physics_variables, only: q95
     implicit none
-    itv_18 = q
+    itv_18 = q95
   end function itv_18
 
   subroutine set_itv_18(ratio)
-    use physics_variables, only: q
+    use physics_variables, only: q95
     implicit none
     real(kind(1.d0)) :: ratio
-    q = ratio
+    q95 = ratio
   end subroutine set_itv_18
 
   !---------------------------------

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -729,14 +729,14 @@ module physics_variables
   !! ion transport power per volume (MW/m3)
 
   real(dp) :: q
-  !! Safety factor 'near' plasma edge (`iteration variable 18`) equal to q95
-  !! (unless `i_plasma_current=2` (ST current scaling), in which case q = mean edge safety factor qbar)
+  !! For backwards compatibility only, q95 can be entered using the symbol q.
 
   real(dp) :: q0
-  !! safety factor on axis
+  !! Safety factor on axis
 
   real(dp) :: q95
-  !! safety factor at 95% surface
+  !! Safety factor at 95% flux surface (iteration variable 18) (unless icurr=2 (ST current scaling),
+  !! in which case q95 = mean edge safety factor qbar)
 
   real(dp) :: qfuel
   !! plasma fuelling rate (nucleus-pairs/s)

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -400,7 +400,7 @@ module physics_variables
   !! switch for current profile consistency:
   !!
   !! - =0 use input values for alphaj, ind_plasma_internal_norm, beta_norm_max
-  !! - =1 make these consistent with input q, q_0 values (recommend `i_plasma_current=4` with this option)
+  !! - =1 make these consistent with input q95, q_0 values (recommend `i_plasma_current=4` with this option)
   !! - =2 use input values for alphaj, ind_plasma_internal_norm. Scale beta_norm_max with aspect ratio (original scaling)
   !! - =3 use input values for alphaj, ind_plasma_internal_norm. Scale beta_norm_max with aspect ratio (Menard scaling)
   !! - =4 use input values for alphaj, beta_norm_max. Set ind_plasma_internal_norm from elongation (Menard scaling)
@@ -727,9 +727,6 @@ module physics_variables
 
   real(dp) :: pden_ion_transport_loss_mw
   !! ion transport power per volume (MW/m3)
-
-  real(dp) :: q
-  !! For backwards compatibility only, q95 can be entered using the symbol q.
 
   real(dp) :: q0
   !! Safety factor on axis
@@ -1072,7 +1069,6 @@ module physics_variables
     p_ion_transport_loss_mw = 0.0D0
     pscalingmw = 0.0D0
     pden_ion_transport_loss_mw = 0.0D0
-    q = 3.0D0
     q0 = 1.0D0
     q95 = 0.0D0
     qfuel = 0.0D0

--- a/source/fortran/scan.f90
+++ b/source/fortran/scan.f90
@@ -195,7 +195,7 @@ contains
       tfcpmw, fcutfsu, acond, fcoolcp, rcool, whttf, ppump, vcool, wwp1, n_tf_coils, &
       dr_tf_wp, b_crit_upper_nbti
     use fwbs_variables, only: tpeak
-    use physics_variables, only: q, aspect, p_plasma_rad_mw, dene, fusion_power, btot, tesep, &
+    use physics_variables, only: q95, aspect, p_plasma_rad_mw, dene, fusion_power, btot, tesep, &
       pdivt, f_nd_alpha_electron, ten, beta_poloidal, hfac, teped, alpha_power_beams, q95_min, rmajor, wallmw, &
       beta, beta_max, bt, plasma_current
     use global_variables, only: verbose, maxcal, runtitle, run_tests
@@ -226,7 +226,7 @@ contains
     outvar(12,iscan) = 1.0D-6 * plasma_current
     outvar(13,iscan) = bt
     outvar(14,iscan) = btot
-    outvar(15,iscan) = q
+    outvar(15,iscan) = q95
     outvar(16,iscan) = q95_min
     outvar(17,iscan) = beta
     outvar(18,iscan) = beta_max

--- a/source/fortran/stellarator.f90
+++ b/source/fortran/stellarator.f90
@@ -54,7 +54,7 @@ contains
     use build_variables, only: dr_cs_tf_gap, iohcl, dr_cs, tfootfi
     use current_drive_variables, only: irfcd
     use pfcoil_variables, only: ohhghf
-    use physics_variables, only: aspect, beta_norm_max, kappa, kappa95, q, rmajor, &
+    use physics_variables, only: aspect, beta_norm_max, kappa, kappa95, q95, rmajor, &
       triang, hfac, labels_confinement_scalings
     use numerics, only: boundl, boundu
     use stellarator_variables, only: istell
@@ -101,7 +101,7 @@ contains
     beta_norm_max = 0.0D0
     kappa95 = 1.0D0
     triang = 0.0D0
-    q = 1.03D0
+    q95 = 1.03D0
 
     !  Turn off current drive
 

--- a/tests/integration/data/large_tokamak_1_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_1_MFILE.DAT
@@ -1418,7 +1418,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/integration/data/large_tokamak_2_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_2_MFILE.DAT
@@ -1419,7 +1419,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/integration/data/large_tokamak_3_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_3_MFILE.DAT
@@ -1419,7 +1419,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/integration/data/large_tokamak_4_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_4_MFILE.DAT
@@ -1419,7 +1419,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/integration/data/large_tokamak_IN.DAT
+++ b/tests/integration/data/large_tokamak_IN.DAT
@@ -229,7 +229,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/integration/data/large_tokamak_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_MFILE.DAT
@@ -1420,7 +1420,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/integration/data/large_tokamak_once_through.IN.DAT
+++ b/tests/integration/data/large_tokamak_once_through.IN.DAT
@@ -342,7 +342,7 @@ iprofile = 1 * switch for current profile consistency;
 i_confinement_time      = 34 * switch for energy confinement time scaling law (see description in `labels_confinement_scalings`)
 i_plasma_geometry   = 0 * switch for plasma cross-sectional shape calculation;
 kappa    = 1.85 * plasma separatrix elongation (calculated if `i_plasma_geometry = 1-5; 7 or 9-10`)
-q        = 3.7339078193128556 * Safety factor 'near' plasma edge (`iteration variable 18`) equal to q95
+q95        = 3.7339078193128556 * Safety factor 'near' plasma edge (`iteration variable 18`) equal to q95
 q0       = 1.0 * safety factor on axis
 f_nd_alpha_electron   = 0.060238763988650204 * thermal alpha density/electron density (`iteration variable 109`)
 rmajor   = 8.0 * plasma major radius (m) (`iteration variable 3`)

--- a/tests/integration/data/ref_IN.DAT
+++ b/tests/integration/data/ref_IN.DAT
@@ -280,7 +280,7 @@ i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: u
 *kappa = 1.7808
 kappa = 1.848
 triang   = 0.5 * Plasma separatrix triangularity (calculated if i_plasma_geometry=1; 3 or 4)
-q        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
+q95        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
 q0       = 1.0 * Safety factor on axis
 rmajor   = 9.072 * Plasma major radius (m) (iteration variable 3)
 i_single_null    = 1 * Switch for single null / double null plasma;
@@ -343,7 +343,7 @@ t_burn    = 1.0d4 * Burn time (s) (calculated if i_pulsed_plant=1)
                      dr_tf_inboard          =  1.2080E+00
                      fwalld         =  1.3100E-01
                      dr_cs          =  5.5242E-01
-                     q              =  3.5000E+00
+                     q95              =  3.5000E+00
                      dr_bore           =  2.3322E+00
                      fbeta_max       =  4.8251E-01
                      coheof         =  2.0726E+07

--- a/tests/integration/data/scan_2D_MFILE.DAT
+++ b/tests/integration/data/scan_2D_MFILE.DAT
@@ -17705,7 +17705,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/integration/data/scan_MFILE.DAT
+++ b/tests/integration/data/scan_MFILE.DAT
@@ -9259,7 +9259,7 @@ i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: u
 *kappa = 1.7808
 kappa = 1.848
 triang   = 0.5 * Plasma separatrix triangularity (calculated if i_plasma_geometry=1; 3 or 4)
-q        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
+q95        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
 q0       = 1.0 * Safety factor on axis
 rmajor   = 9.072 * Plasma major radius (m) (iteration variable 3)
 i_single_null    = 1 * Switch for single null / double null plasma;
@@ -9323,7 +9323,7 @@ t_burn    = 1.0d4 * Burn time (s) (calculated if i_pulsed_plant=1)
                      dr_tf_inboard          =  1.2080E+00
                      fwalld         =  1.3100E-01
                      dr_cs          =  5.5242E-01
-                     q              =  3.5000E+00
+                     q95              =  3.5000E+00
                      dr_bore           =  2.3322E+00
                      fbeta_max       =  4.8251E-01
                      coheof         =  2.0726E+07

--- a/tests/integration/data/uncertainties_nonopt_ref_IN.DAT
+++ b/tests/integration/data/uncertainties_nonopt_ref_IN.DAT
@@ -280,7 +280,7 @@ i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: u
 *kappa = 1.7808
 kappa = 1.848
 triang   = 0.5 * Plasma separatrix triangularity (calculated if i_plasma_geometry=1; 3 or 4)
-q        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
+q95        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
 q0       = 1.0 * Safety factor on axis
 rmajor   = 9.072 * Plasma major radius (m) (iteration variable 3)
 i_single_null    = 1 * Switch for single null / double null plasma;
@@ -343,7 +343,7 @@ t_burn    = 1.0d4 * Burn time (s) (calculated if i_pulsed_plant=1)
                      dr_tf_inboard          =  1.2080E+00
                      fwalld         =  1.3100E-01
                      dr_cs          =  5.5242E-01
-                     q              =  3.5000E+00
+                     q95              =  3.5000E+00
                      dr_bore           =  2.3322E+00
                      fbeta_max       =  4.8251E-01
                      coheof         =  2.0726E+07

--- a/tests/integration/data/uncertainties_ref_IN.DAT
+++ b/tests/integration/data/uncertainties_ref_IN.DAT
@@ -280,7 +280,7 @@ i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: u
 *kappa = 1.7808
 kappa = 1.848
 triang   = 0.5 * Plasma separatrix triangularity (calculated if i_plasma_geometry=1; 3 or 4)
-q        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
+q95        = 3.247 * Safety factor 'near' plasma edge (iteration variable 18);
 q0       = 1.0 * Safety factor on axis
 rmajor   = 9.072 * Plasma major radius (m) (iteration variable 3)
 i_single_null    = 1 * Switch for single null / double null plasma;
@@ -343,7 +343,7 @@ t_burn    = 1.0d4 * Burn time (s) (calculated if i_pulsed_plant=1)
                      dr_tf_inboard          =  1.2080E+00
                      fwalld         =  1.3100E-01
                      dr_cs          =  5.5242E-01
-                     q              =  3.5000E+00
+                     q95              =  3.5000E+00
                      dr_bore           =  2.3322E+00
                      fbeta_max       =  4.8251E-01
                      coheof         =  2.0726E+07

--- a/tests/integration/ref_dicts.json
+++ b/tests/integration/ref_dicts.json
@@ -10423,7 +10423,7 @@
         "pwplh": "lower hybrid wall plug power (MW)",
         "pwpm2": "base AC power requirement per unit floor area (W/m2)",
         "pwpnb": "neutral beam wall plug power (MW)",
-        "q": "safety factor 'near' plasma edge (`iteration variable 18`) equal to q95\n (unless `i_plasma_current=2` (ST current scaling), in which case q = mean edge safety factor qbar)",
+        "q": "safety factor 'near' plasma edge (`iteration variable 18`) equal to q95\n (unless `i_plasma_current=2` (ST current scaling), in which case q95 = mean edge safety factor qbar)",
         "q0": "safety factor on axis",
         "q2": "",
         "q95": "safety factor at 95% surface",

--- a/tests/regression/input_files/large_tokamak.IN.DAT
+++ b/tests/regression/input_files/large_tokamak.IN.DAT
@@ -226,10 +226,10 @@ ixc = 16
 boundl(16) = 0.3
 dr_cs = 0.5
 
-* Safety factor near plasma edge
+* Safety factor at 95% flux surface 
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/regression/input_files/large_tokamak_nof.IN.DAT
+++ b/tests/regression/input_files/large_tokamak_nof.IN.DAT
@@ -208,10 +208,10 @@ ixc = 16
 boundl(16) = 0.3
 dr_cs = 0.5
 
-* q
+* q95
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/regression/input_files/large_tokamak_once_through.IN.DAT
+++ b/tests/regression/input_files/large_tokamak_once_through.IN.DAT
@@ -342,7 +342,7 @@ iprofile = 1 * switch for current profile consistency;
 i_confinement_time      = 34 * switch for energy confinement time scaling law (see description in `labels_confinement_scalings`)
 i_plasma_geometry   = 0 * switch for plasma cross-sectional shape calculation;
 kappa    = 1.85 * plasma separatrix elongation (calculated if `i_plasma_geometry = 1-5; 7 or 9-10`)
-q        = 3.7339078193128556 * Safety factor 'near' plasma edge (`iteration variable 18`) equal to q95
+q95        = 3.7339078193128556 * Safety factor 'near' plasma edge (`iteration variable 18`) equal to q95
 q0       = 1.0 * safety factor on axis
 f_nd_alpha_electron   = 0.060238763988650204 * thermal alpha density/electron density (`iteration variable 109`)
 rmajor   = 8.0 * plasma major radius (m) (`iteration variable 3`)

--- a/tests/regression/input_files/spherical_tokamak_once_through.IN.DAT
+++ b/tests/regression/input_files/spherical_tokamak_once_through.IN.DAT
@@ -352,7 +352,7 @@ i_plasma_geometry = 0 * switch for plasma elongation and triangularity calculati
 itart    = 1 * switch for spherical tokamak (ST) models;
 itartpf  = 1 * switch for Spherical Tokamak PF models;
 kappa    = 2.8 * plasma separatrix elongation (calculated if `i_plasma_geometry = 1-5; 7 or 9-10`)
-q        = 5.835830999686161 * Safety factor 'near' plasma edge (`iteration variable 18`) equal to q95
+q95        = 5.835830999686161 * Safety factor 'near' plasma edge (`iteration variable 18`) equal to q95
 q0       = 2.0 * safety factor on axis
 f_nd_alpha_electron = 0.08870796537675113 * thermal alpha density/electron density (`iteration variable 109`)
 ind_plasma_internal_norm      = 0.3 * plasma normalised internal inductance (calculated from alphaj if `iprofile=1`)

--- a/tests/regression/input_files/st_regression.IN.DAT
+++ b/tests/regression/input_files/st_regression.IN.DAT
@@ -379,7 +379,7 @@ beta_norm_max = 5.0
 *‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
 ixc = 18
-q = 6.0 
+q95 = 6.0 
 boundl(18) = 3.0
 boundu(18) = 20.0
 * DESCRIPTION:   Safety factor at 95% flux surface

--- a/tests/unit/data/large_tokamak_IN.DAT
+++ b/tests/unit/data/large_tokamak_IN.DAT
@@ -229,7 +229,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/unit/data/large_tokamak_MFILE.DAT
+++ b/tests/unit/data/large_tokamak_MFILE.DAT
@@ -1420,7 +1420,7 @@ dr_cs = 0.5
 * q
 ixc = 18
 boundl(18) = 3.0
-q = 3.5
+q95 = 3.5
 
 * Machine dr_bore [m]
 ixc = 29

--- a/tests/unit/test_physics.py
+++ b/tests/unit/test_physics.py
@@ -339,7 +339,7 @@ class BootstrapFractionSauterParam(NamedTuple):
 
     rmajor: Any = None
 
-    q: Any = None
+    q95: Any = None
 
     nesep: Any = None
 
@@ -381,7 +381,7 @@ class BootstrapFractionSauterParam(NamedTuple):
             dene=8.016748468651018e19,
             te=12.570861186498382,
             rmajor=8,
-            q=3.5,
+            q95=3.5,
             nesep=3.6992211545476006e19,
             te0=25.986118047669795,
             neped=6.2886759627309195e19,
@@ -461,7 +461,7 @@ def test_bootstrap_fraction_sauter(bootstrapfractionsauterparam, monkeypatch, ph
         physics_variables, "rmajor", bootstrapfractionsauterparam.rmajor
     )
 
-    monkeypatch.setattr(physics_variables, "q", bootstrapfractionsauterparam.q)
+    monkeypatch.setattr(physics_variables, "q95", bootstrapfractionsauterparam.q95)
 
     monkeypatch.setattr(physics_variables, "nesep", bootstrapfractionsauterparam.nesep)
 
@@ -2246,7 +2246,7 @@ class ConfinementTimeParam(NamedTuple):
 
     pcoreradpv: Any = None
 
-    q: Any = None
+    q95: Any = None
 
     qstar: Any = None
 
@@ -2310,7 +2310,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2352,7 +2352,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2394,7 +2394,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2436,7 +2436,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2478,7 +2478,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2520,7 +2520,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2562,7 +2562,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2604,7 +2604,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2646,7 +2646,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2688,7 +2688,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2730,7 +2730,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2772,7 +2772,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2814,7 +2814,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2856,7 +2856,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2898,7 +2898,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -2940,7 +2940,7 @@ class ConfinementTimeParam(NamedTuple):
             pinjmw=75.397788712812741,
             plasma_current=16616203.759182997,
             pcoreradpv=0.047757569353246924,
-            q=3.5610139569387185,
+            q95=3.5610139569387185,
             qstar=2.9513713188821282,
             rmajor=8,
             rminor=2.6666666666666665,
@@ -3018,7 +3018,7 @@ def test_calculate_confinement_time(confinementtimeparam, monkeypatch, physics):
         pinjmw=confinementtimeparam.pinjmw,
         plasma_current=confinementtimeparam.plasma_current,
         pcoreradpv=confinementtimeparam.pcoreradpv,
-        q=confinementtimeparam.q,
+        q95=confinementtimeparam.q95,
         qstar=confinementtimeparam.qstar,
         rmajor=confinementtimeparam.rmajor,
         rminor=confinementtimeparam.rminor,


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
An update to #321 after merge.
`q` is now be in the input file as just `q95` 

Using `q95` makes it more explicit than just using `q` for the edge and the first assignment in `physics()` was to set `q95 = q`

```python
 physics_variables.q95 = physics_variables.q

        # Calculate plasma composition
        # Issue #261 Remove old radiation model (imprad_model=0)
        self.plasma_composition()
```



## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
