### PR TITLE
Removed confusing comment about double null, added more descriptive c…

### DIFF
--- a/process/build.py
+++ b/process/build.py
@@ -116,8 +116,8 @@ class Build:
 
         # If build_variables.vgap /= 0 use the value set by the user.
 
-        # Height to inside edge of TF coil
-        # Rem SK : definition only valid for double null#
+        # Height to inside edge of TF coil. TF coils are assumed to be symmetrical.
+        # Therefore this applies to single and double null cases.
         build_variables.hmax = (
             physics_variables.rminor * physics_variables.kappa
             + build_variables.vgap


### PR DESCRIPTION
The calculation of hmax in the vertical build was a bit confusing as there was/is a comment that implies it's only valid for double null builds.

In general we assume TF coils to be symmetrical, so in fact this calculation is fine for both single and double null.

I have clarified this in the comment of the code.
