### PR TITLE
Regression tests run after tracking job on main

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -124,7 +124,10 @@ jobs:
 
   regression-py38:
     runs-on: ubuntu-latest
-    needs: make-py38
+    needs: [make-py38, tracking]
+    # depend on make and tracking job, check make job was successful
+    # but dont skip if tracking was skipped
+    if: always() && needs.make-py38.result == 'success'
     continue-on-error: true
     container:
       image: ghcr.io/ukaea/process-ci:latest


### PR DESCRIPTION
## Description

Makes the `regression` job depend on the `make` and `tracking` jobs. However, adding a conditional on the `regression` job ensures it runs even if the tracking job skips provided the `make` job does not fail.