### PR TITLE
Updated gcc install instructions to load from module

### DIFF
--- a/documentation/proc-pages/installation/csd3-for-process.md
+++ b/documentation/proc-pages/installation/csd3-for-process.md
@@ -45,7 +45,7 @@ conda activate my_process
 
 It is worth checking that a compatible version of python has been installed (Python3.10 or 3.11). You can check this by entering `which python` into the terminal. You can install a compatible version of python with the command `conda install python=3.10`.
 
-Next, load a compatible version of gfortran.
+Next load a compatible version of gfortran.
 
 ```bash
 module unload gcc

--- a/documentation/proc-pages/installation/csd3-for-process.md
+++ b/documentation/proc-pages/installation/csd3-for-process.md
@@ -45,10 +45,11 @@ conda activate my_process
 
 It is worth checking that a compatible version of python has been installed (Python3.10 or 3.11). You can check this by entering `which python` into the terminal. You can install a compatible version of python with the command `conda install python=3.10`.
 
-Next, install gfortran.
+Next, load a compatible version of gfortran.
 
 ```bash
-conda install -c conda-forge gfortran
+module unload gcc
+module load gcc/9
 ```
 
 ### Build PROCESS


### PR DESCRIPTION
## Description

Update the install instructions for gcc on CSD3 to load module instead of install to env.

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
