### PR TITLE
Fetch entire history in regression test job

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -136,6 +136,8 @@ jobs:
         tolerance: [0, 5]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## Description

Fetch entire Git history in regression testing job to allow the regression tests to look back through history for a tracked reference MFile.
