### PR TITLE
1038 costing superconductors in all coils using dollars per kam rather than dollars per kg

### DIFF
--- a/process/costs.py
+++ b/process/costs.py
@@ -1438,11 +1438,19 @@ class Costs:
 
             #  Superconductor ($/m)
 
-            costtfsc = (
-                cost_variables.ucsc[tfcoil_variables.i_tf_sc_mat - 1]
-                * tfcoil_variables.whtconsc
-                / (tfcoil_variables.tfleng * tfcoil_variables.n_tf_turn)
-            )
+            if cost_variables.supercond_cost_model == 0:
+
+                costtfsc = (
+                    cost_variables.ucsc[tfcoil_variables.i_tf_sc_mat - 1]
+                    * tfcoil_variables.whtconsc
+                    / (tfcoil_variables.tfleng * tfcoil_variables.n_tf_turn)
+                )
+            else:
+                costtfsc = (
+                    cost_variables.sc_mat_cost_0[tfcoil_variables.i_tf_sc_mat - 1]
+                    * tfcoil_variables.j_crit_str_0[tfcoil_variables.i_tf_sc_mat - 1]
+                    / tfcoil_variables.j_crit_str_tf
+                )
 
             #  Copper ($/m)
 
@@ -1565,18 +1573,28 @@ class Costs:
 
         for i in range(0, npf):
             #  Superconductor ($/m)
-            if pfcoil_variables.ipfres == 0:
-                costpfsc = (
-                    cost_variables.ucsc[pfcoil_variables.isumatpf - 1]
-                    * (1.0e0 - pfcoil_variables.fcupfsu)
-                    * (1.0e0 - pfcoil_variables.vf[i])
-                    * abs(pfcoil_variables.ric[i] / pfcoil_variables.turns[i])
-                    * 1.0e6
-                    / pfcoil_variables.rjconpf[i]
-                    * tfcoil_variables.dcond[pfcoil_variables.isumatpf - 1]
-                )
+            if cost_variables.supercond_cost_model == 0:
+                if pfcoil_variables.ipfres == 0:
+                    costpfsc = (
+                        cost_variables.ucsc[pfcoil_variables.isumatpf - 1]
+                        * (1.0e0 - pfcoil_variables.fcupfsu)
+                        * (1.0e0 - pfcoil_variables.vf[i])
+                        * abs(pfcoil_variables.ric[i] / pfcoil_variables.turns[i])
+                        * 1.0e6
+                        / pfcoil_variables.rjconpf[i]
+                        * tfcoil_variables.dcond[pfcoil_variables.isumatpf - 1]
+                    )
+                else:
+                    costpfsc = 0.0e0
             else:
-                costpfsc = 0.0e0
+                if pfcoil_variables.ipfres == 0:
+                    costpfsc = (
+                        cost_variables.sc_mat_cost_0[pfcoil_variables.isumatpf - 1]
+                        * tfcoil_variables.j_crit_str_0[pfcoil_variables.isumatpf - 1]
+                        / pfcoil_variables.j_crit_str_pf
+                    )
+                else:
+                    costpfsc = 0.0
 
             #  Copper ($/m)
             if pfcoil_variables.ipfres == 0:
@@ -1621,18 +1639,28 @@ class Costs:
 
         if build_variables.iohcl == 1:
             #  Superconductor ($/m)
-            #  Issue #328  Use CS conductor cross-sectional area (m2)
-            if pfcoil_variables.ipfres == 0:
-                costpfsc = (
-                    cost_variables.ucsc[pfcoil_variables.isumatoh - 1]
-                    * pfcoil_variables.awpoh
-                    * (1 - pfcoil_variables.vfohc)
-                    * (1 - pfcoil_variables.fcuohsu)
-                    / pfcoil_variables.turns[pfcoil_variables.nohc - 1]
-                    * tfcoil_variables.dcond[pfcoil_variables.isumatoh - 1]
-                )
+            if cost_variables.supercond_cost_model == 0:
+                #  Issue #328  Use CS conductor cross-sectional area (m2)
+                if pfcoil_variables.ipfres == 0:
+                    costpfsc = (
+                        cost_variables.ucsc[pfcoil_variables.isumatoh - 1]
+                        * pfcoil_variables.awpoh
+                        * (1 - pfcoil_variables.vfohc)
+                        * (1 - pfcoil_variables.fcuohsu)
+                        / pfcoil_variables.turns[pfcoil_variables.nohc - 1]
+                        * tfcoil_variables.dcond[pfcoil_variables.isumatoh - 1]
+                    )
+                else:
+                    costpfsc = 0.0e0
             else:
-                costpfsc = 0.0e0
+                if pfcoil_variables.ipfres == 0:
+                    costpfsc = (
+                        cost_variables.sc_mat_cost_0[pfcoil_variables.isumatoh - 1]
+                        * tfcoil_variables.j_crit_str_0[pfcoil_variables.isumatoh - 1]
+                        / pfcoil_variables.j_crit_str_cs
+                    )
+                else:
+                    costpfsc = 0.0e0
 
             #  Copper ($/m)
 

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -638,6 +638,18 @@ class PFCoil:
                         tfv.tcritsc,
                     )
 
+                    # Strand critical current calculation for costing in $/kAm
+                    # = superconducting filaments jc * (1 - strand copper fraction)
+                    if (
+                        pfv.isumatoh == 2
+                        or pfv.isumatoh == 6
+                        or pfv.isumatoh == 8
+                        or pfv.isumatoh == 9
+                    ):
+                        pfv.j_crit_str_pf = jsc
+                    else:
+                        pfv.j_crit_str_pf = jsc * (1 - pfv.fcupfsu)
+
                 # Length of conductor
 
                 rll = 2.0e0 * constants.pi * pfv.rpf[i] * pfv.turns[i]
@@ -1193,6 +1205,12 @@ class PFCoil:
                 tfv.bcritsc,
                 tfv.tcritsc,
             )
+            # Strand critical current calculation for costing in $/kAm
+            # = superconducting filaments jc * (1 - strand copper fraction)
+            if pfv.isumatoh == 2 or pfv.isumatoh == 6 or pfv.isumatoh == 8:
+                pfv.j_crit_str_cs = pfv.jscoh_eof
+            else:
+                pfv.j_crit_str_cs = pfv.jscoh_eof * (1 - pfv.fcuohsu)
 
             pfv.rjohc = jcritwp * pfv.awpoh / pfv.areaoh
 

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -640,12 +640,7 @@ class PFCoil:
 
                     # Strand critical current calculation for costing in $/kAm
                     # = superconducting filaments jc * (1 - strand copper fraction)
-                    if (
-                        pfv.isumatoh == 2
-                        or pfv.isumatoh == 6
-                        or pfv.isumatoh == 8
-                        or pfv.isumatoh == 9
-                    ):
+                    if pfv.isumatoh == 2 or pfv.isumatoh == 6 or pfv.isumatoh == 8:
                         pfv.j_crit_str_pf = jsc
                     else:
                         pfv.j_crit_str_pf = jsc * (1 - pfv.fcupfsu)

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -640,7 +640,7 @@ class PFCoil:
 
                     # Strand critical current calculation for costing in $/kAm
                     # = superconducting filaments jc * (1 - strand copper fraction)
-                    if pfv.isumatoh == 2 or pfv.isumatoh == 6 or pfv.isumatoh == 8:
+                    if pfv.isumatoh in {2, 6, 8}:
                         pfv.j_crit_str_pf = jsc
                     else:
                         pfv.j_crit_str_pf = jsc * (1 - pfv.fcupfsu)
@@ -1202,7 +1202,7 @@ class PFCoil:
             )
             # Strand critical current calculation for costing in $/kAm
             # = superconducting filaments jc * (1 - strand copper fraction)
-            if pfv.isumatoh == 2 or pfv.isumatoh == 6 or pfv.isumatoh == 8:
+            if pfv.isumatoh in {2, 6, 8}:
                 pfv.j_crit_str_cs = pfv.jscoh_eof
             else:
                 pfv.j_crit_str_cs = pfv.jscoh_eof * (1 - pfv.fcuohsu)

--- a/process/sctfcoil.py
+++ b/process/sctfcoil.py
@@ -665,6 +665,10 @@ class Sctfcoil:
             #  Critical current in cable
             icrit = j_crit_cable * acs
 
+            # Strand critical current calculation for costing in $/kAm
+            # = Superconducting filaments jc * (1 - strand copper fraction)
+            tfcoil_variables.j_crit_str_tf = j_crit_sc * (1.0e0 - fcu)
+
         elif isumat == 2:  # Bi-2212 high temperature superconductor parameterization
             #  Current density in a strand of Bi-2212 conductor
             #  N.B. jcrit returned by superconductors.bi2212 is the critical current density
@@ -679,6 +683,10 @@ class Sctfcoil:
             #  Critical current in cable
             icrit = j_crit_cable * acs * fcond
 
+            # Strand critical current calulation for costing in $ / kAm
+            # Copper in the strand is already accounted for
+            tfcoil_variables.j_crit_str_tf = j_crit_sc
+
         elif isumat == 3:  # NbTi data
             bc20m = 15.0e0
             tc0m = 9.3e0
@@ -688,6 +696,10 @@ class Sctfcoil:
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable
             icrit = j_crit_cable * acs
+
+            # Strand critical current calulation for costing in $ / kAm
+            # = superconducting filaments jc * (1 -strand copper fraction)
+            tfcoil_variables.j_crit_str_tf = j_crit_sc * (1.0e0 - fcu)
 
         elif isumat == 4:  # ITER Nb3Sn parameterization, but user-defined parameters
             bc20m = bcritsc
@@ -703,6 +715,10 @@ class Sctfcoil:
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable
             icrit = j_crit_cable * acs
+
+            # Strand critical current calulation for costing in $ / kAm
+            # = superconducting filaments jc * (1 -strand copper fraction)
+            tfcoil_variables.j_crit_str_tf = j_crit_sc * (1.0e0 - fcu)
 
         elif isumat == 5:  # WST Nb3Sn parameterisation
             bc20m = 32.97e0
@@ -721,6 +737,10 @@ class Sctfcoil:
             #  Critical current in cable
             icrit = j_crit_cable * acs
 
+            # Strand critical current calulation for costing in $ / kAm
+            # = superconducting filaments jc * (1 -strand copper fraction)
+            tfcoil_variables.j_crit_str_tf = j_crit_sc * (1.0e0 - fcu)
+
         elif isumat == 6:  # "REBCO" 2nd generation HTS superconductor in CrCo strand
             raise ValueError(
                 "sctfcoil.supercon has been called but tfcoil_variables.i_tf_sc_mat=6"
@@ -736,6 +756,10 @@ class Sctfcoil:
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable
             icrit = j_crit_cable * acs
+
+            # Strand critical current calulation for costing in $ / kAm
+            # = superconducting filaments jc * (1 -strand copper fraction)
+            tfcoil_variables.j_crit_str_tf = j_crit_sc * (1.0e0 - fcu)
 
         elif isumat == 8:  # Durham Ginzburg-Landau critical surface model for REBCO
             bc20m = 430
@@ -754,6 +778,10 @@ class Sctfcoil:
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable (copper added at this stage in HTS cables)
             icrit = j_crit_cable * acs
+
+            # Strand critical current calulation for costing in $ / kAm
+            # Already includes buffer and support layers so no need to include fcu here
+            tfcoil_variables.j_crit_str_tf = j_crit_sc
 
         elif (
             isumat == 9
@@ -776,6 +804,10 @@ class Sctfcoil:
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable (copper added at this stage in HTS cables)
             icrit = j_crit_cable * acs
+
+            # Strand critical current calulation for costing in $ / kAm
+            # = superconducting filaments jc * (1 -strand copper fraction)
+            tfcoil_variables.j_crit_str_tf = j_crit_sc * (1.0e0 - fcu)
 
         else:
             error_handling.idiags[0] = isumat

--- a/source/fortran/cost_variables.f90
+++ b/source/fortran/cost_variables.f90
@@ -339,6 +339,12 @@ module cost_variables
   real(dp) :: startuppwr
   !! cost associated with additional HCD system power required on start-up ($)
 
+  integer :: supercond_cost_model
+  !! Switch for superconductor cost model:
+  !!
+  !! - =0 use $/kg
+  !! - =1 use $/kAm
+
   real(dp) :: tlife
   !! Full power year plant lifetime (years)
 
@@ -539,6 +545,9 @@ module cost_variables
 
   real(dp), dimension(9) :: ucsc
   !! cost of superconductor ($/kg)
+
+  real(dp), dimension(9) :: sc_mat_cost_0
+  !!cost of superconductor ($/kA m) at 6.4 T, 4.2 K
 
   real(dp), parameter :: ucsh = 115.0D0
   !! cost of shops and warehouses (M$/m3)
@@ -742,6 +751,9 @@ module cost_variables
     ucsc = &
       (/600.0D0, 600.0D0, 300.0D0, 600.0D0, 600.0D0, 600.0D0, 300.0D0, 1200.0D0, &
       1200.0D0/)
+    sc_mat_cost_0 = &
+      (/4.8D0, 2.0D0, 1.0D0, 4.8D0, 4.8D0, 47.4D0, 1.0D0, 47.4D0, 47.4D0/)
+    supercond_cost_model = 0
     ucshld = 32.0D0
     uctfbr = 1.22D0
     uctfbus = 100.0D0

--- a/source/fortran/input.f90
+++ b/source/fortran/input.f90
@@ -256,7 +256,7 @@ contains
       ucblli, ucpfcb, tlife, ipnet, fcdfuel, ucbus, ucpfb, uchts, &
       maintenance_fwbs, fwbs_prob_fail, uclh, ucblss, ucblvd, ucsc, ucturb, &
       ucpens, cland, ucwindpf, i_cp_lifetime, cplife_input, &
-      startupratio, tmain, u_unplanned_cp
+      startupratio, tmain, u_unplanned_cp, supercond_cost_model
     use current_drive_variables, only: pinjfixmw, etaech, pinjalw, etanbi, &
       ftritbm, gamma_ecrh, pheat, beamwd, enbeam, pheatfix, bscfmax, &
       forbitloss, nbshield, tbeamin, feffcd, iefrf, iefrffix, irfcd, cboot, &
@@ -1854,6 +1854,9 @@ contains
        case ('isumatpf')
           call parse_int_variable('isumatpf', isumatpf, 1, 9, &
                'PF coil superconductor material')
+       case ('supercond_cost_model')
+          call parse_int_variable('supercond_cost_model', supercond_cost_model, 0, 1, &
+               'Superconductor cost model')
        case ('i_pf_current')
           call parse_int_variable('i_pf_current', i_pf_current, 0, 2, &
                'Switch for controlling the current of the PF coils')

--- a/source/fortran/pfcoil_variables.f90
+++ b/source/fortran/pfcoil_variables.f90
@@ -161,6 +161,14 @@ module pfcoil_variables
   !! - =8 Durham Ginzburg-Landau critical surface model for REBCO
   !! - =9 Hazelton experimental data + Zhai conceptual model for REBCO
 
+  real(dp) :: j_crit_str_cs
+  !! superconductor strand critical current density under operating
+  !! conditions in central solenoid (A/m2). Necessary for the cost calculation in $/kA m
+
+  real(dp) :: j_crit_str_pf
+  !! superconductor strand critical current density under operating
+  !! conditions in PF coils (A/m2). Necessary for the cost calculation in $/kA m
+
   integer :: i_pf_current
   !! Switch for controlling the current of the PF coils:
   !!
@@ -440,6 +448,8 @@ module pfcoil_variables
     itr_sum = 0.0D0
     isumatoh = 1
     isumatpf = 1
+    j_crit_str_cs = 0.0D0
+    j_crit_str_pf = 0.0D0
     i_pf_current = 1
     i_sup_pf_shape = 0
     jscoh_bop = 0.0D0

--- a/source/fortran/tfcoil_variables.f90
+++ b/source/fortran/tfcoil_variables.f90
@@ -308,6 +308,14 @@ module tfcoil_variables
   real(dp) :: jbus
   !! bussing current density (A/m2)
 
+  real(dp) :: j_crit_str_tf
+  !! j_crit_str : superconductor strand critical current density under operating
+  !! conditions (A/m2). Necessary for the cost calculation in $/kAm
+
+  real(dp), dimension(9) :: j_crit_str_0
+  !! j_crit_str_pf_0 : superconductor strand critical current density at 6 T and 4.2 K (A/m2)
+  !! Necessary for the cost calculation in $/kAm
+
   real(dp) :: jwdgcrt
   !! critical current density for winding pack (A/m2)
 
@@ -896,6 +904,13 @@ module tfcoil_variables
     n_tf_stress_layers = 0
     n_tf_wp_layers = 5
     jbus = 1.25D6
+    j_crit_str_tf = 0.0D0
+    j_crit_str_0 = &
+      (/596905475.80390120D0,1925501534.8512938D0,&
+      724544682.96063495D0,549858624.45072436D0, &
+      669284509.85818779D0,0.0D0,&
+      898964415.36996782D0,1158752995.2559297D0, &
+      865652122.9071957D0/)
     jwdgcrt = 0.0D0
     jwdgpro = 0.0D0
     jwptf = 0.0D0

--- a/tests/unit/test_costs_1990.py
+++ b/tests/unit/test_costs_1990.py
@@ -1765,6 +1765,10 @@ class Acc2221Param(NamedTuple):
 
     i_tf_sup: Any = None
 
+    supercond_cost_model: Any = None
+
+    j_crit_str_tf: Any = None
+
     n_tf_turn: Any = None
 
     tfleng: Any = None
@@ -1819,6 +1823,8 @@ class Acc2221Param(NamedTuple):
             whttflgs=0,
             whtcp=0,
             i_tf_sup=1,
+            supercond_cost_model=0,
+            j_crit_str_tf=300.0,
             n_tf_turn=200,
             tfleng=50.483843027201402,
             i_tf_sc_mat=5,
@@ -1858,6 +1864,8 @@ class Acc2221Param(NamedTuple):
             whttflgs=0,
             whtcp=0,
             i_tf_sup=1,
+            supercond_cost_model=0,
+            j_crit_str_tf=300.0,
             n_tf_turn=200,
             tfleng=50.514015976170839,
             i_tf_sc_mat=5,
@@ -1869,6 +1877,47 @@ class Acc2221Param(NamedTuple):
             c22214=172.4182702723208,
             c22215=57.77719854752457,
             expected_c22211=127.87250498362496,
+            expected_c22212=65.563151615791654,
+        ),
+        Acc2221Param(
+            uccpclb=150,
+            uccase=50,
+            uccu=75,
+            fkind=1,
+            cconshtf=75,
+            ucsc=numpy.array(
+                numpy.array((600, 600, 300, 600, 600, 600, 300, 1200, 1200), order="F"),
+                order="F",
+            ).transpose(),
+            ifueltyp=1,
+            uccpcl1=250,
+            ucwindtf=480,
+            cpstcst=0,
+            lsa=2,
+            cconfix=80,
+            itart=0,
+            clgsmass=1951781.4798732549,
+            aintmass=5829865.436088616,
+            whtconcu=58779.575542593491,
+            whtconsc=5806.038092640837,
+            whtcas=1034699.2182961091,
+            n_tf=16,
+            whttflgs=0,
+            whtcp=0,
+            i_tf_sup=1,
+            supercond_cost_model=1,
+            j_crit_str_tf=300.0,
+            n_tf_turn=200,
+            tfleng=50.514015976170839,
+            i_tf_sc_mat=5,
+            c22=3474.7391916096453,
+            c2221=1122.5144544988982,
+            c22211=127.79612438919186,
+            c22212=65.523989541865234,
+            c22213=698.99887174799562,
+            c22214=172.4182702723208,
+            c22215=57.77719854752457,
+            expected_c22211=1462760.833721748,
             expected_c22212=65.563151615791654,
         ),
     ),
@@ -1930,6 +1979,12 @@ def test_acc2221(acc2221param, monkeypatch, costs):
 
     monkeypatch.setattr(tfcoil_variables, "i_tf_sup", acc2221param.i_tf_sup)
 
+    monkeypatch.setattr(
+        cost_variables, "supercond_cost_model", acc2221param.supercond_cost_model
+    )
+
+    monkeypatch.setattr(tfcoil_variables, "j_crit_str_tf", acc2221param.j_crit_str_tf)
+
     monkeypatch.setattr(tfcoil_variables, "n_tf_turn", acc2221param.n_tf_turn)
 
     monkeypatch.setattr(tfcoil_variables, "tfleng", acc2221param.tfleng)
@@ -1979,6 +2034,12 @@ class Acc2222Param(NamedTuple):
     fkind: Any = None
 
     rjconpf: Any = None
+
+    supercond_cost_model: Any = None
+
+    j_crit_str_cs: Any = None
+
+    j_crit_str_pf: Any = None
 
     ipfres: Any = None
 
@@ -2080,6 +2141,9 @@ class Acc2222Param(NamedTuple):
                 ),
                 order="F",
             ).transpose(),
+            supercond_cost_model=0,
+            j_crit_str_cs=100.0,
+            j_crit_str_pf=200.0,
             ipfres=0,
             vfohc=0.29999999999999999,
             nohc=7,
@@ -2273,6 +2337,9 @@ class Acc2222Param(NamedTuple):
                 ),
                 order="F",
             ).transpose(),
+            supercond_cost_model=0,
+            j_crit_str_cs=100.0,
+            j_crit_str_pf=200.0,
             ipfres=0,
             vfohc=0.29999999999999999,
             nohc=7,
@@ -2422,6 +2489,202 @@ class Acc2222Param(NamedTuple):
             expected_c22223=106.06545230249935,
             expected_c22224=9.1894413521392071,
         ),
+        Acc2222Param(
+            iohcl=1,
+            uccase=50,
+            uccu=75,
+            cconshpf=70,
+            ucfnc=35,
+            cconfix=80,
+            ucsc=numpy.array(
+                numpy.array((600, 600, 300, 600, 600, 600, 300, 1200, 1200), order="F"),
+                order="F",
+            ).transpose(),
+            ucwindpf=465,
+            lsa=2,
+            fkind=1,
+            rjconpf=numpy.array(
+                numpy.array(
+                    (
+                        11000000,
+                        11000000,
+                        6000000,
+                        6000000,
+                        8000000,
+                        8000000,
+                        8000000,
+                        8000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                        30000000,
+                    ),
+                    order="F",
+                ),
+                order="F",
+            ).transpose(),
+            supercond_cost_model=1,
+            j_crit_str_cs=100.0,
+            j_crit_str_pf=200.0,
+            ipfres=0,
+            vfohc=0.29999999999999999,
+            nohc=7,
+            turns=numpy.array(
+                numpy.array(
+                    (
+                        440.26292595093469,
+                        525.4843415877815,
+                        192.44107218389988,
+                        192.44107218389988,
+                        129.65302435274731,
+                        129.65302435274731,
+                        4348.5468837135222,
+                        1,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                    ),
+                    order="F",
+                ),
+                order="F",
+            ).transpose(),
+            isumatpf=3,
+            whtpfs=2510424.9065680322,
+            ric=numpy.array(
+                numpy.array(
+                    (
+                        18.579095475129446,
+                        22.175439215004378,
+                        -8.1210132461605742,
+                        -8.1210132461605742,
+                        -5.575080047168135,
+                        -5.575080047168135,
+                        -186.98751599968145,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                    ),
+                    order="F",
+                ),
+                order="F",
+            ).transpose(),
+            rpf=numpy.array(
+                numpy.array(
+                    (
+                        6.2732560483870969,
+                        6.2732560483870969,
+                        18.401280308184159,
+                        18.401280308184159,
+                        16.803394770584916,
+                        16.803394770584916,
+                        2.6084100000000001,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                    ),
+                    order="F",
+                ),
+                order="F",
+            ).transpose(),
+            isumatoh=5,
+            fcupfsu=0.68999999999999995,
+            fcuohsu=0.70000000000000007,
+            vf=numpy.array(
+                numpy.array(
+                    (
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                        0.29999999999999999,
+                    ),
+                    order="F",
+                ),
+                order="F",
+            ).transpose(),
+            awpoh=3.8004675824985918,
+            fncmass=310716.52923547616,
+            dcond=numpy.array(
+                numpy.array(
+                    (6080, 6080, 6070, 6080, 6080, 8500, 6070, 8500, 8500),
+                    order="F",
+                ),
+                order="F",
+            ).transpose(),
+            c22=3474.7391916096453,
+            c2222=626.57984594974835,
+            c22221=434.46640986938519,
+            c22222=69.02908267696219,
+            c22223=113.89491205126185,
+            c22224=9.1894413521392071,
+            expected_c2222=2271626.1414324627,
+            expected_c22221=2271439.6839775303,
+            expected_c22222=71.202561277966055,
+            expected_c22223=106.06545230249935,
+            expected_c22224=9.1894413521392071,
+        ),
     ),
 )
 def test_acc2222(acc2222param, monkeypatch, costs):
@@ -2458,6 +2721,14 @@ def test_acc2222(acc2222param, monkeypatch, costs):
     monkeypatch.setattr(cost_variables, "fkind", acc2222param.fkind)
 
     monkeypatch.setattr(pfcoil_variables, "rjconpf", acc2222param.rjconpf)
+
+    monkeypatch.setattr(
+        cost_variables, "supercond_cost_model", acc2222param.supercond_cost_model
+    )
+
+    monkeypatch.setattr(pfcoil_variables, "j_crit_str_cs", acc2222param.j_crit_str_cs)
+
+    monkeypatch.setattr(pfcoil_variables, "j_crit_str_pf", acc2222param.j_crit_str_pf)
 
     monkeypatch.setattr(pfcoil_variables, "ipfres", acc2222param.ipfres)
 


### PR DESCRIPTION
## Description

Added new unit cost calculation for superconductors based on $/kAm instead of $/kg.

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
