### PR TITLE
Test input not writing variables correctly

### DIFF
--- a/tests/unit/test_input.py
+++ b/tests/unit/test_input.py
@@ -1,5 +1,6 @@
 import pytest
 from process import fortran
+from process.utilities.f2py_string_patch import string_to_f2py_compatible
 
 
 def _create_input_file(directory, content: str):
@@ -52,8 +53,9 @@ def test_parse_real(epsvmc, expected, tmp_path):
 
     Program to get the expected value for 0.008 provided at https://github.com/ukaea/PROCESS/pull/3067
     """
-    fortran.global_variables.fileprefix = _create_input_file(
-        tmp_path, f"epsvmc = {epsvmc}"
+    fortran.global_variables.fileprefix = string_to_f2py_compatible(
+        fortran.global_variables.fileprefix,
+        _create_input_file(tmp_path, f"epsvmc = {epsvmc}"),
     )
     fortran.init_module.init()
 


### PR DESCRIPTION
I was having some local failures in `test_input.py` (didn't occur on the CI!?). `test_parse_real` is writing to the `global_variables.fileprefix` without using the `string_to_f2py_compatible` which was causing the failure. 