### PR TITLE
Add small d_vv_in for ST regression test

### DIFF
--- a/tests/regression/input_files/st_regression.IN.DAT
+++ b/tests/regression/input_files/st_regression.IN.DAT
@@ -2054,7 +2054,7 @@ gapds = 0.01
 * DESCRIPTION:   Gap Between inboard Vacuum Vessel and Thermal Shield (m)
 * JUSTIFICATION: 
 
-d_vv_in = 0.0 
+d_vv_in = 0.2 
 * DESCRIPTION:   Vacuum Vessel Thickness (m)
 * JUSTIFICATION: Removed to avoid temporary problems with cryo plant
 


### PR DESCRIPTION
## Description

Sets `d_vv_in` for ST regression test to avoid `vv_stress_quench` becoming `NaN`.


[st_regression.MFILE.DAT.txt](https://github.com/ukaea/PROCESS/files/15482686/st_regression.MFILE.DAT.txt)
[st_regression.OUT.DAT.txt](https://github.com/ukaea/PROCESS/files/15482688/st_regression.OUT.DAT.txt)
