### PR TITLE
Remove unused interpolate function from maths_library.f90

### DIFF
--- a/source/fortran/maths_library.f90
+++ b/source/fortran/maths_library.f90
@@ -436,42 +436,6 @@ contains
 
   end function binarysearch
 
-  real(dp) function interpolate(x_len, x_array, y_len, y_array, f, x, y)
-    ! This function uses bilinear interpolation to estimate the value
-    ! of a function f at point (x,y)
-    ! f is assumed to be sampled on a regular grid, with the grid x values specified
-    ! by x_array and the grid y values specified by y_array
-    ! Reference: http://en.wikipedia.org/wiki/Bilinear_interpolation
-    implicit none
-    integer, intent(in) :: x_len, y_len
-    real(dp), dimension(x_len), intent(in) :: x_array
-    real(dp), dimension(y_len), intent(in) :: y_array
-    real(dp), dimension(x_len, y_len), intent(in) :: f
-    real(dp), intent(in) :: x,y
-    real(dp) :: denom, x1, x2, y1, y2
-    integer :: i,j
-
-    i = binarysearch(x_len, x_array, x)
-    j = binarysearch(y_len, y_array, y)
-
-    if (i  >= x_len) then
-       i = x_len -1
-    end if
-    if (j >= y_len) then
-       j = y_len-1
-    end if
-    x1 = x_array(i)
-    x2 = x_array(i+1)
-
-    y1 = y_array(j)
-    y2 = y_array(j+1)
-
-    denom = (x2 - x1)*(y2 - y1)
-
-    interpolate = (f(i,j)*(x2-x)*(y2-y) + f(i+1,j)*(x-x1)*(y2-y) + &
-      f(i,j+1)*(x2-x)*(y-y1) + f(i+1, j+1)*(x-x1)*(y-y1))/denom
-
-  end function interpolate
 
   ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
As a result of #566 have found that the `interpolate` function in `maths_library.f90` is unused, so am removing this function. Closes #566 
## Checklist

I confirm that I have completed the following checks:

- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
