### PR TITLE
3350 tool to automatically convert obsolete variables from input file

### DIFF
--- a/process/main.py
+++ b/process/main.py
@@ -549,6 +549,7 @@ class SingleRun:
         filename = self.input_file
         variables_in_in_dat = []
         modified_lines = []
+        changes_made = []  # To store details of the changes
 
         with open(filename, "r") as file:
             for line in file:
@@ -570,11 +571,17 @@ class SingleRun:
                         if replacement is None:
                             # If no replacement is defined, comment out the line
                             modified_lines.append(f"* Obsolete: {line}")
+                            changes_made.append(
+                                f"Commented out obsolete variable: {variable_name}"
+                            )
                         else:
                             # Replace obsolete variable with updated variable
                             modified_line = line.replace(variable_name, replacement, 1)
                             modified_lines.append(
                                 f"* Replaced '{variable_name}' with '{replacement}'\n{modified_line}"
+                            )
+                            changes_made.append(
+                                f"Replaced '{variable_name}' with '{replacement}'"
                             )
                     else:
                         # If replacement is False, add the line as-is
@@ -593,6 +600,9 @@ class SingleRun:
                 print(
                     "The IN.DAT file has been updated to replace or comment out obsolete variables."
                 )
+                print("Summary of changes made:")
+                for change in changes_made:
+                    print(f" - {change}")
             else:
                 # Only print the report if replace_obsolete is False
                 message = (

--- a/process/main.py
+++ b/process/main.py
@@ -362,7 +362,7 @@ class VaryRun:
 class SingleRun:
     """Perform a single run of PROCESS."""
 
-    def __init__(self, input_file, update_obsolete, solver="vmcon"):
+    def __init__(self, input_file, update_obsolete=False, solver="vmcon"):
         """Read input file and initialise variables.
 
         :param input_file: input file named <optional_name>IN.DAT

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -102,6 +102,8 @@ def test_run_mode(process_obj, monkeypatch):
     monkeypatch.setattr(process_obj, "args", argparse.Namespace(), raising=False)
     monkeypatch.setattr(process_obj.args, "varyiterparams", True, raising=False)
     monkeypatch.setattr(process_obj.args, "version", False, raising=False)
+    monkeypatch.setattr(process_obj.args, "update_obsolete", False, raising=False)
+
     monkeypatch.setattr(
         process_obj.args, "varyiterparamsconfig", "file.conf", raising=False
     )


### PR DESCRIPTION
I modified this validate_input function and added a CLI argument "replace_obsolete"

Now if you pass this argument when you run PROCESS it will automatically convert the variables, spit out the conversion in the terminal and write a comment in the input file where the name was changed.