### PR TITLE
3410 more namespace standards for physics and engineering variables

### DIFF
--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -145,7 +145,13 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 #### Currents
 
-- Currents should start with the `amps_` prefix
+- Currents should start with the `c_` prefix
+
+---------------------
+
+#### Inductances
+
+- Inductances should start with the `h_` prefix
 
 ---------------------
 
@@ -188,7 +194,13 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 #### Frequencies
 
-- Frequencies should start with the `hz_`
+- Frequencies should start with the `freq_`
+
+---------------------
+
+#### Angles
+
+- Angles should start with the `deg_` or `rad_` depending on the units used
 
 ---------------------
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -94,6 +94,12 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 ---------------------
 
+#### Volumes
+
+- Volumes should start with the `vol_` prefix
+
+---------------------
+
 #### Lengths
 
 - Lengths should start with the `len_` prefix
@@ -106,9 +112,22 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 ---------------------
 
+#### Pressures
+
+- Pressures should start with the `pres_` prefix
+
+---------------------
+
+
 #### Densities
 
 - Densities should start with the `den_` prefix
+
+---------------------
+
+#### Voltages
+
+- Voltages should start with the `v_` prefix
 
 ---------------------
 
@@ -124,6 +143,12 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 ---------------------
 
+#### Currents
+
+- Currents should start with the `amps_` prefix
+
+---------------------
+
 #### Current densities
 
 - Current densities should start with the `j_` prefix
@@ -133,6 +158,12 @@ Example, the area of the TF winding pack: `a_tf_wp`
 #### Powers
 
 - Powers should start with the `p_` prefix
+
+---------------------
+
+#### Energies
+
+- Energies should start with the `e_` prefix
 
 ---------------------
 
@@ -151,7 +182,13 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 #### Magnetic field strengths
 
-- Magnetic field strengths should start with the `b_prefix`
+- Magnetic field strengths should start with the `b_`
+
+---------------------
+
+#### Frequencies
+
+- Frequencies should start with the `hz_`
 
 ---------------------
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -56,13 +56,116 @@ If the constants doesn't exist then add it with a source link and uncertainty va
 Use a lowercase single letter, word, or words. Separate words with underscores to improve readability.
 If converting between units it may be required to have some capital letters at the end of the variable name to differentiate between different orders of magnitude, `m` and `M` etc.
 
+The agreed upon style is to name the variables by the following scheme:
+
+`var = <data type>_<system>_<description>_<description...>`
+
+If the variables are physics variables and do not belong to a system then:
+
+`var = <physics variable>_<description>`
+
+The data types of different variables can be seen below:
+
+---------------------
+
+#### Radii and thicknesses
+
+- Radial positions should start with the `r_` prefix
+- Radial thicknesses should start with the `dr_` prefix
+
+- Vertical positions should start with the `z_` prefix
+- Vertical thicknesses should start with the `dz_` prefix
+
+---------------------
+
+#### Integer countable items
+
+- Integer countable items should start with the `n_` prefix
+
+Example, the total number of TF coils: `n_tf_coils`
+
+---------------------
+
+#### Areas
+
+- Areas should start with the `a_` prefix
+
+Example, the area of the TF winding pack: `a_tf_wp`
+
+---------------------
+
+#### Lengths
+
+- Lengths should start with the `len_` prefix
+
+---------------------
+
+#### Mass
+
+- Masses should start with the `m_` prefix
+
+---------------------
+
+#### Densities
+
+- Densities should start with the `den_` prefix
+
+---------------------
+
+#### Resistances
+
+- Resistances should start with the `res_` prefix
+
+---------------------
+
+#### Resistivity
+
+- Resistivity variables should start with the `rho_` prefix
+
+---------------------
+
+#### Current densities
+
+- Current densities should start with the `j_` prefix
+
+---------------------
+
+#### Powers
+
+- Powers should start with the `p_` prefix
+
+---------------------
+
+#### Temperatures
+
+- Temperatures should start with the `temp_` prefix
+
+---------------------
+
+#### Times
+
+- Times should start with the `t_` prefix
+- Time intervals should start with the `dt_` prefix
+
+---------------------
+
+#### Magnetic field strengths
+
+- Magnetic field strengths should start with the `b_prefix`
+
+---------------------
+
 #### Variables representing fractions
 
 If a variable is intended to demonstrate a fraction of a value or distribution etc. Then it should start with the `f_` prefix.
 
+---------------------
+
 #### F-values
 
 Variables used within constraint equations to scale iteration variables (f-values) should start with the `f` prefix without an underscore before the next word.
+
+---------------------
 
 ### Length
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -77,12 +77,16 @@ Below are a few shorthand designations for different systems that should be used
 - Toroidal field coils: `_tf_`
 - Poloidal field coils: `_pf_`
 - Vacuum Vessel: `_vv_`
+- First wall: `_fw_`
 - Divertor: `_div_`
 - Blanket: `_blkt_`
 - Shield: `_shield_`
 - Central Solenoid: `_cs_`
 - Heating & Current Drive: `_hcd_`
-- Neutral Beam: `_nb_`
+    - Electron cyclotron current drive: `_eccd_`
+    - Ion cyclotron current drive: `_iccd_`
+    - Electron Bernstein Wave: `_ebw_`
+    - Neutral Beam: `_nb_`
 - Centre post: `_cp_` Should only be used for ST's
 
 If the variables are physics variables and do not belong to a system then:

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -83,6 +83,7 @@ Below are a few shorthand designations for different systems that should be used
 - Central Solenoid: `_cs_`
 - Heating & Current Drive: `_hcd_`
 - Neutral Beam: `_nb_`
+- Centre post: `_cp_` Should only be used for ST's
 
 If the variables are physics variables and do not belong to a system then:
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -58,7 +58,9 @@ If converting between units it may be required to have some capital letters at t
 
 The agreed upon style is to name the variables by the following scheme:
 
-`var = <data type>_<system>_<description>_<description...>`
+`var = <data type>_<system>_<description>_<units>`
+
+It is not always necessary to add the units abbreviation to the end of the variable but if doing so make sure it is case sensitive.
 
 If the variables are physics variables and do not belong to a system then:
 
@@ -90,8 +92,6 @@ Example, the total number of TF coils: `n_tf_coils`
 
 - Number density items should start with the `nd_` prefix
 
-Example, the plasma electron density: `dn_electron`
-
 ---------------------
 
 #### Areas
@@ -111,6 +111,12 @@ Example, the area of the TF winding pack: `a_tf_wp`
 #### Lengths
 
 - Lengths should start with the `len_` prefix
+
+---------------------
+
+#### Velocities
+
+- Velocities should start with the `vel_` prefix
 
 ---------------------
 
@@ -293,26 +299,26 @@ ii
 
 | Variable name | Description | Units |
 | ------------- | ----------- | :---: |
-| `plasma_current`    | Plasma current | A |
-| `plasma_current_MA` | Plasma current | MA |
+| `c_plasma`    | Plasma current | A |
+| `c_plasma_MA` | Plasma current | MA |
 | `b_t_onaxis`  | Toroidal field on-axis | T |
 | `b_t_max`     | Max toroidal field | T |
-| `n_electron_vol` | Volume average electron density | m-3 |
-| `t_electron_vol_ev` | Volume avgerage electron temperature | eV |
-| `mass_steel` | Mass of steel | kg |
-| `mass_steel_tonne` | Mass of steel | tonne |
-| `e_neutron_ev` | Energy of neutron | eV |
+| `nd_electron_vol` | Volume average electron density | m-3 |
+| `temp_electron_vol_eV` | Volume avgerage electron temperature | eV |
+| `m_steel` | Mass of steel | kg |
+| `m_steel_tonne` | Mass of steel | tonne |
+| `e_neutron_eV` | Energy of neutron | eV |
 | `e_neutron_MeV` | Energy of neutron | MeV |
 | `v_tf_dump` | TF dump voltage | V |
-| `time_plant_life` | Plant lifetime | s |
-| `time_plant_life_yrs` | Plant lifetime | years |
+| `t_plant_life` | Plant lifetime | s |
+| `t_plant_life_yrs` | Plant lifetime | years |
 | `dr_tf_inboard_leg` | TF coil inboard leg radial thickness | m |
 | `dr_blanket_inboard` | Inboard blanket thickness | m |
-| `velocity_coolant` | TF centrepost coolant velocity | m/s |
-| `plasma_volume` | Plasma volume | m3 |
-| `plasma_area` | Plasma area | m2 |
-| `angle_div_target` | Divertor target angle | radians |
-| `angle_div_target_deg` | Divertor target angle | deg |
+| `vel_coolant` | TF centrepost coolant velocity | m/s |
+| `vol_plasma` | Plasma volume | m3 |
+| `a_plasma` | Plasma area | m2 |
+| `rad_div_target` | Divertor target angle | radians |
+| `deg_div_target` | Divertor target angle | deg |
 | `sig_tf_r` | TF radial stress  | Pa |
 | `` |  |  |
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -40,9 +40,13 @@ all new models should have their own function
 
 Use a lowercase word or words. Separate words by underscores(`_`) to improve readability.
 
+---------------------
+
 ### Switches
 
 Switches should start with the `i_` prefix in their name, be of integer type and should be indexed from 0.
+
+---------------------
 
 ### Constants
 
@@ -51,7 +55,13 @@ Use an uppercase single letter, word, or words. Separate words with underscores 
 Refrain from declaring or typing known numerical constants directly in the code. Instead call the value from `constants.f90`
 If the constants doesn't exist then add it with a source link and uncertainty value.
 
+---------------------
+
 ### Variables
+
+!!! note
+
+    Variable names are slowly being converted to their new verbose form as development progresses. Therefore you may come across variables that do not match the style mentioned below.
 
 Use a lowercase single letter, word, or words. Separate words with underscores to improve readability.
 If converting between units it may be required to have some capital letters at the end of the variable name to differentiate between different orders of magnitude, `m` and `M` etc.
@@ -60,7 +70,19 @@ The agreed upon style is to name the variables by the following scheme:
 
 `var = <data type>_<system>_<description>_<units>`
 
-It is not always necessary to add the units abbreviation to the end of the variable but if doing so make sure it is case sensitive.
+#### System designations
+
+Below are a few shorthand designations for different systems that should be used in variable names
+
+- Toroidal field coils: `_tf_`
+- Poloidal field coils: `_pf_`
+- Vacuum Vessel: `_vv_`
+- Divertor: `_div_`
+- Blanket: `_blkt_`
+- Shield: `_shield_`
+- Central Solenoid: `_cs_`
+- Heating & Current Drive: `_hcd_`
+- Neutral Beam: `_nb_`
 
 If the variables are physics variables and do not belong to a system then:
 
@@ -241,6 +263,8 @@ Variables used within constraint equations to scale iteration variables (f-value
 
 Try to keep names to a sensible length while also keeping the name explicit and descriptive.
 
+---------------------
+
 ### Physical Type
 
 The physical type of the variable should form the first part of the variable name, e.g. for plasma resistance the variable should be named:
@@ -264,10 +288,21 @@ Inside PROCESS all variables should be in SI units unless otherwise stated. For 
 ```fortran
 ! Fusion power [W]
 fusion_power = 1000.0d6
+```
 
+If a variable is not in SI units then its units should be put at the end of of the variable name.
+Example:
+
+```fortran
 ! Fusion power [MW]
 fusion_power_MW = 1000.0d0
 ```
+
+!!! note
+
+    With `f2py` you may encounter a Fortran error where the variable with units at the end in capital letters is not recognised. If so for the meantime put the units in their lowercase form. This problem will be solved in the future by full Pythonisation.
+
+---------------------    
 
 ### Coordinates and dimensions
 
@@ -291,6 +326,8 @@ dz_cs =
 dtheta_description =
 ```
 
+---------------------
+
 ### Loop order
 
 Loop variables that use I, j etc. should use
@@ -301,6 +338,8 @@ ii
         kk
             mm
 ```
+
+---------------------
 
 ### Examples
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -129,6 +129,7 @@ Example, the area of the TF winding pack: `a_tf_wp`
 #### Pressures
 
 - Pressures should start with the `pres_` prefix
+- Pressure changes or drops should start with the `dpres_` prefix
 
 ---------------------
 
@@ -178,6 +179,12 @@ Example, the area of the TF winding pack: `a_tf_wp`
 #### Powers
 
 - Powers should start with the `p_` prefix
+
+---------------------
+
+#### Power densities
+
+- Power densities should start with the `pden_` prefix
 
 ---------------------
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -210,6 +210,12 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 ---------------------
 
+#### Power fluxes
+
+- Power fluxes should start with the `pflux_` prefix
+
+---------------------
+
 #### Energies
 
 - Energies should start with the `e_` prefix
@@ -250,6 +256,10 @@ Example, the area of the TF winding pack: `a_tf_wp`
 #### Variables representing fractions
 
 If a variable is intended to demonstrate a fraction of a value or distribution etc. Then it should start with the `f_` prefix.
+
+Similar to this is variables representing efficiencies.
+
+If a variable is intended to represent an engineering efficiency then it should start with the `eta_` prefix to represent $\eta$
 
 ---------------------
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -86,6 +86,14 @@ Example, the total number of TF coils: `n_tf_coils`
 
 ---------------------
 
+#### Number densities
+
+- Number density items should start with the `nd_` prefix
+
+Example, the plasma electron density: `dn_electron`
+
+---------------------
+
 #### Areas
 
 - Areas should start with the `a_` prefix


### PR DESCRIPTION
This pull request includes significant updates to the variable naming conventions in the `documentation/proc-pages/development/standards.md` file. The changes introduce a standardized scheme for naming variables based on their data type, system, description, and units. Additionally, specific prefixes for different types of variables are defined to improve readability and consistency.

### Variable Naming Conventions:

* Introduced a new variable naming scheme: `var = <data type>_<system>_<description>_<units>`. For physics variables not belonging to a system, the scheme is `var = <physics variable>_<description>`.
* Defined prefixes for various types of variables, such as radii (`r_`), thicknesses (`dr_`), integer countable items (`n_`), number densities (`nd_`), areas (`a_`), volumes (`vol_`), lengths (`len_`), velocities (`vel_`), mass (`m_`), pressures (`pres_`), densities (`den_`), voltages (`v_`), resistances (`res_`), resistivity (`rho_`), currents (`c_`), inductances (`h_`), current densities (`j_`), powers (`p_`), energies (`e_`), temperatures (`temp_`), times (`t_`), magnetic field strengths (`b_`), frequencies (`freq_`), and angles (`deg_` or `rad_`).

### Updates to Existing Variables:

* Updated existing variable names to follow the new naming conventions. For example, `plasma_current` is now `c_plasma`, and `mass_steel` is now `m_steel`.## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
