### PR TITLE
fix: correct parameter name from initial_B to initial_b in Vmcon solver

### DIFF
--- a/process/solver.py
+++ b/process/solver.py
@@ -215,7 +215,7 @@ class Vmcon(_Solver):
                 max_iter=global_variables.maxcal,
                 epsilon=self.tolerance,
                 qsp_options={"eps_rel": 1e-1, "adaptive_rho_interval": 25},
-                initial_B=bb,
+                initial_b=bb,
                 callback=_solver_callback,
                 additional_convergence=_ineq_cons_satisfied,
             )


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
