### PR TITLE
Reset working directory after each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 Defines fixtures that will be shared across all test modules.
 """
 
+import os
 import pytest
 from system_check import system_compatible
 import warnings
@@ -140,3 +141,14 @@ def reinitialise_error_module():
     # for now for known error-raisers
     yield
     eh.init_error_handling()
+
+
+@pytest.fixture(autouse=True)
+def return_to_root():
+    """Various parts of PROCESS change directories and do not always change back.
+    This fixture ensures that, at the end of each test, the cwd is reset to what it
+    was at the beginning of the test.
+    """
+    cwd = os.getcwd()
+    yield
+    os.chdir(cwd)

--- a/tests/integration/test_main_int.py
+++ b/tests/integration/test_main_int.py
@@ -2,7 +2,6 @@
 
 from process import main
 from shutil import copy
-import os
 
 
 def test_single_run(temp_data):
@@ -40,20 +39,13 @@ def test_vary_run(temp_data):
     :param temp_data: temporary dir containing data files
     :type temp_data: Path
     """
-    cwd = os.getcwd()
     # Set run_process.conf path in temp dir
     # Chosen because it's the only VaryRun in the test suite, and is fast
     conf_path = temp_data / "run_process.conf"
     conf_file = str(conf_path.resolve())
 
     # Run a VaryRun with an explicit conf file name
-    try:
-        main.main(args=["--varyiterparams", "--varyiterparamsconfig", conf_file])
-    finally:
-        # quick fix for vary run changing the directory and not changing back at the end
-        # finally block ensures that even if the test fails, the directory is changed back
-        # to where we were before.
-        os.chdir(cwd)
+    main.main(args=["--varyiterparams", "--varyiterparamsconfig", conf_file])
 
 
 def test_vary_run_cwd(temp_data_cwd):


### PR DESCRIPTION
Running `pytest` on main was, again, causing the regression tests to fail with error `128`.

It seems that since writing the fix in #3162, another test has been introduced that unsafely changes the working directory. 
I have moved the fix in #3162 to a fixture that will run after each test to avoid this game of cat and mouse.

NOTE: this fixture can (and will) be used to identify which tests are doing naughty directory changes. 