### PR TITLE
Ignore timezone when tracking

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -190,7 +190,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Download tracking data
         run: git clone git@github.com:timothy-nunn/process-tracking-data.git process-tracking-data
-      - name: Download large tokamak MFILE
+      - name: Download MFILEs
         uses: actions/download-artifact@v4
         with:
           name: tracked-mfiles

--- a/tracking/tracking_data.py
+++ b/tracking/tracking_data.py
@@ -203,7 +203,8 @@ class ProcessTracker:
         self.add_extra_metadata("commit_hash", commit_hash)
 
         if database:
-            date = self.tracking_file.meta.get("date").replace("/", "")
+            # split to remove timezone from date if present
+            date = self.tracking_file.meta.get("date").replace("/", "").split(" ")[0]
             time = self.tracking_file.meta.get("time")
 
             # for an mfile called foo.MFILE.DAT created at 16:00 on 15/11/2021
@@ -353,7 +354,8 @@ class TrackedData:
         title = metadata.get("title", "-")
         message = metadata.get("commit_message", "-")
         hash_ = metadata.get("commit_hash", "-")
-        date_str = metadata.get("date", "-")
+        # split to disregard timezone if present
+        date_str = metadata.get("date", "-").split(" ")[0]
         time_str = metadata.get("time", "-")
 
         # common format for the timestamp of the run


### PR DESCRIPTION
Fixes the tracker to ignore timezone information in the date field. The tracker already assumes UTC, as does PROCESS now, hence we lose no information by disregarding 'UTC' from the date string. This method is backwards compatible with data that does not include timezone.