### PR TITLE
Remove unnecessary write statement in input.f90

### DIFF
--- a/source/fortran/input.f90
+++ b/source/fortran/input.f90
@@ -501,7 +501,6 @@ contains
        case ('minmax')
           call parse_int_variable('minmax', minmax, -ipnfoms, ipnfoms, 'Switch for figure of merit')
        case ('neqns')
-           write(*,*)'The total number of constraints is counted automatically and does not need to be stated in IN.DAT.'
            call parse_int_variable('neqns', neqns, 1, ipeqns, 'No of equality constraints')
        case ('nineqns')
           call parse_int_variable('nineqns', nineqns, 1, ipeqns, 'No of inequality constraints')


### PR DESCRIPTION
## Description

The unnecessary print statement has been removed.

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
