### PR TITLE
:bug: Add output parameter to cryostat_output function

### DIFF
--- a/process/build.py
+++ b/process/build.py
@@ -705,7 +705,7 @@ class Build:
         #  Other build quantities
 
         # Output the cryostat geometry
-        _ = self.cryostat_output()
+        _ = self.cryostat_output(output)
 
         # Output the cdivertor geometry
         divht = self.divgeom(output)
@@ -750,49 +750,51 @@ class Build:
                 build_variables.hpfu - (build_variables.hmax + build_variables.tfcth)
             ) / 2.0e0
 
-    def cryostat_output(self) -> None:
+    def cryostat_output(self, output: bool) -> None:
         """
         Outputs the cryostat geometry details to the output file.
 
         Returns:
             None
         """
-        po.oheadr(self.outfile, "Cryostat build")
-        po.ovarrf(
-            self.outfile,
-            "Cryostat thickness (m)",
-            "(dr_cryostat)",
-            build_variables.dr_cryostat,
-            "OP ",
-        )
-        po.ovarrf(
-            self.outfile,
-            "Cryostat intenral half height (m)",
-            "(z_cryostat_half_inside)",
-            fwbs_variables.z_cryostat_half_inside,
-            "OP ",
-        )
-        po.ovarrf(
-            self.outfile,
-            "Vertical clearance from highest PF coil to cryostat (m)",
-            "(dz_pf_cryostat)",
-            blanket_library.dz_pf_cryostat,
-            "OP ",
-        )
-        po.ovarrf(
-            self.outfile,
-            "Cryostat structure volume (m^3)",
-            "(vol_cryostat)",
-            fwbs_variables.vol_cryostat,
-            "OP ",
-        )
-        po.ovarrf(
-            self.outfile,
-            "Cryostat internal volume (m^3)",
-            "(vol_cryostat_internal)",
-            fwbs_variables.vol_cryostat_internal,
-            "OP ",
-        )
+        if output:
+            po.oheadr(self.outfile, "Cryostat build")
+
+            po.ovarrf(
+                self.outfile,
+                "Cryostat thickness (m)",
+                "(dr_cryostat)",
+                build_variables.dr_cryostat,
+                "OP ",
+            )
+            po.ovarrf(
+                self.outfile,
+                "Cryostat intenral half height (m)",
+                "(z_cryostat_half_inside)",
+                fwbs_variables.z_cryostat_half_inside,
+                "OP ",
+            )
+            po.ovarrf(
+                self.outfile,
+                "Vertical clearance from highest PF coil to cryostat (m)",
+                "(dz_pf_cryostat)",
+                blanket_library.dz_pf_cryostat,
+                "OP ",
+            )
+            po.ovarrf(
+                self.outfile,
+                "Cryostat structure volume (m^3)",
+                "(vol_cryostat)",
+                fwbs_variables.vol_cryostat,
+                "OP ",
+            )
+            po.ovarrf(
+                self.outfile,
+                "Cryostat internal volume (m^3)",
+                "(vol_cryostat_internal)",
+                fwbs_variables.vol_cryostat_internal,
+                "OP ",
+            )
 
     def divgeom(self, output: bool):
         """


### PR DESCRIPTION
This pull request includes changes to the `process/build.py` file to enhance the flexibility of the `cryostat_output` method by allowing it to conditionally output geometry details based on a boolean parameter.

Enhancements to conditional output:

* [`process/build.py`](diffhunk://#diff-910a8b8023bcc4dd91a6ab99138349fe076bbab94623695a8c20c4253da30bbfL753-R762): Modified the `cryostat_output` method to accept a boolean parameter `output`, which controls whether the cryostat geometry details are output to the file.
* [`process/build.py`](diffhunk://#diff-910a8b8023bcc4dd91a6ab99138349fe076bbab94623695a8c20c4253da30bbfL708-R708): Updated the `calculate_vertical_build` method to pass the `output` parameter to the `cryostat_output` method, ensuring consistent behavior based on the `output` flag.


## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
