### PR TITLE
Plot proc fix for poloidal cross section

### DIFF
--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -1153,6 +1153,7 @@ def plot_vacuum_vessel(axis, mfile_data, scan, colour_scheme):
             vvg_single_null.rs,
             vvg_single_null.zs,
             color=VESSEL_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
 
     if i_single_null == 0:
@@ -1171,6 +1172,7 @@ def plot_vacuum_vessel(axis, mfile_data, scan, colour_scheme):
             vvg_double_null.rs,
             vvg_double_null.zs,
             color=VESSEL_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
 
 
@@ -1219,7 +1221,10 @@ def plot_shield(axis, mfile_data, scan, colour_scheme):
         )
         axis.plot(sg_single_null.rs, sg_single_null.zs, color="black", lw=thin)
         axis.fill(
-            sg_single_null.rs, sg_single_null.zs, color=SHIELD_COLOUR[colour_scheme - 1]
+            sg_single_null.rs,
+            sg_single_null.zs,
+            color=SHIELD_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
 
     if i_single_null == 0:
@@ -1233,7 +1238,10 @@ def plot_shield(axis, mfile_data, scan, colour_scheme):
         )
         axis.plot(sg_double_null.rs, sg_double_null.zs, color="black", lw=thin)
         axis.fill(
-            sg_double_null.rs, sg_double_null.zs, color=SHIELD_COLOUR[colour_scheme - 1]
+            sg_double_null.rs,
+            sg_double_null.zs,
+            color=SHIELD_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
 
 
@@ -1307,6 +1315,7 @@ def plot_blanket(axis, mfile_data, scan, colour_scheme) -> None:
             bg_single_null.rs,
             bg_single_null.zs,
             color=BLANKET_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
 
     if i_single_null == 0:
@@ -1325,6 +1334,7 @@ def plot_blanket(axis, mfile_data, scan, colour_scheme) -> None:
             bg_double_null.rs[0],
             bg_double_null.zs[0],
             color=BLANKET_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
         if blnkith > 0.0:
             # only plot inboard blanket if inboard blanket thickness > 0
@@ -1335,6 +1345,7 @@ def plot_blanket(axis, mfile_data, scan, colour_scheme) -> None:
                 bg_double_null.rs[1],
                 bg_double_null.zs[1],
                 color=BLANKET_COLOUR[colour_scheme - 1],
+                lw=0.01,
             )
 
 
@@ -1403,6 +1414,7 @@ def plot_firstwall(axis, mfile_data, scan, colour_scheme):
             fwg_single_null.rs,
             fwg_single_null.zs,
             color=FIRSTWALL_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
 
     if i_single_null == 0:
@@ -1423,11 +1435,13 @@ def plot_firstwall(axis, mfile_data, scan, colour_scheme):
             fwg_double_null.rs[0],
             fwg_double_null.zs[0],
             color=FIRSTWALL_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
         axis.fill(
             fwg_double_null.rs[1],
             fwg_double_null.zs[1],
             color=FIRSTWALL_COLOUR[colour_scheme - 1],
+            lw=0.01,
         )
 
 


### PR DESCRIPTION
## Description

Made changes to poloidal cross section plotting. Changed component shape filling from default to a specified linewidth so that components aren't larger than intended and overlapping. This occurs sometimes for thin components as seen in issue #3250. Value was set to "0.01" instead of "thin" so that very thin components like the first wall don't disappear entirely.

ST Before:
![st_before](https://github.com/user-attachments/assets/e661d94b-07b5-4cb1-b61a-1e60a351e9e5)
ST After:
![st_after](https://github.com/user-attachments/assets/fe515e17-b49f-4912-be3c-f2989e5ff9c4)
Tokamak Before:
![tokamak_before](https://github.com/user-attachments/assets/58b79de9-79a4-4028-8e94-4e2ef8019a7e)
Tokamak After:
![tokamak_after](https://github.com/user-attachments/assets/0eb66fd1-2222-4d06-b4f3-6d049f9ef1e5)
