### PR TITLE
3337 bug install instructions incorrectmisleading for python version

### DIFF
--- a/documentation/proc-pages/installation/installation-ubuntu.md
+++ b/documentation/proc-pages/installation/installation-ubuntu.md
@@ -43,7 +43,7 @@ git clone https://github.com/ukaea/PROCESS
 cd PROCESS
 ```
 
-If you would like to install PROCESS using a package manager such as conda, follow the instructions for [HPC installation](https://ukaea.github.io/PROCESS/installation/csd3-for-process/). Otherwise, create and activate a virtual environment. Note that you must use Python 3.8 - 3.11:
+If you would like to install PROCESS using a package manager such as conda, follow the instructions for [HPC installation](https://ukaea.github.io/PROCESS/installation/csd3-for-process/). Otherwise, create and activate a virtual environment, as shown below. Note that you must use Python 3.10 or 3.11:
 
 ```bash
 python3 -m venv env

--- a/documentation/proc-pages/installation/installation-ubuntu.md
+++ b/documentation/proc-pages/installation/installation-ubuntu.md
@@ -43,7 +43,7 @@ git clone https://github.com/ukaea/PROCESS
 cd PROCESS
 ```
 
-Create and activate a virtual environment:
+If you would like to install PROCESS using a package manager such as conda, follow the instructions for [HPC installation](https://ukaea.github.io/PROCESS/installation/csd3-for-process/). Otherwise, create and activate a virtual environment. Note that you must use Python 3.8 - 3.11:
 
 ```bash
 python3 -m venv env

--- a/documentation/proc-pages/installation/introduction.md
+++ b/documentation/proc-pages/installation/introduction.md
@@ -4,6 +4,6 @@ Below are instructions of how to install the applications, code and dependencies
 can begin using or developing PROCESS. This includes differing instructions for those working on
 different operating systems.
 
-PROCESS is natively supported on Ubuntu 20 and 22, and requires Python 3.8 or greater. Other Linux distributions will be able to successfully
+PROCESS is natively supported on Ubuntu 20 and 22, and requires Python 3.8 - 3.11. Other Linux distributions will be able to successfully
 build and execute PROCESS however may give inconsistent results due to version disparities of
 dynamically linked libraries; therefore these can't be guaranteed. To install on Ubuntu, Mac, or Windows, please follow the [installation guide](installation-ubuntu.md).

--- a/documentation/proc-pages/installation/introduction.md
+++ b/documentation/proc-pages/installation/introduction.md
@@ -4,6 +4,6 @@ Below are instructions of how to install the applications, code and dependencies
 can begin using or developing PROCESS. This includes differing instructions for those working on
 different operating systems.
 
-PROCESS is natively supported on Ubuntu 20 and 22, and requires Python 3.8 - 3.11. Other Linux distributions will be able to successfully
+PROCESS is natively supported on Ubuntu 20 and 22, and requires Python 3.10 or 3.11. Other Linux distributions will be able to successfully
 build and execute PROCESS however may give inconsistent results due to version disparities of
 dynamically linked libraries; therefore these can't be guaranteed. To install on Ubuntu, Mac, or Windows, please follow the [installation guide](installation-ubuntu.md).


### PR DESCRIPTION
Update to the docs to prevent people attempting to install PROCESS with Python 3.12