### PR TITLE
Convert element2index and Zav_of_te to Python

### DIFF
--- a/process/impurity_radiation.py
+++ b/process/impurity_radiation.py
@@ -462,6 +462,20 @@ def pimpden(imp_element_index, nprofile, tprofile):
     return pimpden
 
 
+def element2index(element: str):
+    """Returns the index of the `element` in the impurity array with
+    a given name
+    """
+    try:
+        return (
+            impurity_radiation_module.impurity_arr_label.astype(str)
+            .tolist()
+            .index(element)
+        )
+    except ValueError as e:
+        raise ValueError(f"Element {element} is not found in impurity_arr_label") from e
+
+
 class ImpurityRadiation:
     """This class calculates the impurity radiation losses for given temperature and density profiles.
     The considers the  total impurity radiation from the core (radcore) and total impurity radiation

--- a/process/physics.py
+++ b/process/physics.py
@@ -8,6 +8,7 @@ from process.utilities.f2py_string_patch import f2py_compatible_to_string
 import scipy.integrate as integrate
 
 import process.physics_functions as physics_funcs
+import process.impurity_radiation as impurity_radiation
 from process.fortran import (
     constraint_variables,
     reinke_variables,
@@ -2465,9 +2466,9 @@ class Physics:
         znimp = 0.0
         for imp in range(impurity_radiation_module.nimp):
             if impurity_radiation_module.impurity_arr_z[imp] > 2:
-                znimp += impurity_radiation_module.zav_of_te(
-                    imp + 1, physics_variables.te
-                ) * (
+                znimp += impurity_radiation.zav_of_te(
+                    imp, np.array([physics_variables.te])
+                ).squeeze() * (
                     impurity_radiation_module.impurity_arr_frac[imp]
                     * physics_variables.dene
                 )
@@ -2490,7 +2491,7 @@ class Physics:
         # Set hydrogen and helium impurity fractions for
         # radiation calculations
         impurity_radiation_module.impurity_arr_frac[
-            impurity_radiation_module.element2index("H_") - 1
+            impurity_radiation.element2index("H_")
         ] = (
             physics_variables.dnprot
             + (physics_variables.fdeut + physics_variables.ftrit)
@@ -2499,7 +2500,7 @@ class Physics:
         ) / physics_variables.dene
 
         impurity_radiation_module.impurity_arr_frac[
-            impurity_radiation_module.element2index("He") - 1
+            impurity_radiation.element2index("He")
         ] = (
             physics_variables.fhe3 * physics_variables.deni / physics_variables.dene
             + physics_variables.ralpne
@@ -2526,17 +2527,17 @@ class Physics:
         # Set some (obsolescent) impurity fraction variables
         # for the benefit of other routines
         physics_variables.rncne = impurity_radiation_module.impurity_arr_frac[
-            impurity_radiation_module.element2index("C_")
+            impurity_radiation.element2index("C_")
         ]
         physics_variables.rnone = impurity_radiation_module.impurity_arr_frac[
-            impurity_radiation_module.element2index("O_")
+            impurity_radiation.element2index("O_")
         ]
         physics_variables.rnfene = (
             impurity_radiation_module.impurity_arr_frac[
-                impurity_radiation_module.element2index("Fe")
+                impurity_radiation.element2index("Fe")
             ]
             + impurity_radiation_module.impurity_arr_frac[
-                impurity_radiation_module.element2index("Ar")
+                impurity_radiation.element2index("Ar")
             ]
         )
 
@@ -2547,7 +2548,9 @@ class Physics:
         for imp in range(impurity_radiation_module.nimp):
             physics_variables.zeff += (
                 impurity_radiation_module.impurity_arr_frac[imp]
-                * impurity_radiation_module.zav_of_te(imp + 1, physics_variables.te)
+                * impurity_radiation.zav_of_te(
+                    imp, np.array([physics_variables.te])
+                ).squeeze()
                 ** 2
             )
 
@@ -2627,7 +2630,9 @@ class Physics:
             if impurity_radiation_module.impurity_arr_z[imp] > 2:
                 physics_variables.zeffai += (
                     impurity_radiation_module.impurity_arr_frac[imp]
-                    * impurity_radiation_module.zav_of_te(imp + 1, physics_variables.te)
+                    * impurity_radiation.zav_of_te(
+                        imp, np.array([physics_variables.te])
+                    ).squeeze()
                     ** 2
                     / impurity_radiation_module.impurity_arr_amass[imp]
                 )

--- a/source/fortran/impurity_radiation.f90
+++ b/source/fortran/impurity_radiation.f90
@@ -22,10 +22,9 @@ module impurity_radiation_module
   implicit none
 
   private
-  public :: Zav_of_te, init_impurity_radiation_module, element2index
-  public :: impurity_arr_amass, impurity_arr_frac, impurity_arr_Label, &
-   impurity_arr_len_tab, impurity_arr_Lz_Wm3, impurity_arr_Temp_keV, &
-   impurity_arr_Z, impurity_arr_Zav
+  public :: init_impurity_radiation_module, impurity_arr_amass, impurity_arr_frac, &
+   impurity_arr_Label,impurity_arr_len_tab, impurity_arr_Lz_Wm3, &
+   impurity_arr_Temp_keV, impurity_arr_Z, impurity_arr_Zav
 
 
   !! (It is recommended to turn on
@@ -143,115 +142,6 @@ contains
       ! Re-initialise entire array
   end subroutine init_impurity_radiation_module
 
-  ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  function element2index(element_label)
-
-    !! Returns the index of the element in the impurity array with
-    !! a given name
-    !! author: P J Knight, CCFE, Culham Science Centre
-    !! element_label : input string : impurity name
-    !! This function returns the index of the element
-    !! in the impurity array with the corresponding name.
-    !! None
-    !
-    ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-		use error_handling, only: report_error
-    implicit none
-
-    integer :: element2index
-
-    !  Arguments
-
-    character(len=*), intent(in) :: element_label
-
-    !  Local variables
-
-    integer :: i
-
-    ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-    do i = 1, size(impurity_arr_Label)
-       if (element_label == impurity_arr_Label(i)) then
-          element2index = i
-          return
-       end if
-    end do
-
-    !  Should only get here if there is a problem
-
-    call report_error(34)
-
-  end function element2index
-
   ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  function Zav_of_te(imp_element_index,te)
-
-    !! Electron temperature dependent average atomic number
-    !! author: H Lux, CCFE, Culham Science Centre
-    !! imp_element : input imp_dat : impurity element
-    !! te : input real : electron temperature (keV)
-    !! This routine returns the interpolated average atomic
-    !! charge for a given electron temperature.
-    !! <P>The Zav versus temperature data is interpolated from
-    !! lookup tables from the ADAS data base provided by Martin O'Mullane.
-    !! None
-    !
-    ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-       implicit none
-
-    real(dp) :: Zav_of_te
-
-    !  Arguments
-
-    integer,  intent(in) :: imp_element_index
-    real(dp), intent(in) :: te
-
-    !  Local variables
-
-    integer :: i
-    real(dp) :: xi, yi, c
-
-    ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-    !  Interpolate tabulated data
-
-    !  Temperatures lower than the minimum, or higher than the maximum,
-    !  are dealt with by taking the Zav value at the nearest tabulated
-    !  temperature point
-
-    if (te <= impurity_arr_Temp_keV(imp_element_index, 1)) then
-       ! This should not be too unreasonable.
-       Zav_of_te = impurity_arr_Zav(imp_element_index,1)
-
-    else if (te >= impurity_arr_Temp_keV(imp_element_index, impurity_arr_len_tab(imp_element_index))) then
-       !  This should be okay, as most elements are fully ionised by now.
-       Zav_of_te = impurity_arr_Zav(imp_element_index, impurity_arr_len_tab(imp_element_index))
-
-    else
-
-       do i = 1, impurity_arr_len_tab(imp_element_index)-1
-
-          !  Linear interpolation in log-lin space
-
-          if ( (te > impurity_arr_Temp_keV(imp_element_index, i)) .and. &
-               (te <= impurity_arr_Temp_keV(imp_element_index, i+1)) ) then
-
-             yi = impurity_arr_Zav(imp_element_index, i)
-             xi = log(impurity_arr_Temp_keV(imp_element_index, i))
-             c  = (impurity_arr_Zav(imp_element_index, i+1) - yi) / &
-                  (log(impurity_arr_Temp_keV(imp_element_index,i+1)) - xi)
-             Zav_of_te = yi + c * (log(te) - xi)
-             exit
-          end if
-
-       end do
-
-    end if
-
-  end function Zav_of_te
-
 
 end module impurity_radiation_module


### PR DESCRIPTION
Use the `zav_of_te` function already in Python, remove old function from Fortran.

Convert `element2index` to Python