### PR TITLE
Ensure idempotence of model evaluations

### DIFF
--- a/process/caller.py
+++ b/process/caller.py
@@ -114,9 +114,6 @@ class Caller:
         # TODO The only way to ensure idempotence in all outputs is by comparing
         # mfiles at this stage
         previous_mfile_arr = None
-        # Path of output file prefix required for writing intermediate idempotence-
-        # checking mfiles in the same directory as input file
-        output_prefix = ft.global_variables.output_prefix
 
         # Evaluate models up to 10 times; any more implies non-converging values
         for _ in range(10):
@@ -127,8 +124,11 @@ class Caller:
             # Write mfile
             finalise(self.models, ifail)
 
-            # Extract mfile data
-            mfile_path = f2py_compatible_to_string(output_prefix) + "IDEM_MFILE.DAT"
+            # Extract data from intermediate idempotence-checking mfile
+            mfile_path = (
+                f2py_compatible_to_string(ft.global_variables.output_prefix)
+                + "IDEM_MFILE.DAT"
+            )
             mfile = MFile(mfile_path)
             mfile_data = {}
             for var in mfile.data.keys():

--- a/process/caller.py
+++ b/process/caller.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
 from process import fortran as ft
 import numpy as np
 import logging
 from typing import Union, Tuple
+import process.main
+from process.final import finalise
+from process.io.mfile import MFile
+from process.utilities.f2py_string_patch import f2py_compatible_to_string
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +14,7 @@ logger = logging.getLogger(__name__)
 class Caller:
     """Calls physics and engineering models."""
 
-    def __init__(self, models, x):
+    def __init__(self, models):
         """Initialise all physics and engineering models.
 
         To ensure that, at the start of a run, all physics/engineering
@@ -18,8 +23,6 @@ class Caller:
 
         :param models: physics and engineering model objects
         :type models: process.main.Models
-        :param x: optimisation parameters
-        :type x: np.ndarray
         """
         self.models = models
 
@@ -56,7 +59,7 @@ class Caller:
         conf_prev = None
 
         # Evaluate models up to 10 times; any more implies non-converging values
-        for i in range(10):
+        for _ in range(10):
             self._call_models_once(xc)
             # Evaluate objective function and constraints
             objf = ft.function_evaluator.funfom()
@@ -89,6 +92,75 @@ class Caller:
             "Model evaluations at the current optimisation parameter vector "
             "don't produce idempotent values for the objective function and "
             "constraints."
+        )
+
+    def call_models_full_idempotence(self, xc: np.ndarray, ifail: int) -> None:
+        """Evaluate models until all results are idempotent.
+
+        Ensure all outputs in mfile are idempotent before returning, by
+        evaluating models multiple times. Typically used at the end of an
+        optimisation, or in a non-optimising evaluation.
+
+        :param xc: optimisation parameter
+        :type xc: np.ndarray
+        :param ifail: return code of solver
+        :type ifail: int
+        :raises RuntimeError: if values are non-idempotent after successive
+        evaluations
+        """
+        # TODO The only way to ensure idempotence in all outputs is by comparing
+        # mfiles at this stage
+        previous_mfile_arr = None
+        file_prefix = ft.global_variables.fileprefix
+        # Evaluate models up to 10 times; any more implies non-converging values
+        for _ in range(10):
+            # Divert OUT.DAT and MFILE.DAT output to scratch files for
+            # idempotence checking
+            ft.init_module.open_idempotence_files()
+            self._call_models_once(xc)
+            # Write mfile
+            finalise(self.models, ifail)
+
+            # Extract mfile data
+            mfile_path = (
+                f2py_compatible_to_string(file_prefix).split("IN.DAT")[0]
+                + "IDEM_MFILE.DAT"
+            )
+            mfile = MFile(mfile_path)
+            mfile_data = {}
+            for var in mfile.data.keys():
+                mfile_data[var] = mfile.data[var].get_scan(-1)
+
+            # Extract floats from mfile dict into array for straightforward
+            # comparison: only compare floats
+            current_mfile_arr = np.array(
+                [val for val in mfile_data.values() if type(val) is float]
+            )
+            if previous_mfile_arr is None:
+                # First run: need another run to compare with
+                logger.debug(
+                    "New mfile created: evaluating models again to check idempotence"
+                )
+                previous_mfile_arr = np.copy(current_mfile_arr)
+                continue
+
+            if self.check_agreement(previous_mfile_arr, current_mfile_arr):
+                # Previous and current mfiles agree (idempotent)
+                logger.debug("Mfiles idempotent, returning")
+                # Divert OUT.DAT and MFILE.DAT output back to original files
+                # now idempotence checking complete
+                ft.init_module.close_idempotence_files()
+                # Write final output file and mfile
+                finalise(self.models, ifail)
+                return
+            else:
+                # Mfiles not yet idempotent: re-evaluate models
+                logger.debug("Mfiles not idempotent, evaluating models again")
+                previous_mfile_arr = np.copy(current_mfile_arr)
+
+        raise RuntimeError(
+            "Model evaluations at the current optimisation parameter vector "
+            "don't produce idempotent values in the final output."
         )
 
     def _call_models_once(self, xc):
@@ -227,3 +299,21 @@ class Caller:
         self.models.costs.run()
 
         # FISPACT and LOCA model (not used)- removed
+
+
+def write_idempotent_result(models: process.main.Models, ifail: int) -> None:
+    """Ensure result idempotence, then write output files.
+
+    :param models: physics and engineering models
+    :type models: process.main.Models
+    :param ifail: solver return code
+    :type ifail: int
+    """
+    n = ft.numerics.nvar
+    x = ft.numerics.xcm[:n]
+    # Call models, ensuring output mfiles are fully idempotent
+    caller = Caller(models)
+    caller.call_models_full_idempotence(
+        xc=x,
+        ifail=ifail,
+    )

--- a/process/evaluators.py
+++ b/process/evaluators.py
@@ -3,7 +3,6 @@ from process.fortran import global_variables as gv
 from process.fortran import cost_variables as cv
 from process.fortran import numerics
 from process.fortran import physics_variables as pv
-from process.fortran import stellarator_variables as sv
 from process.fortran import times_variables as tv
 import numpy as np
 import math
@@ -52,24 +51,6 @@ class Evaluators:
 
         # Evaluate machine parameters at xv
         objf, conf = self.caller.call_models(xv, m)
-
-        # Convergence loop to ensure burn time consistency
-        # TODO This can be removed once model evaluations become effectively
-        # idempotent
-        if sv.istell == 0:
-            for _ in range(10):
-                if abs((tv.tburn - tv.tburn0) / max(tv.tburn, 0.01)) <= 0.001:
-                    break
-
-                objf, conf = self.caller.call_models(xv, m)
-                if gv.verbose == 1:
-                    print("Internal tburn consistency check: ", tv.tburn, tv.tburn0)
-            else:
-                print(
-                    "Burn time values are not consistent in iteration: ",
-                    numerics.nviter,
-                )
-                print("tburn, tburn0: ", tv.tburn, tv.tburn0)
 
         # Verbose diagnostics
         if gv.verbose == 1:

--- a/process/evaluators.py
+++ b/process/evaluators.py
@@ -23,7 +23,7 @@ class Evaluators:
         :param x: optimisation parameters
         :type x: np.ndarray
         """
-        self.caller = Caller(models, x)
+        self.caller = Caller(models)
 
     def fcnvmc1(self, n, m, xv, ifail):
         """Function evaluator for VMCON.

--- a/process/final.py
+++ b/process/final.py
@@ -1,4 +1,5 @@
 """Final output at the end of a scan."""
+
 from process import fortran as ft
 from process.fortran import final_module as fm
 from process import output as op
@@ -6,6 +7,8 @@ from process import output as op
 
 def finalise(models, ifail):
     """Routine to print out the final point in the scan.
+
+    Writes to OUT.DAT and MFILE.DAT.
 
     :param models: physics and engineering model objects
     :type models: process.main.Models
@@ -18,7 +21,7 @@ def finalise(models, ifail):
     if ft.numerics.ioptimz == -2:
         fm.no_optimisation()
 
-    # Write output to OUT.DAT
+    # Write output to OUT.DAT and MFILE.DAT
     op.write(models, ft.constants.nout)
 
     fm.final_output()

--- a/process/main.py
+++ b/process/main.py
@@ -71,7 +71,7 @@ from process.blanket_library import BlanketLibrary
 from process.fw import Fw
 from process.current_drive import CurrentDrive
 from process.impurity_radiation import initialise_imprad
-from process.caller import write_idempotent_result
+from process.caller import write_output_files
 
 
 from pathlib import Path
@@ -467,10 +467,13 @@ class SingleRun:
             # Get optimisation parameters x, evaluate models
             fortran.define_iteration_variables.loadxc()
             self.ifail = 6
-            write_idempotent_result(models=self.models, ifail=self.ifail)
+            write_output_files(models=self.models, ifail=self.ifail)
             self.show_errors()
         else:
-            raise ValueError(f"Invalid ioptimz value: {fortran.numerics.ioptimz}")
+            raise ValueError(
+                f"Invalid ioptimz value: {fortran.numerics.ioptimz}. Please "
+                "select either 1 (optimise) or -2 (no optimisation)."
+            )
 
     def show_errors(self):
         """Report all informational/error messages encountered."""

--- a/process/scan.py
+++ b/process/scan.py
@@ -2,8 +2,8 @@ from process.fortran import error_handling
 from process.fortran import scan_module
 from process.fortran import numerics
 from process.optimiser import Optimiser
-from process import final
 import numpy as np
+from process.caller import write_idempotent_result
 
 
 class Scan:
@@ -34,7 +34,7 @@ class Scan:
 
         if scan_module.isweep == 0:
             ifail = self.doopt()
-            final.finalise(self.models, ifail)
+            write_idempotent_result(models=self.models, ifail=ifail)
             error_handling.show_errors()
             return
 
@@ -76,7 +76,7 @@ class Scan:
             scan_module.scan_1d_write_point_header(iscan)
             ifail = self.doopt()
             scan_1d_ifail_dict[iscan] = ifail
-            final.finalise(self.models, ifail)
+            write_idempotent_result(models=self.models, ifail=ifail)
 
             # outvar is an intent(out) of scan_1d_store_output()
             outvar = scan_module.scan_1d_store_output(
@@ -146,7 +146,7 @@ class Scan:
                 )
                 ifail = self.doopt()
 
-                final.finalise(self.models, ifail)
+                write_idempotent_result(models=self.models, ifail=ifail)
 
                 outvar, sweep_1_vals, sweep_2_vals = scan_module.scan_2d_store_output(
                     ifail,

--- a/process/scan.py
+++ b/process/scan.py
@@ -3,7 +3,7 @@ from process.fortran import scan_module
 from process.fortran import numerics
 from process.optimiser import Optimiser
 import numpy as np
-from process.caller import write_idempotent_result
+from process.caller import write_output_files
 
 
 class Scan:
@@ -34,7 +34,7 @@ class Scan:
 
         if scan_module.isweep == 0:
             ifail = self.doopt()
-            write_idempotent_result(models=self.models, ifail=ifail)
+            write_output_files(models=self.models, ifail=ifail)
             error_handling.show_errors()
             return
 
@@ -76,7 +76,7 @@ class Scan:
             scan_module.scan_1d_write_point_header(iscan)
             ifail = self.doopt()
             scan_1d_ifail_dict[iscan] = ifail
-            write_idempotent_result(models=self.models, ifail=ifail)
+            write_output_files(models=self.models, ifail=ifail)
 
             # outvar is an intent(out) of scan_1d_store_output()
             outvar = scan_module.scan_1d_store_output(
@@ -146,7 +146,7 @@ class Scan:
                 )
                 ifail = self.doopt()
 
-                write_idempotent_result(models=self.models, ifail=ifail)
+                write_output_files(models=self.models, ifail=ifail)
 
                 outvar, sweep_1_vals, sweep_2_vals = scan_module.scan_2d_store_output(
                     ifail,

--- a/source/fortran/final_module.f90
+++ b/source/fortran/final_module.f90
@@ -73,7 +73,7 @@ module final_module
   end subroutine no_optimisation
 
   subroutine final_output()
-    use constants, only: iotty
+    use constants, only: iotty, mfile
     use numerics, only: nfev1, ncalls, xcm, ioptimz, nviter, &
       nvar
     use define_iteration_variables, only: loadxc
@@ -117,5 +117,9 @@ module final_module
           t2,'The HYBRD point required ',i5,' iterations',/, &
           t2,'The optimisation required ',i5,' iterations',/, &
           t2,'There were ',i6,' function calls')
+
+    ! Required to ensure mfile fully written before any model evaluation
+    ! idempotence checks
+    flush(mfile)
   end subroutine final_output
 end module final_module

--- a/source/fortran/init_module.f90
+++ b/source/fortran/init_module.f90
@@ -186,8 +186,9 @@ contains
    end subroutine open_idempotence_files
 
    subroutine close_idempotence_files
-      ! Revert back to writing to original OUT.DAT and MFILE.DAT, after
-      ! checking model evaluation idempotence
+      ! Close the intermediate idempotence-check files, deleting them in the process
+      ! Re-open the original OUT.DAT and MFILE.DAT output files, ready to write
+      ! the final data, now model evaluation idempotence has been checked
       use global_variables, only: output_prefix
       use constants, only: nout, mfile
       implicit none

--- a/source/fortran/init_module.f90
+++ b/source/fortran/init_module.f90
@@ -168,6 +168,38 @@ contains
 
    end subroutine init
 
+   subroutine open_idempotence_files
+      ! Open new output file and mfile to write output to
+      ! This is used when checking model evaluation idempotence, to avoid
+      ! polluting the final output file and mfile with intermediate result checks
+      use global_variables, only: output_prefix
+      use constants, only: nout, mfile
+      implicit none
+
+      ! Close existing output file and mfile (could be original out and mfiles
+      ! or idem scratch files)
+      close(unit = nout)
+      close(unit = mfile)
+      ! Open scratch files with same units
+      open(unit=nout, file=trim(output_prefix)//'IDEM_OUT.DAT', action='write', status='replace')
+      open(unit=mfile, file=trim(output_prefix)//'IDEM_MFILE.DAT', action='write', status='replace')
+   end subroutine open_idempotence_files
+
+   subroutine close_idempotence_files
+      ! Revert back to writing to original OUT.DAT and MFILE.DAT, after
+      ! checking model evaluation idempotence
+      use global_variables, only: output_prefix
+      use constants, only: nout, mfile
+      implicit none
+
+      ! Close idempotence files, deleting them in the process
+      close(unit = nout, status="delete")
+      close(unit = mfile, status="delete")
+      ! Re-open original output file and mfile, appending future output to them
+      open(unit=nout, file=trim(output_prefix)//'OUT.DAT', action='write', position='append')
+      open(unit=mfile, file=trim(output_prefix)//'MFILE.DAT', action='write', position='append')
+   end subroutine close_idempotence_files
+
    subroutine finish
       ! Originally at the end of the "program", this subroutine writes some final
       ! lines via the output module and then closes any open files. This is


### PR DESCRIPTION
To try to ensure idempotency in the result of the model evaluations whilst being efficient, the idea is to:

- When optimising, ensure idempotence for objective function and constraints **ONLY**
- When not optimising or outputting final result, ensure idempotence for all variables in mfile​

This will at least double model evaluations (and hence code runtime)​, as a comparison of previous and current results for the same optimisation parameter vector is required in each case.