### PR TITLE
Use Bokeh 3.x interface in tracking scripts

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,6 @@ mkdocs-material>=4.6.3
 mkdocs-git-revision-date-localized-plugin >= 1.2
 mkdocs-glightbox >= 0.3.4
 pymdown-extensions>=6.3
-bokeh==2.4.0
+bokeh>=3.0.0,<4
 mkdocstrings==0.18.0
 Jinja2>=3.0

--- a/tracking/tracking_data.py
+++ b/tracking/tracking_data.py
@@ -41,9 +41,14 @@ import inspect
 import argparse
 import math
 from bokeh.plotting import figure
-from bokeh.models import ColumnDataSource, HoverTool, DatetimeTickFormatter
+from bokeh.models import (
+    ColumnDataSource,
+    HoverTool,
+    DatetimeTickFormatter,
+    Tabs,
+    TabPanel,
+)
 from bokeh.layouts import gridplot
-from bokeh.models.widgets import Panel, Tabs
 from bokeh.palettes import Category10
 from bokeh.resources import CDN
 from bokeh.embed import file_html
@@ -427,14 +432,12 @@ def plot_tracking_data(database):
             df["title"].to_numpy()
         )  # all scenarios this variable is tracked in
 
-        figur = figure(
-            title=variable, x_axis_type="datetime", plot_width=600, plot_height=600
-        )
+        figur = figure(title=variable, x_axis_type="datetime", width=600, height=600)
         figur.xaxis.formatter = DatetimeTickFormatter(
-            hours=["%d %B %Y"],
-            days=["%d %B %Y"],
-            months=["%d %B %Y"],
-            years=["%d %B %Y"],
+            hours="%d %B %Y",
+            days="%d %B %Y",
+            months="%d %B %Y",
+            years="%d %B %Y",
         )
         figur.xaxis.major_label_orientation = math.pi / 4
 
@@ -503,7 +506,7 @@ def plot_tracking_data(database):
         else:
             gplot = gridplot([figs[i : i + 2] for i in range(0, len(figs) - 1, 2)])
 
-        panels.append(Panel(child=gplot, title=parent_module_name))
+        panels.append(TabPanel(child=gplot, title=parent_module_name))
 
     tabs = Tabs(tabs=panels)
 


### PR DESCRIPTION
Modifies some of the Bokeh imports and function calls to use the newer 3.x interface. Hence, we no longer need to fix onto version 2.4 and can support any version 3 API.
