### PR TITLE
Added warning for magnet current ratios above 0.7

### DIFF
--- a/documentation/proc-pages/eng-models/central-solenoid.md
+++ b/documentation/proc-pages/eng-models/central-solenoid.md
@@ -175,5 +175,5 @@ no. 106 (`ftmargoh`).
 It is recommended that EITHER the temperature margin constraint (60), OR the current density 
 constraints (26 and 27) are activated.
 
-!!! note
+!!! tip "Recommended maximum current ratio"
     For engineering feasibility, the centrepost currents at end of flat-top and beginning of pulse (`fjohc` and `fjohc0` respectively) shouldn't be set above 0.7.

--- a/documentation/proc-pages/eng-models/central-solenoid.md
+++ b/documentation/proc-pages/eng-models/central-solenoid.md
@@ -174,3 +174,6 @@ no. 106 (`ftmargoh`).
 
 It is recommended that EITHER the temperature margin constraint (60), OR the current density 
 constraints (26 and 27) are activated.
+
+!!! note
+    For engineering feasibility, the centrepost currents at end of flat-top and beginning of pulse (`fjohc` and `fjohc0` respectively) shouldn't be set above 0.7.

--- a/documentation/proc-pages/eng-models/tf-coil.md
+++ b/documentation/proc-pages/eng-models/tf-coil.md
@@ -28,6 +28,9 @@ $$
 
 This approximation is sufficiently accurate at the plasma centre.
 
+!!! note
+    For engineering feasibility, the TF coil operating current / critical current ratio shouldn't be set above 0.7, i.e. `fiooic` shouldn't be above 0.7.
+
 ## TF coil inboard mid-plane geometry
 This section describes TF coil inboard leg geometry of the cross-section defined by z=0 (mid-plane).  Resistive and superconducting coils are described separately.
 

--- a/documentation/proc-pages/eng-models/tf-coil.md
+++ b/documentation/proc-pages/eng-models/tf-coil.md
@@ -28,7 +28,7 @@ $$
 
 This approximation is sufficiently accurate at the plasma centre.
 
-!!! note
+!!! tip "Recommended maximum critical current ratio"
     For engineering feasibility, the TF coil operating current / critical current ratio shouldn't be set above 0.7, i.e. `fiooic` shouldn't be above 0.7.
 
 ## TF coil inboard mid-plane geometry

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -2213,6 +2213,12 @@ class PFCoil:
                 if not pf.cslimit:
                     eh.report_error(135)
 
+                # Check whether CS coil currents are feasible from engineering POV
+                if ctv.fjohc > 0.7:
+                    eh.report_error(286)
+                if ctv.fjohc0 > 0.7:
+                    eh.report_error(287)
+
                 # REBCO fractures in strains above ~+/- 0.7%
                 if (
                     (pfv.isumatoh == 6 or pfv.isumatoh == 8 or pfv.isumatoh == 9)

--- a/process/utilities/errorlist.json
+++ b/process/utilities/errorlist.json
@@ -8,7 +8,7 @@
   "comment2": [
     "Increment n_errortypes if an error is added to this list"
   ],
-  "n_errortypes": 284,
+  "n_errortypes": 287,
   "errors": [
     {
       "no": 1,
@@ -1429,6 +1429,21 @@
       "no": 284,
       "level": 3,
       "message": "CHECK: idia = 0 should be used with the Sakai plasma current scaling."
+    },
+    {
+      "no": 285,
+      "level": 2,
+      "message": "[tfcoil]: fiooic shouldn't be above 0.7 for engineering reliability."
+    },
+    {
+      "no": 286,
+      "level": 2,
+      "message": "[pfcoil][cntrpost]: fjohc shouldn't be above 0.7 for engineering reliability."
+    },
+    {
+      "no": 287,
+      "level": 2,
+      "message": "[pfcoil][cntrpost]: fjohc0 shouldn't be above 0.7 for engineering reliability."
     }
   ]
 }

--- a/source/fortran/constraint_equations.f90
+++ b/source/fortran/constraint_equations.f90
@@ -1597,6 +1597,7 @@ contains
       character(len=1), intent(out) :: tmp_symbol
       character(len=10), intent(out) :: tmp_units
 
+      if (fiooic > 0.7D0) call report_error(285)
       tmp_cc =  1.0D0 - fiooic * jwdgcrt/jwptf
       tmp_con = jwdgcrt * (1.0D0 - tmp_cc)
       tmp_err = jwptf * tmp_cc


### PR DESCRIPTION
## Description

Adds a warning if the TF or centrepost magnet current ratios are over 70%. This is to warn the user of engineering infeasibility.

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
