### PR TITLE
Require setuptools<74 for the build system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # requirements.txt includes the dependencies necessary for running the PROCESS build system
 # (cmake --build build).
 
+# setuptools <74 required by f2py (at least for some versions of numpy)
+setuptools<74
+
 # numpy is required for some of the install scripts
 numpy>=1.23,<2
 


### PR DESCRIPTION
Requires `setuptools<74` in `requirements.txt` which is installed before the f2py build stage. At this point, I don't see it as a valuable use of time changing the `f2py` backend in use because our use of `f2py` will significantly reduce in the coming months as we convert sections of PROCESS.