### PR TITLE
Update action versions in process.yml workflows

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -14,8 +14,8 @@ jobs:
   make:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Build PROCESS
@@ -24,14 +24,14 @@ jobs:
           cmake -S. -Bbuild
           cmake --build build
       - name: Archive build artifacts in process
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: process-build-artifacts
           path: |
             process/**/*.so
             process/io/python_fortran_dicts.json
       - name: Archive ford artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ford-artifact
           path: build/ford_project.pickle
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: make
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: process-build-artifacts
           path: process/
@@ -58,13 +58,8 @@ jobs:
         run: |
           pytest --cov=process tests/unit -v \
                  --cov-report xml
-      - name: Archive unit test coverage data
-        uses: actions/upload-artifact@v3
-        with:
-          name: unit-coverage-artifacts
-          path: .coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -74,12 +69,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: make
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: process-build-artifacts
           path: process/
@@ -107,14 +102,14 @@ jobs:
       matrix:
         tolerance: [0, 5]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: process-build-artifacts
           path: process/
@@ -133,12 +128,12 @@ jobs:
     needs: make
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: process-build-artifacts
           path: process/
@@ -149,7 +144,7 @@ jobs:
       - name: Run regression input files
         run: python tracking/run_tracking_inputs.py run tests/regression/input_files
       - name: Archive tracked MFILEs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tracked-mfiles
           path: tracking/*_MFILE.DAT
@@ -157,8 +152,8 @@ jobs:
   pre-commit-quality-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dev dependencies
@@ -176,12 +171,12 @@ jobs:
     env:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: process-build-artifacts
           path: process/
@@ -196,7 +191,7 @@ jobs:
       - name: Download tracking data
         run: git clone git@github.com:timothy-nunn/process-tracking-data.git process-tracking-data
       - name: Download large tokamak MFILE
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tracked-mfiles
           path: tracking/
@@ -209,7 +204,7 @@ jobs:
       - name: Create the tracking dashboard
         run: python tracking/tracking_data.py plot process-tracking-data --out tracking.html
       - name: Archive tracking dashboard
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tracking-html
           path: tracking.html
@@ -232,14 +227,14 @@ jobs:
     needs: tracking
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: process-build-artifacts
           path: process/
@@ -251,7 +246,7 @@ jobs:
         run: pip install git+https://github.com/jonmaddock/ford
       - run: ford documentation/ford/index.md
       - name: Download ford project
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ford-artifact
           path: build/
@@ -261,7 +256,7 @@ jobs:
       - run: mkdocs build
       - run: mv ford_site site
       - name: Download tracking html
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tracking-html
       - run: mv tracking.html site || cp site/404.html site/tracking.html


### PR DESCRIPTION
Updates the versions of actions we use in our CI. Some of these were causing warnings due to deprecation.

The `.coverage` artifact was causing a warning due to the fact it does not exist.