### PR TITLE
Fix Stellarator to allow it to run on open-source process

### DIFF
--- a/process/main.py
+++ b/process/main.py
@@ -347,6 +347,7 @@ class SingleRun:
         self.validate_input()
         self.init_module_vars()
         self.set_filenames()
+        self.initialise()
         self.models = Models()
         self.solver = solver
 
@@ -355,8 +356,6 @@ class SingleRun:
 
         This is separate from init to allow model instances to be modified before a run.
         """
-        self.set_filenames()
-        self.initialise()
         self.validate_user_model()
         self.run_tests()
         self.call_solver()
@@ -603,6 +602,9 @@ class Models:
         self.blanket_library = BlanketLibrary(fw=self.fw)
         self.ccfe_hcpb = CCFE_HCPB(blanket_library=self.blanket_library)
         self.current_drive = CurrentDrive()
+        self.physics = Physics(
+            plasma_profile=self.plasma_profile, current_drive=self.current_drive
+        )
         self.stellarator = Stellarator(
             availability=self.availability,
             buildings=self.buildings,
@@ -612,9 +614,7 @@ class Models:
             plasma_profile=self.plasma_profile,
             hcpb=self.ccfe_hcpb,
             current_drive=self.current_drive,
-        )
-        self.physics = Physics(
-            plasma_profile=self.plasma_profile, current_drive=self.current_drive
+            physics=self.physics,
         )
         self.dcll = DCLL(blanket_library=self.blanket_library)
 

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -33,6 +33,7 @@ from process.fortran import (
 import process.superconductors as superconductors
 import process.physics_functions as physics_funcs
 from process.coolprop_interface import FluidProperties
+from process.physics import rether
 
 logger = logging.getLogger(__name__)
 # Logging handler for console output
@@ -4063,7 +4064,7 @@ class Stellarator:
 
         #  Calculate ion/electron equilibration power
 
-        physics_variables.piepv = self.physics.rether(
+        physics_variables.piepv = rether(
             physics_variables.alphan,
             physics_variables.alphat,
             physics_variables.dene,

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -3266,7 +3266,6 @@ class Stellarator:
         Assumes current peak temperature (which is inaccurate as the cordey pass should be calculated)
         Maybe use this: https://doi.org/10.1088/0029-5515/49/8/085026
         """
-
         te_old = copy(physics_variables.te)
         # Volume averaged physics_variables.te from te0_achievable
         physics_variables.te = te0_available / (1.0e0 + physics_variables.alphat)
@@ -3868,7 +3867,7 @@ class Stellarator:
         self.physics.plasma_composition()
 
         # Calculate density and temperature profile quantities
-        profiles_module.plasma_profiles()
+        self.plasma_profile.run()
 
         #  Total field
         physics_variables.btot = np.sqrt(

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -24,7 +24,6 @@ from process.fortran import (
     constraint_variables,
     rebco_variables,
     maths_library,
-    profiles_module,
     physics_functions_module,
     neoclassics_module,
     impurity_radiation_module,

--- a/tests/unit/test_stellarator.py
+++ b/tests/unit/test_stellarator.py
@@ -24,6 +24,7 @@ from process.hcpb import CCFE_HCPB
 from process.blanket_library import BlanketLibrary
 from process.fw import Fw
 from process.current_drive import CurrentDrive
+from process.physics import Physics
 
 
 @pytest.fixture
@@ -42,6 +43,7 @@ def stellarator():
         PlasmaProfile(),
         CCFE_HCPB(BlanketLibrary(Fw())),
         CurrentDrive(),
+        Physics(PlasmaProfile(), CurrentDrive()),
     )
 
 


### PR DESCRIPTION
## Description

Allows Stellarator to run by updating it to use the new physics interface post-conversion. 

Adds in the following calculation for VV stress to enable constraint 65:
```python
sctfcoil_module.vv_stress_quench = (
    f_vv_actual
    * 1e6
    * ((build_variables.d_vv_in + build_variables.d_vv_out) / 2)
)
```

Modifies the `SingleRun` initialisation order slightly so that the correct cost model is passed to Stellarator/IFE
