### PR TITLE
Increase lablxc length to 30

### DIFF
--- a/source/fortran/numerics.f90
+++ b/source/fortran/numerics.f90
@@ -200,7 +200,7 @@ module numerics
   !!               array defining which iteration variables to activate
   !!               (see lablxc for descriptions)
 
-  character*14, dimension(ipnvars) :: lablxc
+  character*30, dimension(ipnvars) :: lablxc
   !! lablxc(ipnvars) : labels describing iteration variables<UL>
   !!  <LI> ( 1) aspect
   !!  <LI> ( 2) bt


### PR DESCRIPTION
Increase the string length of `lablxc`'s to 30 so that iteration variable names are not cut off when accessed from Fortran