### PR TITLE
Don't use system Python for tracking jobs in CI

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -134,6 +134,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -174,6 +177,9 @@ jobs:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -229,6 +235,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ numpy>=1.23,<2
 
 # Markdown versions for ford compatibility
 Markdown>=3.2.2,<3.4
+pymdown-extensions<=10.4
 
 # f2py requires to read some Fortran code
 charset-normalizer>=3.3


### PR DESCRIPTION
Some of the CI jobs were not using the `setup-python` action. Changes in the system Python version on the runner (new ubuntu LTS version) mean the `fortran` extension compiled for 3.10 does not work. 