### PR TITLE
Install development dependencies in tracking input runner

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -148,6 +148,8 @@ jobs:
           path: process/
       - name: Install PROCESS
         run: pip install -e .
+      - name: Install dev dependencies
+        run: pip install -r requirements_dev.txt
       - name: Run regression input files
         run: python tracking/run_tracking_inputs.py run tests/regression/input_files
       - name: Archive tracked MFILEs


### PR DESCRIPTION
Hotfixes bokeh being missing in the `run-tracking-inputs` job.