### PR TITLE
Remove developer group from docs

### DIFF
--- a/documentation/proc-pages/index.md
+++ b/documentation/proc-pages/index.md
@@ -65,20 +65,6 @@ itself to ensure that the documentation remains consistent with the latest versi
 It is to be hoped that it will be of assistance not only to users of PROCESS, but 
 to anyone using PROCESS outputs or models based on them.
 
-## Developer Group
-
-- [James Morris](mailto:james.morris2@ukaea.uk)
-- [Michael Kovari](mailto:michael.kovari@ukaea.uk)
-- [Stuart Muldrew](mailto:stuart.muldrew@ukaea.uk)
-- [Alex Pearce](mailto:alexander.pearce@ukaea.uk)
-- [Jonathan Maddock](mailto:jonathan.maddock@ukaea.uk)
-- [Timothy Nunn](mailto:timothy.nunn@ukaea.uk)
-- [Christopher Ashe](mailto:christopher.ashe@ukaea.uk)
-- [Georgina Graham](mailto:georgina.graham@ukaea.uk)
-- [Jack Foster](mailto:jack.foster@ukaea.uk)
-- [Graeme Turkington](mailto:graeme.turkington@ukaea.uk)
-- [Jonathan Matthews](mailto:jonathan.matthews@ukaea.uk)
-
 ## References
 
 Below is a list of PROCESS publications describing the models:


### PR DESCRIPTION
I've decided to remove the "developer group" in the docs, as suggested in the issue. The `CITATION.cff` will be used as the full citation for the repository (with credit to all authors), whilst the "contacts" at the bottom of the readme will be the key contacts. As Graeme points out, the post-gitlab contributors are recorded by Github anyway.