### PR TITLE
Sort test percentage difference by absolute percentage difference

### DIFF
--- a/tests/regression/test_process_input_files.py
+++ b/tests/regression/test_process_input_files.py
@@ -123,7 +123,7 @@ class RegressionTestScenario:
         )
         if differences:
             differences = sorted(
-                differences, key=lambda i: i.percentage_change, reverse=True
+                differences, key=lambda i: abs(i.percentage_change), reverse=True
             )
 
             logger.warning(


### PR DESCRIPTION
Regression test failure is now sorted by absolute percentage difference:

```
WARNING  test_process_input_files:test_process_input_files.py:129 Variable                     Ref             New        % Change
WARNING  test_process_input_files:test_process_input_files.py:132 ------------------------------------------------------------
WARNING  test_process_input_files:test_process_input_files.py:134 c22224                      7.51            -751       -10100.00
WARNING  test_process_input_files:test_process_input_files.py:134 c22223                      90.2        9.02e+03         9900.00
WARNING  test_process_input_files:test_process_input_files.py:134 c2223                        254       -1.27e+03         -600.00
WARNING  test_process_input_files:test_process_input_files.py:134 c2222                        636        3.18e+03          400.00
WARNING  test_process_input_files:test_process_input_files.py:134 c22221                       462            -231         -150.00
WARNING  test_process_input_files:test_process_input_files.py:134 c22222                      76.2            7.62          -90.00
```