### PR TITLE
#392 Sauter's formulae for plasma current and geometric parameters.

### DIFF
--- a/process/plasma_geometry.py
+++ b/process/plasma_geometry.py
@@ -554,7 +554,7 @@ class PlasmaGeom:
 
         return xsect0
 
-    def Sauter_geometry(self, a, r0, kap, tri):
+    def sauter_geometry(self, a, r0, kap, tri):
         """
         Plasma geometry based on equations (36) in O. Sauter, Fusion Engineering and Design 112 (2016) 633–645
         'Geometric formulas for system codes including the effect of negative triangularity'

--- a/process/plasma_geometry.py
+++ b/process/plasma_geometry.py
@@ -222,24 +222,8 @@ class PlasmaGeom:
             physics_variables.kappa,
             physics_variables.triang,
         )
-
-        #  Poloidal perimeter
-        physics_variables.pperim = 2.0e0 * (xo * thetao + xi * thetai)
-        physics_variables.sf = physics_variables.pperim / (
-            2.0e0 * numpy.pi * physics_variables.rminor
-        )
-
-        #  Volume
-        physics_variables.vol = physics_variables.cvol * self.xvol(
-            physics_variables.rmajor,
-            physics_variables.rminor,
-            xi,
-            thetai,
-            xo,
-            thetao,
-        )
-
-        #  Surface area
+        #  Surface area - inboard and outboard.  These are not given by Sauter but
+        #  the outboard area is required by DCLL and divertor
         xsi, xso = self.xsurf(
             physics_variables.rmajor,
             physics_variables.rminor,
@@ -249,10 +233,45 @@ class PlasmaGeom:
             thetao,
         )
         physics_variables.sareao = xso
-        physics_variables.sarea = xsi + xso
 
-        #  Cross-sectional area
-        physics_variables.xarea = self.xsecta(xi, thetai, xo, thetao)
+        # icurr = 8 specifies use of the Sauter geometry as well as plasma current.
+        if physics_variables.icurr == 8:
+            (
+                physics_variables.pperim,
+                physics_variables.sf,
+                physics_variables.sarea,
+                physics_variables.xarea,
+                physics_variables.vol,
+            ) = self.Sauter_geometry(
+                physics_variables.rminor,
+                physics_variables.rmajor,
+                physics_variables.kappa,
+                physics_variables.triang,
+            )
+
+        else:
+
+            #  Poloidal perimeter
+            physics_variables.pperim = 2.0e0 * (xo * thetao + xi * thetai)
+            physics_variables.sf = physics_variables.pperim / (
+                2.0e0 * numpy.pi * physics_variables.rminor
+            )
+
+            #  Volume
+            physics_variables.vol = physics_variables.cvol * self.xvol(
+                physics_variables.rmajor,
+                physics_variables.rminor,
+                xi,
+                thetai,
+                xo,
+                thetao,
+            )
+
+            #  Cross-sectional area
+            physics_variables.xarea = self.xsecta(xi, thetai, xo, thetao)
+
+            #  Surface area - sum of inboard and outboard.
+            physics_variables.sarea = xsi + xso
 
     def xparam(self, a, kap, tri):
         """
@@ -534,3 +553,40 @@ class PlasmaGeom:
         xsect0 = xlo**2 * (thetao - cto * sto) + xli**2 * (thetai - cti * sti)
 
         return xsect0
+
+    def Sauter_geometry(self, a, r0, kap, tri):
+        """
+        Plasma geometry based on equations (36) in O. Sauter, Fusion Engineering and Design 112 (2016) 633–645
+        'Geometric formulas for system codes including the effect of negative triangularity'
+        Author: Michael Kovari, issue #392
+        a      : input real :  plasma minor radius (m)
+        r0     : input real :  plasma major radius (m)
+        kap    : input real :  plasma separatrix elongation
+        tri    : input real :  plasma separatrix triangularity
+        """
+        w07 = 1
+        eps = a / r0
+
+        # Poloidal perimeter (named Lp in Sauter)
+        pperim = (
+            2.0e0
+            * numpy.pi
+            * a
+            * (1 + 0.55 * (kap - 1))
+            * (1 + 0.08 * tri**2)
+            * (1 + 0.2 * (w07 - 1))
+        )
+
+        # A geometric factor
+        sf = pperim / (2.0e0 * numpy.pi * a)
+
+        # Surface area (named Ap in Sauter)
+        sarea = 2.0e0 * numpy.pi * r0 * (1 - 0.32 * tri * eps) * pperim
+
+        # Cross-section area (named S_phi in Sauter)
+        xarea = numpy.pi * a**2 * kap * (1 + 0.52 * (w07 - 1))
+
+        # Volume
+        vol = 2.0e0 * numpy.pi * r0 * (1 - 0.25 * tri * eps) * xarea
+
+        return pperim, sf, sarea, xarea, vol

--- a/process/sctfcoil.py
+++ b/process/sctfcoil.py
@@ -804,7 +804,7 @@ class Sctfcoil:
             jtol = 1.0e4
 
             for lap in range(100):
-                if ttest <= 0.0e0:
+                if ttest <= delt:
                     error_handling.idiags[0] = lap
                     error_handling.fdiags[0] = ttest
                     error_handling.report_error(157)

--- a/tests/unit/test_physics.py
+++ b/tests/unit/test_physics.py
@@ -498,7 +498,7 @@ class CulcurParam(NamedTuple):
 
     q0: Any = None
 
-    qpsi: Any = None
+    q95: Any = None
 
     rmajor: Any = None
 
@@ -541,7 +541,7 @@ class CulcurParam(NamedTuple):
             p0=0,
             pperim=24.081367139525412,
             q0=1,
-            qpsi=3.5,
+            q95=3.5,
             rmajor=8,
             rminor=2.6666666666666665,
             sf=1.4372507312498271,
@@ -569,7 +569,7 @@ class CulcurParam(NamedTuple):
             p0=626431.90482713911,
             pperim=24.081367139525412,
             q0=1,
-            qpsi=3.5,
+            q95=3.5,
             rmajor=8,
             rminor=2.6666666666666665,
             sf=1.4372507312498271,
@@ -616,7 +616,7 @@ def test_culcur(culcurparam, monkeypatch, physics):
         p0=culcurparam.p0,
         pperim=culcurparam.pperim,
         q0=culcurparam.q0,
-        qpsi=culcurparam.qpsi,
+        q95=culcurparam.q95,
         rmajor=culcurparam.rmajor,
         rminor=culcurparam.rminor,
         sf=culcurparam.sf,


### PR DESCRIPTION
Minor refactor of `culcur` in `physics.py`, as described in #392:
Update docstring.
Rename qpsi in culcur as q95.
Eliminate curhat since it's not necessary.
Test for a range of values of triangularity.