### PR TITLE
Removed tfsai and tfsao from sctfcoil due to obsolete var in calcs

### DIFF
--- a/process/power.py
+++ b/process/power.py
@@ -789,7 +789,7 @@ class Power:
             # heat_transport_variables.helpow calculation
             heat_transport_variables.helpow = self.cryo(
                 tfcoil_variables.i_tf_sup,
-                tfcoil_variables.tfsai,
+                tfcoil_variables.tfcryoarea,
                 structure_variables.coldmass,
                 fwbs_variables.ptfnuc,
                 pf_power_variables.ensxpfm,
@@ -2251,13 +2251,15 @@ class Power:
     # 30    format(t20,a20,t40,a8,t50,a8,t60,a8,t70,a8,t80,a8,t90,a8,t100,a8)
     # 40    format(t20,a20,t40,f8.2,t50,f8.2,t60,f8.2,t70,f8.2,t80,f8.2,t90,f8.2,t100,f8.2,t110,f8.2)
 
-    def cryo(self, i_tf_sup, tfsai, coldmass, ptfnuc, ensxpfm, tpulse, cpttf, n_tf):
+    def cryo(
+        self, i_tf_sup, tfcryoarea, coldmass, ptfnuc, ensxpfm, tpulse, cpttf, n_tf
+    ):
         """
         Calculates cryogenic loads
         author: P J Knight, CCFE, Culham Science Centre
         itfsup : input integer : Switch denoting whether TF coils are
         superconducting
-        tfsai : input real : Inboard TF coil surface area (m2)
+        tfcryoarea : input real : Surface area of toroidal shells covering TF coils (m2)
         coldmass : input real : Mass of cold (cryogenic) components (kg),
         including TF coils, PF coils, cryostat, and
         intercoil structure
@@ -2272,7 +2274,7 @@ class Power:
         """
         self.qss = 4.3e-4 * coldmass
         if i_tf_sup == 1:
-            self.qss = self.qss + 2.0e0 * tfsai
+            self.qss = self.qss + 2.0e0 * tfcryoarea
 
         #  Nuclear heating of TF coils (W) (zero if resistive)
         if fwbs_variables.inuclear == 0 and i_tf_sup == 1:

--- a/process/sctfcoil.py
+++ b/process/sctfcoil.py
@@ -2506,7 +2506,6 @@ class Sctfcoil:
         # ---
 
         # Surface areas (for cryo system) [m2]
-        # tfsai, tfcoil_variables.tfsao are retained for the (obsolescent) TF coil nuclear heating calculation
         wbtf = (
             build_variables.r_tf_inboard_out * numpy.sin(sctfcoil_module.theta_coil)
             - build_variables.r_tf_inboard_in * sctfcoil_module.tan_theta_coil
@@ -2515,24 +2514,10 @@ class Sctfcoil:
             build_variables.r_tf_inboard_in * sctfcoil_module.tan_theta_coil
         )
         tfcoil_variables.tficrn = tfcoil_variables.tfocrn + wbtf
-        tfcoil_variables.tfsai = (
-            4.0e0
-            * tfcoil_variables.n_tf
-            * tfcoil_variables.tficrn
-            * build_variables.hr1
-        )
-        tfcoil_variables.tfsao = (
-            2.0e0
-            * tfcoil_variables.n_tf
-            * tfcoil_variables.tficrn
-            * (tfcoil_variables.tfleng - 2.0e0 * build_variables.hr1)
-        )
 
         # Total surface area of two toroidal shells covering the TF coils [m2]
         # (inside and outside surfaces)
         # = 2 * centroid coil length * 2 pi R, where R is average of i/b and o/b centres
-        # (This will possibly be used to replace 2*tfcoil_variables.tfsai in the calculation of qss
-        # in subroutine cryo - not done at present.)
         tfcoil_variables.tfcryoarea = (
             2.0e0
             * tfcoil_variables.tfleng

--- a/tests/unit/test_power.py
+++ b/tests/unit/test_power.py
@@ -56,7 +56,7 @@ class CryoParam(NamedTuple):
 
     n_tf: Any = None
 
-    tfsai: Any = None
+    tfcryoarea: Any = None
 
     tpulse: Any = None
 
@@ -87,7 +87,7 @@ class CryoParam(NamedTuple):
             ensxpfm=37429.525515086898,
             ptfnuc=0.044178296011112193,
             n_tf=16,
-            tfsai=0,
+            tfcryoarea=0,
             tpulse=10364.426139387357,
             expected_qss=20361.633927097802,
             expected_qac=3611.3456752656607,
@@ -108,7 +108,7 @@ class CryoParam(NamedTuple):
             ensxpfm=37427.228965055205,
             ptfnuc=0.045535131445547841,
             n_tf=16,
-            tfsai=0,
+            tfcryoarea=0,
             tpulse=364.42613938735633,
             expected_qss=20342.863776957758,
             expected_qac=102701.82327748176,
@@ -150,7 +150,7 @@ def test_cryo(cryoparam, monkeypatch, power):
         ensxpfm=cryoparam.ensxpfm,
         ptfnuc=cryoparam.ptfnuc,
         n_tf=cryoparam.n_tf,
-        tfsai=cryoparam.tfsai,
+        tfcryoarea=cryoparam.tfcryoarea,
         tpulse=cryoparam.tpulse,
     )
 

--- a/tests/unit/test_sctfcoil.py
+++ b/tests/unit/test_sctfcoil.py
@@ -1846,8 +1846,6 @@ class TfCoilAreaAndMassesParam(NamedTuple):
 
     tfcryoarea: Any = None
 
-    tfsao: Any = None
-
     whtgw: Any = None
 
     tfocrn: Any = None
@@ -1860,7 +1858,7 @@ class TfCoilAreaAndMassesParam(NamedTuple):
 
     whtconin: Any = None
 
-    tfsai: Any = None
+    tfcryoarea: Any = None
 
     vftf: Any = None
 
@@ -1940,8 +1938,6 @@ class TfCoilAreaAndMassesParam(NamedTuple):
 
     expected_tfcryoarea: Any = None
 
-    expected_tfsao: Any = None
-
     expected_whtgw: Any = None
 
     expected_tfocrn: Any = None
@@ -1974,14 +1970,12 @@ class TfCoilAreaAndMassesParam(NamedTuple):
             whtcas=0,
             tficrn=0,
             tfcryoarea=0,
-            tfsao=0,
             whtgw=0,
             tfocrn=0,
             whtconsc=0,
             whtconcu=0,
             whtcon=0,
             whtconin=0,
-            tfsai=0,
             vftf=0.30000000000000004,
             dcond=numpy.array(
                 numpy.array(
@@ -2026,7 +2020,6 @@ class TfCoilAreaAndMassesParam(NamedTuple):
             expected_whtcas=1034021.9996272125,
             expected_tficrn=0.8197580588957678,
             expected_tfcryoarea=6381.2092203414386,
-            expected_tfsao=1324.3051892984724,
             expected_whtgw=5909.3507916745702,
             expected_tfocrn=0.59553192892551199,
             expected_whtconsc=5802.5700395134345,
@@ -2049,14 +2042,12 @@ class TfCoilAreaAndMassesParam(NamedTuple):
             whtcas=1034021.9996272125,
             tficrn=0.8197580588957678,
             tfcryoarea=6381.2092203414386,
-            tfsao=1324.3051892984724,
             whtgw=5909.3507916745702,
             tfocrn=0.59553192892551199,
             whtconsc=5802.5700395134345,
             whtconcu=58744.465423173802,
             whtcon=0,
             whtconin=0,
-            tfsai=0,
             vftf=0.30000000000000004,
             dcond=numpy.array(
                 numpy.array(
@@ -2101,7 +2092,6 @@ class TfCoilAreaAndMassesParam(NamedTuple):
             expected_whtcas=1034699.2182961091,
             expected_tficrn=0.8197580588957678,
             expected_tfcryoarea=6385.0231118485681,
-            expected_tfsao=1325.0966938769795,
             expected_whtgw=5912.8826650262808,
             expected_tfocrn=0.59553192892551199,
             expected_whtconsc=5806.038092640837,
@@ -2161,8 +2151,6 @@ def test_tf_coil_area_and_masses(tfcoilareaandmassesparam, monkeypatch, sctfcoil
         tfcoil_variables, "tfcryoarea", tfcoilareaandmassesparam.tfcryoarea
     )
 
-    monkeypatch.setattr(tfcoil_variables, "tfsao", tfcoilareaandmassesparam.tfsao)
-
     monkeypatch.setattr(tfcoil_variables, "whtgw", tfcoilareaandmassesparam.whtgw)
 
     monkeypatch.setattr(tfcoil_variables, "tfocrn", tfcoilareaandmassesparam.tfocrn)
@@ -2175,7 +2163,9 @@ def test_tf_coil_area_and_masses(tfcoilareaandmassesparam, monkeypatch, sctfcoil
 
     monkeypatch.setattr(tfcoil_variables, "whtconin", tfcoilareaandmassesparam.whtconin)
 
-    monkeypatch.setattr(tfcoil_variables, "tfsai", tfcoilareaandmassesparam.tfsai)
+    monkeypatch.setattr(
+        tfcoil_variables, "tfcryoarea", tfcoilareaandmassesparam.tfcryoarea
+    )
 
     monkeypatch.setattr(tfcoil_variables, "vftf", tfcoilareaandmassesparam.vftf)
 
@@ -2285,10 +2275,6 @@ def test_tf_coil_area_and_masses(tfcoilareaandmassesparam, monkeypatch, sctfcoil
 
     assert tfcoil_variables.tfcryoarea == pytest.approx(
         tfcoilareaandmassesparam.expected_tfcryoarea
-    )
-
-    assert tfcoil_variables.tfsao == pytest.approx(
-        tfcoilareaandmassesparam.expected_tfsao
     )
 
     assert tfcoil_variables.whtgw == pytest.approx(


### PR DESCRIPTION
## Description

I removed `tfsai` and `tfsao` from `sctfcoil.py` as they were using the variable `hr1` which wasn't calculated or an input and just set to 0. A power calculation that used `tfsai` was then replaced with `tfcryoarea` based on comments in the code (which have now been removed).

## Checklist

I confirm that I have completed the following checks:

- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
