### PR TITLE
:memo: Enhance documentation on variable naming standards and introdu…

### DIFF
--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -72,6 +72,20 @@ $\mathtt{var = \ <data type>\_<system>\_<description>\_<units>}$
 
 **Having the units at the end of the name is only necessary when the variable is not in SI/standard units.**
 
+For example, a variable can look like:
+
+$$
+\mathtt{var = \ a_\_tf\_wp}
+$$
+
+Which represents:
+
+$$
+\mathtt{var = \ \text{Area}:\text{Toroidal Field system}:\text{Winding Pack}}
+$$
+
+So for above; `a` is the data type representing area, `tf` is the system representing the TF coils and `wp` is the secondary description or system. This variable thus represents the cross-sectional area of the TF coil winding pack.
+
 It may also be useful to use several data type prefixes to greater greater clarity.
 
 For example, a variable can look like:
@@ -118,7 +132,11 @@ The data types of different variables can be seen below:
 
 ---------------------
 
-#### Radii and thicknesses
+#### Data types
+
+---------------------
+
+##### Radii and thicknesses
 
 - Radial positions should start with the `r_` prefix
 - Radial thicknesses should start with the `dr_` prefix
@@ -128,7 +146,7 @@ The data types of different variables can be seen below:
 
 ---------------------
 
-#### Integer countable items
+##### Integer countable items
 
 - Integer countable items should start with the `n_` prefix
 
@@ -136,13 +154,13 @@ Example, the total number of TF coils: `n_tf_coils`
 
 ---------------------
 
-#### Number densities
+##### Number densities
 
 - Number density items should start with the `nd_` prefix
 
 ---------------------
 
-#### Areas
+##### Areas
 
 - Areas should start with the `a_` prefix
 
@@ -150,37 +168,37 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 ---------------------
 
-#### Volumes
+##### Volumes
 
 - Volumes should start with the `vol_` prefix
 
 ---------------------
 
-#### Lengths
+##### Lengths
 
 - Lengths should start with the `len_` prefix
 
 ---------------------
 
-#### Radii
+##### Radii
 
 - Radii should start with the `radius_` prefix
 
 ---------------------
 
-#### Velocities
+##### Velocities
 
 - Velocities should start with the `vel_` prefix
 
 ---------------------
 
-#### Mass
+##### Mass
 
 - Masses should start with the `m_` prefix
 
 ---------------------
 
-#### Mass flow rates
+##### Mass flow rates
 
 - Mass flow rates should start with the `mflow_` prefix
 
@@ -188,7 +206,7 @@ This should be used for units of $\text{kg} \cdot \text{s}^{-1}$
 
 ---------------------
 
-#### Mass fluxes rates
+##### Mass fluxes rates
 
 - Mass fluxes should start with the `mflux_` prefix
 
@@ -196,7 +214,7 @@ This should be used for units of $\text{kg} \cdot \text{m}^{-2}\text{s}^{-1}$
 
 ---------------------
 
-#### Pressures
+##### Pressures
 
 - Pressures should start with the `pres_` prefix
 - Pressure changes or drops should start with the `dpres_` prefix
@@ -204,110 +222,110 @@ This should be used for units of $\text{kg} \cdot \text{m}^{-2}\text{s}^{-1}$
 ---------------------
 
 
-#### Densities
+##### Densities
 
 - Densities should start with the `den_` prefix
 
 ---------------------
 
-#### Voltages
+##### Voltages
 
 - Voltages should start with the `v_` prefix
 
 ---------------------
 
-#### Resistances
+##### Resistances
 
 - Resistances should start with the `res_` prefix
 
 ---------------------
 
-#### Resistivity
+##### Resistivity
 
 - Resistivity variables should start with the `rho_` prefix
 
 ---------------------
 
-#### Currents
+##### Currents
 
 - Currents should start with the `c_` prefix
 
 ---------------------
 
-#### Inductances
+##### Inductances
 
 - Inductances should start with the `h_` prefix
 
 ---------------------
 
-#### Current densities
+##### Current densities
 
 - Current densities should start with the `j_` prefix
 
 ---------------------
 
-#### Powers
+##### Powers
 
 - Powers should start with the `p_` prefix
 
 ---------------------
 
-#### Power densities
+##### Power densities
 
 - Power densities should start with the `pden_` prefix
 
 ---------------------
 
-#### Power fluxes
+##### Power fluxes
 
 - Power fluxes should start with the `pflux_` prefix
 
 ---------------------
 
-#### Energies
+##### Energies
 
 - Energies should start with the `e_` prefix
 
 ---------------------
 
-#### Particle fluence
+##### Particle fluence
 
 - Fluences should start with the `flu_` prefix
 
 ---------------------
 
-#### Temperatures
+##### Temperatures
 
 - Temperatures should start with the `temp_` prefix
 
 ---------------------
 
-#### Times
+##### Times
 
 - Times should start with the `t_` prefix
 - Time intervals should start with the `dt_` prefix
 
 ---------------------
 
-#### Magnetic field strengths
+##### Magnetic field strengths
 
 - Magnetic field strengths should start with the `b_`
 
 ---------------------
 
-#### Frequencies
+##### Frequencies
 
 - Frequencies should start with the `freq_`
 
 ---------------------
 
-#### Angles
+##### Angles
 
 - Angles should start with the `deg_` or `rad_` depending on the units used
 
 ---------------------
 
-#### Variables representing fractions
+##### Variables representing fractions
 
 If a variable is intended to demonstrate a fraction of a value or distribution etc. Then it should start with the `f_` prefix.
 
@@ -317,7 +335,7 @@ If a variable is intended to represent an engineering efficiency then it should 
 
 ---------------------
 
-#### F-values
+##### F-values
 
 Variables used within constraint equations to scale iteration variables (f-values) should start with the `f` prefix without an underscore before the next word.
 

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -70,6 +70,8 @@ The agreed upon style is to name the variables by the following scheme:
 
 $\mathtt{var = \ <data type>\_<system>\_<description>\_<units>}$
 
+**Having the units at the end of the name is only necessary when the variable is not in SI/standard units.**
+
 It may also be useful to use several data type prefixes to greater greater clarity.
 
 For example, a variable can look like:

--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -68,7 +68,26 @@ If converting between units it may be required to have some capital letters at t
 
 The agreed upon style is to name the variables by the following scheme:
 
-`var = <data type>_<system>_<description>_<units>`
+$\mathtt{var = \ <data type>\_<system>\_<description>\_<units>}$
+
+It may also be useful to use several data type prefixes to greater greater clarity.
+
+For example, a variable can look like:
+
+$$
+\mathtt{var = \ f\_a_\_tf\_wp}
+$$
+
+In system designation it means this:
+
+$$
+\mathtt{var = \ \text{Fraction}:\text{Area}:\text{Toroidal Field system}:\text{Winding Pack}}
+$$
+
+This means the variable represents the fraction of the TF coil area taken up by the winding pack.
+
+
+--------------
 
 #### System designations
 
@@ -80,7 +99,7 @@ Below are a few shorthand designations for different systems that should be used
 - First wall: `_fw_`
 - Divertor: `_div_`
 - Blanket: `_blkt_`
-- Shield: `_shield_`
+- Shield: `_shld_`
 - Central Solenoid: `_cs_`
 - Heating & Current Drive: `_hcd_`
     - Electron cyclotron current drive: `_eccd_`
@@ -141,6 +160,12 @@ Example, the area of the TF winding pack: `a_tf_wp`
 
 ---------------------
 
+#### Radii
+
+- Radii should start with the `radius_` prefix
+
+---------------------
+
 #### Velocities
 
 - Velocities should start with the `vel_` prefix
@@ -150,6 +175,22 @@ Example, the area of the TF winding pack: `a_tf_wp`
 #### Mass
 
 - Masses should start with the `m_` prefix
+
+---------------------
+
+#### Mass flow rates
+
+- Mass flow rates should start with the `mflow_` prefix
+
+This should be used for units of $\text{kg} \cdot \text{s}^{-1}$
+
+---------------------
+
+#### Mass fluxes rates
+
+- Mass fluxes should start with the `mflux_` prefix
+
+This should be used for units of $\text{kg} \cdot \text{m}^{-2}\text{s}^{-1}$
 
 ---------------------
 
@@ -224,6 +265,12 @@ Example, the area of the TF winding pack: `a_tf_wp`
 #### Energies
 
 - Energies should start with the `e_` prefix
+
+---------------------
+
+#### Particle fluence
+
+- Fluences should start with the `flu_` prefix
 
 ---------------------
 


### PR DESCRIPTION
This pull request includes several updates to the documentation standards for naming variables in the `documentation/proc-pages/development/standards.md` file. The changes introduce new conventions for variable prefixes and update existing ones for better clarity and consistency.

Updates to variable naming conventions:

* Expanded the variable naming section to explain in more detail how variable prefixes can be combined
* Updated the shorthand designation for the "Shield" system from `_shield_` to `_shld_`.
* Added new prefixes for radii (`radius_`), mass flow rates (`mflow_`), and mass fluxes (`mflux_`) to standardize naming conventions. 
* Introduced a new prefix for particle fluence (`flu_`) to ensure consistency in variable naming.


## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
