### PR TITLE
:bug: Add cryostat internal radius output and update obsolete variables

### DIFF
--- a/process/build.py
+++ b/process/build.py
@@ -769,6 +769,13 @@ class Build:
             )
             po.ovarrf(
                 self.outfile,
+                "Cryostat internal radius (m)",
+                "(r_cryostat_inboard)",
+                fwbs_variables.r_cryostat_inboard,
+                "OP ",
+            )
+            po.ovarrf(
+                self.outfile,
                 "Cryostat intenral half height (m)",
                 "(z_cryostat_half_inside)",
                 fwbs_variables.z_cryostat_half_inside,

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -159,6 +159,10 @@ OBS_VARS = {
     "rnbeam": "f_nd_beam_electron",
     "ralpne": "f_nd_alpha_electron",
     "protium": "f_nd_protium_electrons",
+    "clhsf": "f_z_cryostat",
+    "ddwex": "dr_cryostat",
+    "clh1": "dz_tf_cryostat",
+    "rpf2dewar": "dr_pf_cryostat",
 }
 
 OBS_VARS_HELP = {


### PR DESCRIPTION


## Description

* Added a new `po.ovarrf` call to output the cryostat internal radius with the label "Cryostat internal radius (m)" and the variable `fwbs_variables.r_cryostat_inboard`. This allows `plot_proc.py` to plot the cryostat again.

* : Added new obsolete variable mappings for cryostat dimensions, including `clhsf`, `ddwex`, `clh1`, and `rpf2dewar`. This should have been included in #3501.


## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
