### PR TITLE
Plot-proc fixes in poloidal cross section for first wall and blanket

### DIFF
--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -1326,17 +1326,21 @@ def plot_blanket(axis, mfile_data, scan, colour_scheme) -> None:
         )
         # Plot blanket
         axis.plot(bg_double_null.rs[0], bg_double_null.zs[0], color="black", lw=thin)
-        axis.plot(bg_double_null.rs[1], bg_double_null.zs[1], color="black", lw=thin)
         axis.fill(
             bg_double_null.rs[0],
             bg_double_null.zs[0],
             color=BLANKET_COLOUR[colour_scheme - 1],
         )
-        axis.fill(
-            bg_double_null.rs[1],
-            bg_double_null.zs[1],
-            color=BLANKET_COLOUR[colour_scheme - 1],
-        )
+        if blnkith > 0:
+            # only plot inboard blanket if inboard blanket thickness > 0
+            axis.plot(
+                bg_double_null.rs[1], bg_double_null.zs[1], color="black", lw=thin
+            )
+            axis.fill(
+                bg_double_null.rs[1],
+                bg_double_null.zs[1],
+                color=BLANKET_COLOUR[colour_scheme - 1],
+            )
 
 
 def plot_firstwall(axis, mfile_data, scan, colour_scheme):

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -1417,18 +1417,18 @@ def plot_firstwall(axis, mfile_data, scan, colour_scheme):
             fwoth=fwoth,
             tfwvt=tfwvt,
         )
-        # Plot blanket
+        # Plot first wall
         axis.plot(fwg_double_null.rs[0], fwg_double_null.zs[0], color="black", lw=thin)
         axis.plot(fwg_double_null.rs[1], fwg_double_null.zs[1], color="black", lw=thin)
         axis.fill(
             fwg_double_null.rs[0],
             fwg_double_null.zs[0],
-            color=BLANKET_COLOUR[colour_scheme - 1],
+            color=FIRSTWALL_COLOUR[colour_scheme - 1],
         )
         axis.fill(
             fwg_double_null.rs[1],
             fwg_double_null.zs[1],
-            color=BLANKET_COLOUR[colour_scheme - 1],
+            color=FIRSTWALL_COLOUR[colour_scheme - 1],
         )
 
 

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -1331,7 +1331,7 @@ def plot_blanket(axis, mfile_data, scan, colour_scheme) -> None:
             bg_double_null.zs[0],
             color=BLANKET_COLOUR[colour_scheme - 1],
         )
-        if blnkith > 0:
+        if blnkith > 0.0:
             # only plot inboard blanket if inboard blanket thickness > 0
             axis.plot(
                 bg_double_null.rs[1], bg_double_null.zs[1], color="black", lw=thin


### PR DESCRIPTION
## Description

Changed the colour of the first wall fill for double null case to use first wall colour not the blanket colour. Also added small if statement to not plot the inboard blanket if it has 0 thickness for the double null case.

First image shows the poloidal cross section before any changes. The second shows the present of inner blanket when there shouldn't be overlapping with the first wall. Final image is post changes.

![Before](https://github.com/user-attachments/assets/3f86e5e2-8bec-4bf7-a668-27ee09be38ad)
![inner_blanket](https://github.com/user-attachments/assets/5fa05582-2e47-4e69-a8bb-7e536b942f8a)
![After](https://github.com/user-attachments/assets/a7e24da9-6680-43c9-8a4a-4411ba484d2e)

