### PR TITLE
3123 broken link in scan docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ fortran.py
 .coverage
 dist/*
 process/io/python_fortran_dicts.json
-documentation/proc-pages/vardes.md
+documentation/proc-pages/io/vardes.md
 lcov_results/
 env/
 .venv

--- a/documentation/proc-pages/io/input-guide.md
+++ b/documentation/proc-pages/io/input-guide.md
@@ -50,8 +50,8 @@ which are discussed below.
 
 !!! Info "Constraints"  
     A full list of constraints is given on the variable description page in the row labelled 
-    `lablcc` [here](../vardes/#numerics).  
-    See [solver](../../solver/solver-guide) page for more info
+    `lablcc` [here](vardes.md#numerics).  
+    See [solver](../solver/solver-guide.md) page for more info
 
 ## Iteration Variables
 
@@ -83,8 +83,8 @@ the default, if no value is specified), will be used as the starting value.
 
 !!! Note "Iteration Variables"  
     A full list of iteration variables is given on the variable description page in the row labelled 
-    `lablxc` [here](../vardes/#numerics).  
-    (See [solver](../../solver/solver-guide) page for more info)
+    `lablxc` [here](vardes.md#numerics).  
+    (See [solver](../solver/solver-guide.md) page for more info)
 
 ## Bounds
 
@@ -134,7 +134,7 @@ epsvmc   = 1.0e-8 * Error tolerance for vmcon
 
 !!! Info "Figure of Merit"  
     A full list of figures of merit is given on the variable description page in the row labelled 
-    `lablmm` [here](../vardes/#numerics).  
+    `lablmm` [here](vardes.md#numerics).  
 
 ## Input Variables
 
@@ -153,7 +153,7 @@ one can add a `*` to the beginning of the line, as below:
 
 !!! Info "Variable Descriptions"  
     A full list of inputs variables is given in the PROCESS `html` documentation 
-    file `vardes.html` and on the variable description page [here](../vardes).
+    file `vardes.html` and on the variable description page [here](vardes.md).
 
 ## Scan
 
@@ -169,7 +169,7 @@ isweep = 4
 sweep = 2.8, 2.9, 3.0, 3.1
 ```
 
-where `nsweep` is the scan variable chosen (see [variable descriptions](../vardes)),
+where `nsweep` is the scan variable chosen (see [variable descriptions](vardes.md)),
 `isweep` is the number of scan points and `sweep` is the array of scan values. In this example, 
 PROCESS runs for each of the four values given of the plasma aspect ratio variable `aspect`. 
 
@@ -201,7 +201,7 @@ Scan variables should not be confused with iteration variables.
 !!! Info "Scanning"    
     For obvious reasons, the active scanning variable or variables must not also be active
     iteration variables.   
-    A full list of scan variables is [here](../vardes/#scan_module).  
+    A full list of scan variables is [here](vardes.md#scan_module).  
 
 ## Examples
 

--- a/documentation/proc-pages/io/input-guide.md
+++ b/documentation/proc-pages/io/input-guide.md
@@ -51,7 +51,7 @@ which are discussed below.
 !!! Info "Constraints"  
     A full list of constraints is given on the variable description page in the row labelled 
     `lablcc` [here](../vardes/#numerics).  
-    See [solver](../solver/solver-guide) page for more info
+    See [solver](../../solver/solver-guide) page for more info
 
 ## Iteration Variables
 
@@ -84,7 +84,7 @@ the default, if no value is specified), will be used as the starting value.
 !!! Note "Iteration Variables"  
     A full list of iteration variables is given on the variable description page in the row labelled 
     `lablxc` [here](../vardes/#numerics).  
-    (See [solver](../solver/solver-guide) page for more info)
+    (See [solver](../../solver/solver-guide) page for more info)
 
 ## Bounds
 

--- a/documentation/proc-pages/io/output-guide.md
+++ b/documentation/proc-pages/io/output-guide.md
@@ -2,14 +2,14 @@
 # Output Files
 
 The default names of the output files are given below.  The filenames can be modified as 
-described in [File Naming Convention](../vardes.md/#file-naming-convention)
+described in [File Naming Convention](input-guide.md#file-naming-convention)
 
 The main output from the code is sent to a text file `OUT.DAT` in the working directory. 
 It is essential to check that the code reports that it has found a *feasible solution*.  
 
 A second text file, `MFILE.DAT`, is also produced in the working directory. This file contains 
 most of the same data as `OUT.DAT` but in a different format and has been designed to be 
-"machine-readable" by some of the [utility programs](../vardes.md/#python-utilities) for 
+"machine-readable" by some of the [utility programs](../utilities) for 
 post-processing and graphical output.
 
 An additional diagnostic output text file `VFILE.DAT` is generated if the `verbose` flag is set 

--- a/documentation/proc-pages/io/output-guide.md
+++ b/documentation/proc-pages/io/output-guide.md
@@ -9,7 +9,7 @@ It is essential to check that the code reports that it has found a *feasible sol
 
 A second text file, `MFILE.DAT`, is also produced in the working directory. This file contains 
 most of the same data as `OUT.DAT` but in a different format and has been designed to be 
-"machine-readable" by some of the [utility programs](../utilities) for 
+"machine-readable" by some of the [utility programs](utilities.md) for 
 post-processing and graphical output.
 
 An additional diagnostic output text file `VFILE.DAT` is generated if the `verbose` flag is set 

--- a/documentation/proc-pages/unique-models/water_use.md
+++ b/documentation/proc-pages/unique-models/water_use.md
@@ -33,7 +33,7 @@ Most nuclear power stations in the UK today are on the coast and use seawater fo
 
 ## Caveats and Limitations
 
-- For simplicity, the properties of water in these calculations are those at 21$\degree$C.  
+- For simplicity, the properties of water in these calculations are those at 21$^{\circ}$C.  
 - Any water used for the rejection of low grade heat is neglected.
 
 (Updated 12/4/23)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ nav:
           - Output: io/output-guide.md
           - Python Libraries: io/python-lib-guide.md
           - Utilities: io/utilities.md
-          - Variable Descriptions: vardes.md
+          - Variable Descriptions: io/vardes.md
   - Development:
       - Git:
           - Usage: development/git-usage.md

--- a/scripts/vardes.py
+++ b/scripts/vardes.py
@@ -47,9 +47,11 @@ def get_variables_and_modules(ford_project: Path):
                     var.name.lower(),
                     mod.name.lower(),
                     var.doc,
-                    VariableTypes.PARAMETER
-                    if var.parameter
-                    else VariableTypes.VARIABLE,
+                    (
+                        VariableTypes.PARAMETER
+                        if var.parameter
+                        else VariableTypes.VARIABLE
+                    ),
                     var.vartype,
                     var.initial,
                     permission == "private",
@@ -122,6 +124,7 @@ if __name__ == "__main__":
     vardes_template = env.get_template("vardes.jinja2")
 
     with open(
-        Path(__file__).resolve().parent / "../documentation/proc-pages/vardes.md", "w"
+        Path(__file__).resolve().parent / "../documentation/proc-pages/io/vardes.md",
+        "w",
     ) as f:
         f.write(vardes_template.render(mods=mods))


### PR DESCRIPTION
Broken links to variable descriptions in the docs have been fixed by changing the path of `vardes.md` when it's generated to match the other pages in I/O. Broken links to the solver docs have also been fixed by changing the relative path to the URL. A latex degree symbol has also been corrected to format properly.

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
