### PR TITLE
Implement wcll option using inputted pressure drop within dcll model

### DIFF
--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -143,7 +143,7 @@ where $\texttt{tkfw}$ is the thermal conductivity of the first wall material and
 The temperature difference between the channel inner wall (film temperature) and the bulk coolant is calculated using the heat transfer coefficient, which is derived using the [Gnielinski correlation](https://en.wikipedia.org/wiki/Nusselt_number#Gnielinski_correlation).  The pressure drop is based on the Darcy fraction factor, using the [Haaland equation](https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Haaland_equation), an approximation to the implicit Colebrook–White equation.  The thermal conductivity of Eurofer is used, from "Fusion Demo Interim Structural Design Criteria - Appendix A Material Design Limit Data", F. Tavassoli, TW4-TTMS-005-D01, 2004"
 
 !!! Note "Note" 
-    The pressure drop calculation is only performed for primary_pumping = 2, as for 3 it is used as an input.
+    The pressure drop calculation is only performed for primary_pumping = 2, as for 3 it is used as an input, as explained in the heat transport section.
 
 ### Model Switches
 

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -44,11 +44,6 @@ electricity have been revised extensively.
     using parametric fits to an MCNP neutron and photon transport model of a 
     sector of a tokamak. The blanket contains lithium orthosilicate 
     Li$_4$SiO$_4$, titanium beryllide TiBe$_{12}$, helium and Eurofer steel. 
-- `== 2` -- KIT HCPB model. It allows the energy multiplication factor `emult`, 
-    the shielding requirements and tritium breeding ratio to be calculated 
-    self-consistently with the blanket and shielding materials and sub-assembly 
-    thicknesses, and for constraints to be applied to satisfy the engineering 
-    requirements. For further details of this model.
 - `== 3` -- CCFE HCPB model with tritium breeding ratio. It has the features of 
     the CCFE HCPB model above, with a set of fitting functions for calculating 
     tritium breeding ratio (TBR).  It requires a choice of `iblanket_thickness`, 
@@ -69,103 +64,6 @@ electricity have been revised extensively.
 first wall and blanket is determined, and also how the calculation of the plant's 
 thermal to electric conversion efficiency (the secondary cycle thermal 
 efficiency) proceeds.
-
-### KIT Blanket Neutronics Model
-
-The model used if `blktmodel = 1` is based on the Helium-Cooled Pebble
-Bed (HCPB) blanket concept developed by KIT (a second advanced model --
-Helium-Cooled Lithium Lead, HCLL -- will be implemented in due course). The
-blanket, shield and vacuum vessel are segmented radially into a number of
-sub-assemblies. Moving in the direction away from the plasma/first wall, these
-are:
-
-Breeding Zone (BZ) (which includes the first wall), with radial
-thicknesses (inboard and outboard, respectively) `fwith + blbuith`,
-`fwoth+blbuoth`. This consists of beryllium (with fraction by volume `fblbe`), 
-breeder material (`fblbreed`), steel (`fblss`) and helium coolant. Three 
-forms of breeder material are available: 
-  
-| `breedmat` | Description                           |
-| :--------: | ------------------------------------- |
-|     1      | lithium orthosilicate (Li$_4$SiO$_4$) |
-|     2      | lithium metatitanate (Li$_2$TiO$_3$)  |
-|     3      | lithium zirconate (Li$_2$ZrO$_3$)     |
-
-The $^6$Li enrichment percentage may be modified from the default 30% using 
-input parameter `li6enrich`.
-
-- Box Manifold (BM), with radial thicknesses (inboard and outboard,
-  respectively) `blbmith`, `blbmoth` and helium fractions `fblhebmi`, `fblhebmo` 
-  (the rest being steel).
-- Back Plate (BP), with radial thicknesses (inboard and outboard,
-  respectively) `blbpith`, `blbpoth` and helium fractions `fblhebpi`, `fblhebpo` 
-  (the rest being steel).
-
-Together, the BZ, BM and BP make up the `blanket`, with total radial
-thicknesses `blnkith` (inboard) and `blnkoth` (outboard), and void (coolant) 
-fraction `vfblkt`; Note that these quantities are `calculated` from the 
-sub-assembly values if `blktmodel > 0`, rather than being input parameters.
-
-Low Temperature Shield and Vacuum Vessel (lumped together for these 
-calculations), with radial thicknesses (inboard and outboard, respectively) 
-`shldith + d_vv_in`, `shldoth + d_vv_out` and **water** coolant fraction 
-`vfshld` (the rest being assumed to be steel for its mass calculation; the 
-neutronics model assumes that the shield contains 2% boron  as a neutron absorber, 
-but this material is not explicitly mentioned elsewhere in the code -- so 
-its cost is not calculated, for example).
-
-!!! Note "Note" 
-    The fact that water is assumed to be the coolant in the shield, whereas 
-    helium is the coolant in the blanket, leads to an inconsistency when 
-    specifying the coolant type via switch `coolwh`. At present we mitigate this 
-    by forcing `coolwh=2` (making water the coolant), as in this case the
-    coolant mass and pumping costs are higher, giving the more pessimistic
-    solution with regards to costs.
-
-A few other input parameters are useful for tuning purposes, as follows:
-
-|     Parameter      | Description                                                                                                                                                                                                                    |
-| :----------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|  `fvolsi/fvolso`   | area (and volume) coverage factors for the inboard and outboard shields, respectively.                                                                                                                                         |
-|      `fvoldw`      | multiplier for volume of vacuum vessel, used in mass calculations to account for ports, etc.                                                                                                                                   |
-|      `npdiv`       | number of divertor ports, used in the calculation of the tritium breeding ratio.                                                                                                                                               |
-| `nphcdin/nphcdout` | number of heating/current drive ports on the inboard and outboard sides, respectively, used in the calculation of the tritium breeding ratio. These may be either 'small'  (`hcdportsize = 1`) or 'large' (`hcdportsize = 2`). |
-|      `wallpf`      | neutron wall load peaking factor (maximum/mean), used in the calculation of the blanket lifetime.                                                                                                                              |
-|    `ucblbreed`     | unit cost (\$/kg) of the breeder material                                                                                                                                                                                      |
-
-#### KIT model outputs and available constraints
-
-The KIT blanket model has the following available constraints
-
-| Constraint No. |  F-value  | F-value No. |    Limit    | Description                        |
-| :------------: | :-------: | :---------: | :---------: | ---------------------------------- |
-|       52       |  `ftbr`   |     89      |  `tbrmin`   | Min required `tbr`                 |
-|       53       | `fflutf`  |     92      | `nflutfmax` | Max allowed TF fluence             |
-|       54       | `fptfnuc` |     95      | `ptfnucmax` | Max allowed heating of TF coils    |
-|       55       |  `fvvhe`  |     96      |  `vvhealw`  | Max allowed He concentration in VV |
-
-The KIT blanket neutronics model provides the following outputs:
-
-|   Output    |  Units   | Itvar. | Description                                                              |
-| :---------: | :------: | ------ | ------------------------------------------------------------------------ |
-| `pnucblkt`  |    MW    | -      | Total nuclear power deposited in blanket                                 |
-| `pnucshld`  |    MW    | -      | Total nuclear power deposited in shield                                  |
-|   `emult`   |    -     | -      | The energy multiplication factor in the blanket                          |
-|    `tbr`    |    -     | -      | Tritium breeding ratio                                                   |
-|  `blbuith`  |    m     | 90     | Inboard blanket thickness                                                |
-|  `blbuoth`  |    m     | 91     | Outboard blanket thickness                                               |
-| `tritprate` |    -     | -      | The tritium production rate in grammes/day is calculated.                |
-|  `nflutfi`  | n/m$^2$  | -      | The fast neutron fluence on the inboard TF coils                         |
-|  `nflutfo`  | n/m$^2$  | -      | The fast neutron fluence on the inboard TF coils                         |
-|  `shldith`  |    m     | 93     | Inboard shield thickness                                                 |
-|  `shldoth`  |    m     | 94     | Outboard shield thickness                                                |
-|  `pnuctfi`  | MW/m$^3$ | -      | Nuclear heating power on inboard TF coil                                 |
-|  `pnuctfo`  | MW/m$^3$ | -      | Nuclear heating power on outboard TF coil                                |
-| `vvhemini`  |   appm   | -      | Min He concentration in the inboard VV at the end of the plant lifetime  |
-| `vvhemaxi`  |   appm   | -      | Max He concentration in the inboard VV at the end of the plant lifetime  |
-| `vvhemino`  |   appm   | -      | Min He concentration in the outboard VV at the end of the plant lifetime |
-| `vvhemaxo`  |   appm   | -      | Max He concentration in the outboard VV at the end of the plant lifetime |
-|  `bktlife`  |  fp-yrs  | -      | Blanket lifetime in full power years assuming max damage ~60 dpa         |
 
 ## Thermo-hydraulic model for first wall and blanket
 

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -68,7 +68,7 @@ efficiency) proceeds.
 ## Thermo-hydraulic model for first wall and blanket
 
 !!! Note "Note" 
-    This is only called for primary_pumping = 2
+    This is called for primary_pumping = 2 and 3
 
 Summary of key variables and switches:  
 
@@ -142,6 +142,8 @@ where $\texttt{tkfw}$ is the thermal conductivity of the first wall material and
 
 The temperature difference between the channel inner wall (film temperature) and the bulk coolant is calculated using the heat transfer coefficient, which is derived using the [Gnielinski correlation](https://en.wikipedia.org/wiki/Nusselt_number#Gnielinski_correlation).  The pressure drop is based on the Darcy fraction factor, using the [Haaland equation](https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Haaland_equation), an approximation to the implicit Colebrook–White equation.  The thermal conductivity of Eurofer is used, from "Fusion Demo Interim Structural Design Criteria - Appendix A Material Design Limit Data", F. Tavassoli, TW4-TTMS-005-D01, 2004"
 
+!!! Note "Note" 
+    The pressure drop calculation is only performed for primary_pumping = 2, as for 3 it is used as an input.
 
 ### Model Switches
 

--- a/documentation/proc-pages/eng-models/power-conversion-and-heat-dissipation-systems.md
+++ b/documentation/proc-pages/eng-models/power-conversion-and-heat-dissipation-systems.md
@@ -62,7 +62,18 @@ for the primary coolant.
       mechanical power used) is specified by the parameter `etaiso`. Note that the mechanical pumping 
       power for the shield and divertor are still calculated using the simplified method (a fixed 
       fraction of the heat transported).
-  - If `primary_pumping` = 3, the mechanical pumping power is calculated using specified pressure drop.  The pressures and temperatures are set by the user.  
+  - If `primary_pumping` = 3, the mechanical pumping power is calculated using specified pressure drop. 
+    The pressures and temperatures are set by the user.
+      - When used with the DCLL model a different set of pressure drop variables are used, which are outlined below:
+
+    |   Variable    | Units | Itvar. | Default | Description                                                                      |
+    | :----------:  | :---: | ------ | ------- | -------------------------------------------------------------------------------- |
+    | `dp_fw_blnkt` |  Pa   |        | 1.5D5   | Pressure drop in FW and blanket coolant including heat exchanger and pipes       |
+    | `dp_fw`       |  Pa   |        | 1.5D5   | Pressure drop in FW coolant including heat exchanger and pipes                   |
+    | `dp_blkt`     |  Pa   |        | 3.5D3   | Pressure drop in blanket coolant including heat exchanger and pipes              |
+    | `dp_liq`      |  Pa   |        | 1.0D7   | Pressure drop in liquid metal blanket coolant including heat exchanger and pipes |
+
+     - The defaults for these variables are geared towards a WCLL concept, so different values should be used with Helium cooling.
 
 `secondary_cycle` : This switch controls the calculation of the thermal to electric conversion 
 efficiency in the secondary cycle.

--- a/documentation/proc-pages/eng-models/power-conversion-and-heat-dissipation-systems.md
+++ b/documentation/proc-pages/eng-models/power-conversion-and-heat-dissipation-systems.md
@@ -66,12 +66,12 @@ for the primary coolant.
     The pressures and temperatures are set by the user.
       - When used with the DCLL model a different set of pressure drop variables are used, which are outlined below:
 
-    |   Variable    | Units | Itvar. | Default | Description                                                                      |
-    | :----------:  | :---: | ------ | ------- | -------------------------------------------------------------------------------- |
-    | `dp_fw_blnkt` |  Pa   |        | 1.5D5   | Pressure drop in FW and blanket coolant including heat exchanger and pipes       |
-    | `dp_fw`       |  Pa   |        | 1.5D5   | Pressure drop in FW coolant including heat exchanger and pipes                   |
-    | `dp_blkt`     |  Pa   |        | 3.5D3   | Pressure drop in blanket coolant including heat exchanger and pipes              |
-    | `dp_liq`      |  Pa   |        | 1.0D7   | Pressure drop in liquid metal blanket coolant including heat exchanger and pipes |
+    |   Variable    | Units | Default | Description                                                                      |
+    | :----------:  | :---: | ------- | -------------------------------------------------------------------------------- |
+    | `dp_fw_blnkt` |  Pa   | 1.5D5   | Pressure drop in FW and blanket coolant including heat exchanger and pipes       |
+    | `dp_fw`       |  Pa   | 1.5D5   | Pressure drop in FW coolant including heat exchanger and pipes                   |
+    | `dp_blkt`     |  Pa   | 3.5D3   | Pressure drop in blanket coolant including heat exchanger and pipes              |
+    | `dp_liq`      |  Pa   | 1.0D7   | Pressure drop in liquid metal blanket coolant including heat exchanger and pipes |
 
      - The defaults for these variables are geared towards a WCLL concept, so different values should be used with Helium cooling.
 

--- a/process/dcll.py
+++ b/process/dcll.py
@@ -297,7 +297,6 @@ class DCLL:
             )
 
         elif fwbs_variables.primary_pumping in [2, 3]:
-            # elif fwbs_variables.primary_pumping == 2:
             # Mechanical pumping power is calculated for first wall and blanket
             self.blanket_library.thermo_hydraulic_model(output=output)
             # For divertor,mechanical pumping power is a fraction of thermal power removed by coolant

--- a/process/dcll.py
+++ b/process/dcll.py
@@ -296,10 +296,10 @@ class DCLL:
                 + fwbs_variables.praddiv
             )
 
-        elif fwbs_variables.primary_pumping == 2:
+        elif fwbs_variables.primary_pumping in [2, 3]:
+            # elif fwbs_variables.primary_pumping == 2:
             # Mechanical pumping power is calculated for first wall and blanket
             self.blanket_library.thermo_hydraulic_model(output=output)
-
             # For divertor,mechanical pumping power is a fraction of thermal power removed by coolant
             heat_transport_variables.htpmw_div = heat_transport_variables.fpumpdiv * (
                 physics_variables.pdivt

--- a/source/fortran/input.f90
+++ b/source/fortran/input.f90
@@ -279,7 +279,8 @@ contains
       denstl, declfw, nphcdout, iblnkith, vfpblkt, fwinlet, wallpf, fblbe, &
       fhole, fwbsshape, coolp, tfwmatmax, irefprop, fw_channel_length, &
       li6enrich, etaiso, nblktmodto, fvoldw, i_shield_mat, i_bb_liq, &
-      icooldual, ifci, inlet_temp_liq, outlet_temp_liq, bz_channel_conduct_liq, ipump, ims
+      icooldual, ifci, inlet_temp_liq, outlet_temp_liq, bz_channel_conduct_liq, ipump, ims, &
+      coolwh, emult
     use heat_transport_variables, only: htpmw_fw, baseel, fmgdmw, htpmw_div, &
       pwpm2, etath, vachtmw, iprimshld, fpumpdiv, pinjmax, htpmw_blkt, etatf, &
       htpmw_min, fpumpblkt, ipowerflow, htpmw_shld, fpumpshld, trithtmw, &
@@ -316,7 +317,8 @@ contains
     use pf_power_variables, only: iscenr, maxpoloidalpower
     use pulse_variables, only: lpulse, dtstor, itcycl, istore, bctmp
 
-    use primary_pumping_variables, only: t_in_bb, t_out_bb, dp_he, p_he, gamma_he
+    use primary_pumping_variables, only: t_in_bb, t_out_bb, dp_he, p_he, gamma_he, &
+      dp_fw_blkt, dp_fw, dp_blkt, dp_liq
 
     use scan_module, only: isweep_2, nsweep, isweep, scan_dim, nsweep_2, &
       sweep_2, sweep, ipnscns, ipnscnv
@@ -2037,6 +2039,9 @@ contains
       case ('ims')
          call parse_int_variable('ims', ims, 0, 1, &
                ' Switch for Multi or Single Modle Segment (MMS or SMS)')
+      case ('coolwh')
+         call parse_int_variable('coolwh', coolwh, 1, 2, &
+               ' Blanket coolant type (1=He, 2=H20)')
 
       case ('secondary_cycle')
           call parse_int_variable('secondary_cycle', secondary_cycle, 0, 4, &
@@ -2321,6 +2326,18 @@ contains
        case ('dp_he')
           call parse_real_variable('dp_he', dp_he, 0.0D0, 10.0D6, &
               'Helium Pressure drop or Gas Pressure drop (Pa)')
+       case ('dp_fw_blkt')
+          call parse_real_variable('dp_fw_blkt', dp_fw_blkt, 0.0D0, 10.0D6, &
+              'Pressure drop across FW and blanket (Pa)')
+       case ('dp_fw')
+          call parse_real_variable('dp_fw', dp_fw, 0.0D0, 10.0D6, &
+              'Pressure drop across FW (Pa)')
+       case ('dp_blkt')
+          call parse_real_variable('dp_blkt', dp_blkt, 0.0D0, 10.0D6, &
+              'Pressure drop across blanket (Pa)')
+       case ('dp_liq')
+          call parse_real_variable('dp_liq', dp_liq, 0.0D0, 10.0D6, &
+              'Pressure drop across liquid metal blanket (Pa)')
        case ('p_he')
           call parse_real_variable('p_he', p_he, 0.0D0, 100.0D6, &
               'Pressure in FW and blanket coolant at pump exit')

--- a/source/fortran/primary_pumping_variables.f90
+++ b/source/fortran/primary_pumping_variables.f90
@@ -34,6 +34,18 @@ module primary_pumping_variables
   real(dp) :: dp_he
   !! pressure drop in FW and blanket coolant including heat exchanger and pipes (`primary_pumping=3`) [Pa]
 
+  real(dp) :: dp_fw_blkt
+  !! pressure drop in FW and blanket coolant including heat exchanger and pipes (`primary_pumping=3`) [Pa]
+
+  real(dp) :: dp_fw
+  !! pressure drop in FW coolant including heat exchanger and pipes (`primary_pumping=3`) [Pa]
+
+  real(dp) :: dp_blkt
+  !! pressure drop in blanket coolant including heat exchanger and pipes (`primary_pumping=3`) [Pa]
+
+  real(dp) :: dp_liq
+  !! pressure drop in liquid metal blanket coolant including heat exchanger and pipes (`primary_pumping=3`) [Pa]
+
   real(dp) :: htpmw_fw_blkt
   !! mechanical pumping power for FW and blanket including heat exchanger and
   !! pipes (`primary_pumping=3`) [MW]
@@ -51,6 +63,10 @@ module primary_pumping_variables
     t_out_bb = 773.13D0 ! K
     p_he = 8.0D6 ! Pa
     dp_he = 5.5D5 ! Pa
+    dp_fw_blkt = 1.5D5 ! Pa
+    dp_fw = 1.5D5 ! Pa
+    dp_blkt = 3.5D3 ! Pa
+    dp_liq = 1.0D7 ! Pa
     htpmw_fw_blkt = 0.0D0
 
   end subroutine init_primary_pumping_variables


### PR DESCRIPTION
## Description

Resolves #3305.

Split up previous DCLL thermo_hydraulic_model to function for both primary_pumping=2 and 3 (new). This alongside changing the pumppower function so that the adiabatic index is based upon whether it is helium or water rather than just assuming helium means a WCLL blanket configuration can be modeled.

For primary_pumping=3 to work 4 pressure drop variables were added to primary_pumping_variables:

- dp_fw_blkt -> pressure drop across first wall and blanket
- dp_fw -> pressure drop across first wall
- dp_blkt -> pressure drop across blanket
- dp_liq -> pressure drop across liquid metal breeder

These can be used as inputs with primary_pumping=3, iblanket=5, ipupm=0, icooldual=1, and coolwh=2 to get a WCLL blanket when running PROCESS.

## Checklist

I confirm that I have completed the following checks:

- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
