### PR TITLE
Added else to account for divlife_cal not being set correctly

### DIFF
--- a/process/costs.py
+++ b/process/costs.py
@@ -2885,14 +2885,20 @@ class Costs:
             fwbs_variables.bktlife_cal = fwbs_variables.bktlife * cost_variables.cfactr
             # Current drive system lifetime (assumed equal to first wall and blanket lifetime)
             cost_variables.cdrlife_cal = fwbs_variables.bktlife_cal
+        else:
+            fwbs_variables.bktlife_cal = fwbs_variables.bktlife
 
         # Divertor
         if cost_variables.divlife < cost_variables.tlife:
             cost_variables.divlife_cal = cost_variables.divlife * cost_variables.cfactr
+        else:
+            cost_variables.divlife_cal = cost_variables.divlife
 
         # Centrepost
-        if (
-            physics_variables.itart == 1
-            and cost_variables.cplife < cost_variables.tlife
-        ):
-            cost_variables.cplife_cal = cost_variables.cplife * cost_variables.cfactr
+        if physics_variables.itart == 1:
+            if cost_variables.cplife < cost_variables.tlife:
+                cost_variables.cplife_cal = (
+                    cost_variables.cplife * cost_variables.cfactr
+                )
+            else:
+                cost_variables.cplife_cal = cost_variables.cplife


### PR DESCRIPTION
## Description

Fixes `divlife_cal` not being set, causing `coe` to be NaN.

## Checklist

I confirm that I have completed the following checks:

- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
