### PR TITLE
Update relative links in process docs

### DIFF
--- a/documentation/proc-pages/eng-models/central-solenoid.md
+++ b/documentation/proc-pages/eng-models/central-solenoid.md
@@ -85,7 +85,7 @@ in the case of the CS coils).
     11. A safety factor of 2 is used for the crack size.   
 
 <figure markdown>
-![CS defect](../../images/conductor_coordinates.png){ width="100%"}
+![CS defect](../images/conductor_coordinates.png){ width="100%"}
 <figcaption>Figure 2: Sketch of CS conductor with a planar defect.</figcaption>
 </figure>
 
@@ -153,7 +153,7 @@ using `fcohbop` (iteration variable no. 41). The current density in the CS at al
 calculated by taking into account the flux swing necessary to initiate and maintain plasma current. 
 
 <figure markdown>
-![current-vs-time-plot](../../images/current_vs_time.png){ width="100%"}
+![current-vs-time-plot](../images/current_vs_time.png){ width="100%"}
 <figcaption>Figure 2: Plot showing schematically the current waveforms for the plasma, a typical PF 
 coil, and the central solenoid. Note that the currents in some of the PF coils may be the opposite 
 sign to that shown, and the central solenoid current may remain positive during the I<sub>p</sub> 

--- a/documentation/proc-pages/eng-models/pf-coil.md
+++ b/documentation/proc-pages/eng-models/pf-coil.md
@@ -16,7 +16,7 @@ an element `ipfloc(j)` assigned to it. Input parameter `ngrp` should be set to t
 and `ncls(j)` should be assigned the number of coils in each group - which should be 2 in each case.
 
 <figure markdown>
-![Machine build](../../images/vertical-build.png){ width="100%"}
+![Machine build](../images/vertical-build.png){ width="100%"}
 <figcaption>Figure 1: Machine build for D-shaped major components</figcaption>
 </figure>
 
@@ -48,7 +48,7 @@ each PF coil `i` are inputs. The PF coil currents vary as a function of time dur
 operation as indicated in Figure 2. They contribute part of the flux swing necessary to maintain the plasma current.
 
 <figure markdown>
-![Current waveform for Plasma, PF coil and Central Solenoid](../../images/current_vs_time.png){ width="100%"}
+![Current waveform for Plasma, PF coil and Central Solenoid](../images/current_vs_time.png){ width="100%"}
 <figcaption>Figure 2: Plot showing schematically the current waveforms for the plasma, a typical PF 
 coil, and the central solenoid. Note that the currents in some of the PF coils may be the opposite 
 sign to that shown, and the central solenoid current may remain positive during the I<sub>p</sub> 

--- a/documentation/proc-pages/eng-models/power-conversion-and-heat-dissipation-systems.md
+++ b/documentation/proc-pages/eng-models/power-conversion-and-heat-dissipation-systems.md
@@ -5,7 +5,7 @@ power to electricity, from the coolant systems in the plant components to the he
 turbines. Figure 1 shows the power flow. 
 
 <figure markdown>
-![Power flow](../../images/Overall-power-flow.png){ width="100%"}
+![Power flow](../images/Overall-power-flow.png){ width="100%"}
 <figcaption>Figure 1: Power flows</figcaption>
 </figure>
 

--- a/documentation/proc-pages/eng-models/vacuum-vessel.md
+++ b/documentation/proc-pages/eng-models/vacuum-vessel.md
@@ -29,7 +29,7 @@ The reference above proceeds as follows.
 1.  An analytical formula is derived for the self-inductance of a TF coil composed of 6 circular arcs:
     
     <figure markdown>
-    ![TF shape Definition](../../images/tf-shape-definition.png)
+    ![TF shape Definition](../images/tf-shape-definition.png)
     <figcaption>Figure 1: Shape definition of current center lines in poloidal cross-section[^1]. This diagram is a representation of the geometry of both the TF coils and the vacuum vessel.</figcaption>
     </figure>
 

--- a/documentation/proc-pages/physics-models/plasma.md
+++ b/documentation/proc-pages/physics-models/plasma.md
@@ -544,7 +544,7 @@ allowance for radiation. This is not recommended for power plant models.
 The figure below shows the flow of power as calculated by the code.
 
 <figure markdown>
-![Power balance](../../images/Overall-power-flow.png){ width="100%"}
+![Power balance](../images/Overall-power-flow.png){ width="100%"}
 <figcaption>Figure 1: Machine build for D-shaped major components</figcaption>
 </figure>
 

--- a/documentation/proc-pages/usage/plotting.md
+++ b/documentation/proc-pages/usage/plotting.md
@@ -15,17 +15,17 @@ or through Process's main CLI (working, but still in development):
 process -i path/to/IN.DAT --plot --mfile path/to/MFILE.DAT
 ``` 
 <figure markdown>
-![plot_proc_1](../../images/plot_proc_1.PNG){ width="100%"}
+![plot_proc_1](../images/plot_proc_1.PNG){ width="100%"}
 <figcaption>Figure 1: plot_proc front summary page </figcaption>
 </figure>
 
 <figure markdown>
-![plot_proc_2](../../images/plot_proc_2.PNG){ width="100%"}
+![plot_proc_2](../images/plot_proc_2.PNG){ width="100%"}
 <figcaption>Figure 2: plot_proc plasma profiles and cross-sections page </figcaption>
 </figure>
 
 <figure markdown>
-![plot_proc_3](../../images/plot_proc_3.PNG){ width="100%"}
+![plot_proc_3](../images/plot_proc_3.PNG){ width="100%"}
 <figcaption>Figure 3: plot_proc TF coil and turn structure page </figcaption>
 </figure>
 
@@ -38,12 +38,12 @@ Scans can be done in one or two dimensions.
 python process/io/plot_scans.py -f path/to/MFILE.DAT
 ```
 <figure markdown>
-![2D_contour_plot](../../images/2D_contour_plot_example.png){figures-side, width="100%"}  
+![2D_contour_plot](../images/2D_contour_plot_example.png){figures-side, width="100%"}  
 <figcaption>Figure 4: 2D scan contour plot </figcaption>
 </figure>
 
 <figure markdown>
-![2D_stack_plot](../../images/stack_scan_plot_example.png){figures-side, width="100%"}  
+![2D_stack_plot](../images/stack_scan_plot_example.png){figures-side, width="100%"}  
 <figcaption>Figure 5: 1D scan plot </figcaption>
 </figure>
 
@@ -57,7 +57,7 @@ python process/io/plot_scans.py -f path/to/MFILE.DAT
 python process/io/plot_radial_build.py -f path/to/MFILE.DAT
 ```
 <figure markdown>
-![radial_build_plot](../../images/radial_build_plot.png){ width="100%"}
-<figcaption>Figure 6: Simple radial build plot </figcaption>
+![radial_build_plot](../images/radial_build_plot.png){ width="100%"}
+<figcaption>Figure 5: Simple radial build plot </figcaption>
 </figure>
 


### PR DESCRIPTION
## Description
Corrects relative image links.

**This PR does not include testing to avoid this happening in future**
The only way I can see to (easily) test this would be to check `mkdocs build --strict` does not fail. However, by the nature of our docs, some warnings will *always* occur. E.g.
```
WARNING -  [git-revision-date-localized-plugin] '/Users/timothynunn/process/documentation/proc-pages/io/vardes.md' has no git logs, using current
           timestamp
WARNING -  [git-revision-date-localized-plugin] '/Users/timothynunn/process/documentation/proc-pages/io/vardes.md' has no git logs, using current
           timestamp
```

@j-a-foster I know this doesn't solve your issue, but I don't think its possible without significant time investment that is likely not worth it.