### PR TITLE
782 simple model to calculate the allowable current density in a superconducting coil

### DIFF
--- a/process/utilities/errorlist.json
+++ b/process/utilities/errorlist.json
@@ -248,7 +248,7 @@
     {
       "no": 48,
       "level": 3,
-      "message": "LOADXC: Do not use thkcas as an iteration variable if tfc_model=0 or istell=1"
+      "message": "LOADXC: Do not use thkcas as an iteration variable if istell=1"
     },
     {
       "no": 49,

--- a/process/utilities/errorlist.json
+++ b/process/utilities/errorlist.json
@@ -527,8 +527,8 @@
     },
     {
       "no": 104,
-      "level": 3,
-      "message": "STRESSCL: Illegal value for tfc_model"
+      "level": 0,
+      "message": "OBSOLETE"
     },
     {
       "no": 105,

--- a/source/fortran/input.f90
+++ b/source/fortran/input.f90
@@ -1731,9 +1731,6 @@ contains
        case ('tdmptf')
           call parse_real_variable('tdmptf', tdmptf, 0.1D0, 100.0D0, &
                'Dump time for TF coil (s)')
-      !  case ('tfc_model')
-      !     call parse_int_variable('tfc_model', tfc_model, 0, 1, &
-      !          'Switch for TF coil model')
        case ('tfinsgap')
           call parse_real_variable('tfinsgap', tfinsgap, 1.0D-10, 1.0D-1, &
                'TF coil WP insertion gap (m)')

--- a/source/fortran/tfcoil_variables.f90
+++ b/source/fortran/tfcoil_variables.f90
@@ -504,12 +504,6 @@ module tfcoil_variables
   real(dp) :: tfckw
   !! available DC power for charging the TF coils (kW)
 
-  !#TODO: issue #781
-  ! integer :: tfc_model
-  ! !! tfc_model /1/ : switch for TF coil magnet stress model:<UL>
-  ! !!                 <LI> = 0 simple model (solid copper coil)
-  ! !!                 <LI> = 1 CCFE two-layer stress model; superconductor</UL>
-
   real(dp) :: tfcmw
   !! Peak power per TF power supply (MW)
 


### PR DESCRIPTION
Closes #782.

Removed previously commented out sections of code relating to the tfc_model which is no longer used (unused in over 4 years). Removed mention of tfc_model in error relating to stellarators, and marked error 104 as obsolete (error to do with tfc_model).