### PR TITLE
Fallback to minmax when plotting old solutions

### DIFF
--- a/tests/integration/data/large_tokamak_1_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_1_MFILE.DAT
@@ -18,7 +18,6 @@
  Number_of_constraints_(total)___________________________________________ (neqns+nineqns)_______________             26    
  Optimisation_switch_____________________________________________________ (ioptimz)_____________________              1    
  Figure_of_merit_switch__________________________________________________ (minmax)______________________              1    
- Objective_function_name_________________________________________________ (objf_name)___________________     "major radius"    
  Square_root_of_the_sum_of_squares_of_the_constraint_residuals___________ (sqsumsq)_____________________      1.8713E-04 OP 
  VMCON_convergence_parameter_____________________________________________ (convergence_parameter)_______      0.0000E+00 OP 
  Normalised_objective_function___________________________________________ (norm_objf)___________________      1.6000E+00 OP 

--- a/tests/integration/test_plot_solutions.py
+++ b/tests/integration/test_plot_solutions.py
@@ -35,4 +35,4 @@ def test_plot_mfile_solutions(run_metadata: Sequence[RunMetadata]):
     )
 
     # Check shape of solution df as evidence of plotting without error
-    assert results_df.shape == (3, 93)
+    assert results_df.shape == (3, 94)


### PR DESCRIPTION
## Description

Uses the `minmax` output parameter when the newer `objf_name` parameter is not present (ie in old mfiles file)

When comparing more than 1 MFile, if any of them are missing `objf_name` it defaults to `minmax`.

Updated `tests/integration/data/large_tokamak_1_MFILE.DAT` to reflect this possibility.