### PR TITLE
Fix variable names cut off in MFile

### DIFF
--- a/process/availability.py
+++ b/process/availability.py
@@ -4,13 +4,13 @@ import math
 from scipy.special import comb as combinations
 
 from process import fortran as ft
+from process import process_output as po
 from process.fortran import constraint_variables as ctv
 from process.fortran import cost_variables as cv
 from process.fortran import divertor_variables as dv
 from process.fortran import fwbs_variables as fwbsv
 from process.fortran import ife_variables as ifev
 from process.fortran import physics_variables as pv
-from process.fortran import process_output as po
 from process.fortran import tfcoil_variables as tfv
 from process.fortran import times_variables as tv
 from process.fortran import vacuum_variables as vacv

--- a/process/blanket_library.py
+++ b/process/blanket_library.py
@@ -5,6 +5,9 @@ author: G Graham, CCFE, Culham Science Centre
 
 import numpy as np
 
+from process import (
+    process_output as po,
+)
 from process.coolprop_interface import FluidProperties
 from process.fortran import (
     blanket_library,
@@ -21,9 +24,6 @@ from process.fortran import (
 )
 from process.fortran import (
     error_handling as eh,
-)
-from process.fortran import (
-    process_output as po,
 )
 from process.utilities.f2py_string_patch import f2py_compatible_to_string
 

--- a/process/build.py
+++ b/process/build.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 
+from process import process_output as po
 from process.blanket_library import dshellarea, eshellarea
 from process.fortran import (
     blanket_library,
@@ -17,7 +18,6 @@ from process.fortran import (
     physics_variables,
     tfcoil_variables,
 )
-from process.fortran import process_output as po
 from process.variables import AnnotatedVariable
 
 logger = logging.getLogger(__name__)

--- a/process/build.py
+++ b/process/build.py
@@ -973,7 +973,7 @@ class Build:
                 po.ovarrf(
                     self.outfile,
                     "Plasma geometric centre, radial (m)",
-                    "(physics_variables.rmajor.)",
+                    "(rmajor.)",
                     physics_variables.rmajor,
                     "OP ",
                 )
@@ -986,7 +986,7 @@ class Build:
                 )
                 po.ovarrf(
                     self.outfile,
-                    "Plasma lower physics_variables.triangularity",
+                    "Plasma lower triangularity",
                     "(tril)",
                     tril,
                     "OP ",
@@ -994,7 +994,7 @@ class Build:
                 po.ovarrf(
                     self.outfile,
                     "Plasma elongation",
-                    "(physics_variables.kappa.)",
+                    "(kappa.)",
                     kap,
                     "OP ",
                 )

--- a/process/buildings.py
+++ b/process/buildings.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 
+from process import process_output as po
 from process.fortran import (
     build_variables,
     buildings_variables,
@@ -15,7 +16,6 @@ from process.fortran import (
     physics_variables,
     tfcoil_variables,
 )
-from process.fortran import process_output as po
 
 logger = logging.getLogger(__name__)
 

--- a/process/costs.py
+++ b/process/costs.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from process import process_output as po
 from process.fortran import (
     build_variables,
     buildings_variables,
@@ -20,7 +21,6 @@ from process.fortran import (
     times_variables,
     vacuum_variables,
 )
-from process.fortran import process_output as po
 from process.variables import AnnotatedVariable
 
 

--- a/process/costs_2015.py
+++ b/process/costs_2015.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 
+from process import process_output as po
 from process.fortran import (
     build_variables,
     constants,
@@ -15,7 +16,6 @@ from process.fortran import (
     physics_variables,
     tfcoil_variables,
 )
-from process.fortran import process_output as po
 from process.variables import AnnotatedVariable
 
 logger = logging.getLogger(__name__)

--- a/process/current_drive.py
+++ b/process/current_drive.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from process import (
+    process_output as po,
+)
 from process.fortran import (
     constants,
     cost_variables,
@@ -9,9 +12,6 @@ from process.fortran import (
 )
 from process.fortran import (
     error_handling as eh,
-)
-from process.fortran import (
-    process_output as po,
 )
 from process.plasma_profiles import PlasmaProfile
 

--- a/process/dcll.py
+++ b/process/dcll.py
@@ -1,3 +1,6 @@
+from process import (
+    process_output as po,
+)
 from process.fortran import (
     build_variables,
     constants,
@@ -7,9 +10,6 @@ from process.fortran import (
     heat_transport_variables,
     physics_variables,
     primary_pumping_variables,
-)
-from process.fortran import (
-    process_output as po,
 )
 
 

--- a/process/divertor.py
+++ b/process/divertor.py
@@ -1,11 +1,11 @@
 import math
 
+from process import process_output as po
 from process.fortran import build_variables as bv
 from process.fortran import constants
 from process.fortran import divertor_variables as dv
 from process.fortran import error_handling as eh
 from process.fortran import physics_variables as pv
-from process.fortran import process_output as po
 from process.fortran import tfcoil_variables as tfv
 
 

--- a/process/final.py
+++ b/process/final.py
@@ -3,13 +3,13 @@
 from tabulate import tabulate
 
 from process import output as op
+from process import (
+    process_output as po,
+)
 from process.fortran import (
     constants,
     constraints,
     numerics,
-)
-from process.fortran import (
-    process_output as po,
 )
 from process.objectives import objective_function
 from process.utilities.f2py_string_patch import f2py_compatible_to_string

--- a/process/fw.py
+++ b/process/fw.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from process import (
+    process_output as po,
+)
 from process.coolprop_interface import FluidProperties
 from process.fortran import (
     constants,
@@ -8,9 +11,6 @@ from process.fortran import (
 )
 from process.fortran import (
     error_handling as eh,
-)
-from process.fortran import (
-    process_output as po,
 )
 from process.utilities.f2py_string_patch import f2py_compatible_to_string
 

--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from process import (
+    process_output as po,
+)
 from process.coolprop_interface import FluidProperties
 from process.fortran import (
     build_variables,
@@ -17,9 +20,6 @@ from process.fortran import (
 )
 from process.fortran import (
     error_handling as eh,
-)
-from process.fortran import (
-    process_output as po,
 )
 
 

--- a/process/ife.py
+++ b/process/ife.py
@@ -7,6 +7,7 @@ parameters of an Inertial Fusion Energy power plant.
 
 import numpy as np
 
+from process import process_output
 from process.fortran import (
     build_variables,
     buildings_variables,
@@ -17,7 +18,6 @@ from process.fortran import (
     heat_transport_variables,
     ife_variables,
     physics_variables,
-    process_output,
     structure_variables,
     vacuum_variables,
 )

--- a/process/init.py
+++ b/process/init.py
@@ -79,71 +79,71 @@ def run_summary():
     # Outfile and terminal #
     for outfile in [fortran.constants.nout, fortran.constants.iotty]:
         # PROCESS code header
-        fortran.process_output.oblnkl(outfile)
-        fortran.process_output.ostars(outfile, 110)
-        fortran.process_output.ocentr(outfile, "PROCESS", 110)
-        fortran.process_output.ocentr(outfile, "Power Reactor Optimisation Code", 110)
-        fortran.process_output.ostars(outfile, 110)
-        fortran.process_output.oblnkl(outfile)
+        process.process_output.oblnkl(outfile)
+        process.process_output.ostars(outfile, 110)
+        process.process_output.ocentr(outfile, "PROCESS", 110)
+        process.process_output.ocentr(outfile, "Power Reactor Optimisation Code", 110)
+        process.process_output.ostars(outfile, 110)
+        process.process_output.oblnkl(outfile)
 
         # Run execution details
         version = process.__version__
-        fortran.process_output.ocmmnt(outfile, f"Version : {version}")
+        process.process_output.ocmmnt(outfile, f"Version : {version}")
 
         git_branch, git_tag = get_git_summary()
 
-        fortran.process_output.ocmmnt(outfile, f"Git Tag : {git_tag}")
-        fortran.process_output.ocmmnt(outfile, f"Git Branch : {git_branch}")
+        process.process_output.ocmmnt(outfile, f"Git Tag : {git_tag}")
+        process.process_output.ocmmnt(outfile, f"Git Branch : {git_branch}")
 
         date_string = datetime.datetime.now(datetime.timezone.utc).strftime(
             "%d/%m/%Y %Z"
         )
         time_string = datetime.datetime.now(datetime.timezone.utc).strftime("%H:%M")
 
-        fortran.process_output.ocmmnt(outfile, f"Date : {date_string}")
-        fortran.process_output.ocmmnt(outfile, f"Time : {time_string}")
+        process.process_output.ocmmnt(outfile, f"Date : {date_string}")
+        process.process_output.ocmmnt(outfile, f"Time : {time_string}")
 
         user = getpass.getuser()
         machine = socket.gethostname()
 
-        fortran.process_output.ocmmnt(outfile, f"User : {user}")
-        fortran.process_output.ocmmnt(outfile, f"Computer : {machine}")
-        fortran.process_output.ocmmnt(outfile, f"Directory : {Path.cwd()}")
+        process.process_output.ocmmnt(outfile, f"User : {user}")
+        process.process_output.ocmmnt(outfile, f"Computer : {machine}")
+        process.process_output.ocmmnt(outfile, f"Directory : {Path.cwd()}")
 
         fileprefix = f2py_compatible_to_string(fortran.global_variables.fileprefix)
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile,
             f"Input : {fileprefix}",
         )
         runtitle = f2py_compatible_to_string(fortran.global_variables.runtitle)
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile,
             f"Run title : {runtitle}",
         )
 
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile,
             f"Run type : Reactor concept design: {f2py_compatible_to_string(fortran.global_variables.icase)}, (c) UK Atomic Energy Authority",
         )
 
-        fortran.process_output.oblnkl(outfile)
-        fortran.process_output.ostars(outfile, 110)
-        fortran.process_output.oblnkl(outfile)
+        process.process_output.oblnkl(outfile)
+        process.process_output.ostars(outfile, 110)
+        process.process_output.oblnkl(outfile)
 
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile, f"Equality constraints : {fortran.numerics.neqns.item()}"
         )
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile, f"Inequality constraints : {fortran.numerics.nineqns.item()}"
         )
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile,
             f"Total constraints : {fortran.numerics.nineqns.item() + fortran.numerics.neqns.item()}",
         )
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile, f"Iteration variables : {fortran.numerics.nvar.item()}"
         )
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile, f"Max iterations : {fortran.global_variables.maxcal.item()}"
         )
 
@@ -157,41 +157,41 @@ def run_summary():
         fom_string = f2py_compatible_to_string(
             fortran.numerics.lablmm[abs(fortran.numerics.minmax) - 1]
         )
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile,
             f"Figure of merit : {minmax_sign}{abs(fortran.numerics.minmax)}{minmax_string}{fom_string}",
         )
-        fortran.process_output.ocmmnt(
+        process.process_output.ocmmnt(
             outfile,
             f"Convergence parameter : {fortran.numerics.epsvmc}",
         )
 
-        fortran.process_output.oblnkl(outfile)
-        fortran.process_output.ostars(outfile, 110)
+        process.process_output.oblnkl(outfile)
+        process.process_output.ostars(outfile, 110)
 
     # MFile #
     mfile = fortran.constants.mfile
 
-    fortran.process_output.ovarst(mfile, "PROCESS version", "(procver)", f'"{version}"')
-    fortran.process_output.ovarst(mfile, "Date of run", "(date)", f'"{date_string}"')
-    fortran.process_output.ovarst(mfile, "Time of run", "(time)", f'"{time_string}"')
-    fortran.process_output.ovarst(mfile, "User", "(username)", f'"{user}"')
-    fortran.process_output.ovarst(
+    process.process_output.ovarst(mfile, "PROCESS version", "(procver)", f'"{version}"')
+    process.process_output.ovarst(mfile, "Date of run", "(date)", f'"{date_string}"')
+    process.process_output.ovarst(mfile, "Time of run", "(time)", f'"{time_string}"')
+    process.process_output.ovarst(mfile, "User", "(username)", f'"{user}"')
+    process.process_output.ovarst(
         mfile, "PROCESS run title", "(runtitle)", f'"{runtitle}"'
     )
-    fortran.process_output.ovarst(mfile, "PROCESS git tag", "(tagno)", f'"{git_tag}"')
-    fortran.process_output.ovarst(
+    process.process_output.ovarst(mfile, "PROCESS git tag", "(tagno)", f'"{git_tag}"')
+    process.process_output.ovarst(
         mfile, "PROCESS git branch", "(branch_name)", f'"{git_branch}"'
     )
-    fortran.process_output.ovarst(
+    process.process_output.ovarst(
         mfile, "Input filename", "(fileprefix)", f'"{fileprefix}"'
     )
 
-    fortran.process_output.ovarin(
+    process.process_output.ovarin(
         mfile, "Optimisation switch", "(ioptimz)", fortran.numerics.ioptimz
     )
     if fortran.numerics.ioptimz == -2:
-        fortran.process_output.ovarin(
+        process.process_output.ovarin(
             mfile, "Figure of merit switch", "(minmax)", fortran.numerics.minmax
         )
 

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -2050,7 +2050,7 @@ class PFCoil:
                 op.ovarre(
                     self.outfile,
                     "Residual manufacturing strain in CS superconductor material",
-                    "(tfcoil_variables.str_cs_con_res)",
+                    "(str_cs_con_res)",
                     tfv.str_cs_con_res,
                 )
                 op.ovarre(

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -9,6 +9,7 @@ from scipy.special import ellipe, ellipk
 
 import process.superconductors as superconductors
 from process import fortran as ft
+from process import process_output as op
 from process.fortran import build_variables as bv
 from process.fortran import constants, numerics
 from process.fortran import constraint_variables as ctv
@@ -18,7 +19,6 @@ from process.fortran import fwbs_variables as fwbsv
 from process.fortran import pfcoil_module as pf
 from process.fortran import pfcoil_variables as pfv
 from process.fortran import physics_variables as pv
-from process.fortran import process_output as op
 from process.fortran import rebco_variables as rcv
 from process.fortran import tfcoil_variables as tfv
 from process.fortran import times_variables as tv

--- a/process/physics.py
+++ b/process/physics.py
@@ -9,6 +9,9 @@ from scipy.optimize import root_scalar
 import process.confinement_time as confinement
 import process.impurity_radiation as impurity_radiation
 import process.physics_functions as physics_funcs
+from process import (
+    process_output as po,
+)
 from process.fortran import (
     build_variables,
     constants,
@@ -26,9 +29,6 @@ from process.fortran import (
     reinke_variables,
     stellarator_variables,
     times_variables,
-)
-from process.fortran import (
-    process_output as po,
 )
 from process.utilities.f2py_string_patch import f2py_compatible_to_string
 

--- a/process/power.py
+++ b/process/power.py
@@ -3,6 +3,7 @@ import math
 
 import numpy as np
 
+from process import process_output as po
 from process.fortran import (
     build_variables,
     buildings_variables,
@@ -22,7 +23,6 @@ from process.fortran import (
     tfcoil_variables,
     times_variables,
 )
-from process.fortran import process_output as po
 from process.variables import AnnotatedVariable
 
 logger = logging.getLogger(__name__)

--- a/process/power.py
+++ b/process/power.py
@@ -971,7 +971,7 @@ class Power:
 
         po.ovarre(
             self.outfile,
-            "Sum = Total heat removal at cryogenic temperatures (tfcoil_variables.tmpcry & tfcoil_variables.tcoolin) (MW)",
+            "Sum = Total heat removal at cryogenic temperatures (tmpcry & tcoolin) (MW)",
             "(helpow + helpow_cryal/1.0d6)",
             (heat_transport_variables.helpow + heat_transport_variables.helpow_cryal)
             * 1.0e-6,

--- a/process/process_output.py
+++ b/process/process_output.py
@@ -1,0 +1,17 @@
+from process.fortran import process_output_fortran
+
+ocentr = process_output_fortran.ocentr
+ostars = process_output_fortran.ostars
+oheadr = process_output_fortran.oheadr
+oshead = process_output_fortran.oshead
+oblnkl = process_output_fortran.oblnkl
+osubhd = process_output_fortran.osubhd
+ocmmnt = process_output_fortran.ocmmnt
+write = process_output_fortran.write
+dblcol = process_output_fortran.dblcol
+ovarrf = process_output_fortran.ovarrf
+ovarre = process_output_fortran.ovarre
+ovarin = process_output_fortran.ovarin
+ovarst = process_output_fortran.ovarst
+ocosts = process_output_fortran.ocosts
+obuild = process_output_fortran.obuild

--- a/process/process_output.py
+++ b/process/process_output.py
@@ -1,5 +1,9 @@
-from process.fortran import process_output_fortran
+import numpy as np
 
+from process.fortran import constants, process_output_fortran
+
+# necessary to avoid using process_output in the code through
+# two different interfaces
 ocentr = process_output_fortran.ocentr
 ostars = process_output_fortran.ostars
 oheadr = process_output_fortran.oheadr
@@ -9,9 +13,33 @@ osubhd = process_output_fortran.osubhd
 ocmmnt = process_output_fortran.ocmmnt
 write = process_output_fortran.write
 dblcol = process_output_fortran.dblcol
-ovarrf = process_output_fortran.ovarrf
-ovarre = process_output_fortran.ovarre
 ovarin = process_output_fortran.ovarin
 ovarst = process_output_fortran.ovarst
-ocosts = process_output_fortran.ocosts
 obuild = process_output_fortran.obuild
+
+
+def ovarre(file, descr: str, varnam: str, value, output_flag: str = ""):
+    replacement_character = "_"
+    if file != constants.mfile:
+        replacement_character = " "
+
+    description = f"{descr:<72}".replace(" ", replacement_character)
+    varname = f"{varnam:<30}".replace(" ", replacement_character)
+
+    if isinstance(value, np.ndarray):
+        value = value.item()
+    elif isinstance(value, str):
+        value = float(value)
+
+    line = f"{description}{replacement_character} {varname}{replacement_character} {value:.17e} {output_flag}"
+    write(file, line)
+    if file != constants.mfile:
+        ovarre(constants.mfile, descr, varnam, value, output_flag)
+
+
+def ocosts(file, varnam: str, descr: str, value):
+    ovarre(file, descr, varnam, value)
+
+
+def ovarrf(file, descr: str, varnam: str, value, output_flag: str = ""):
+    ovarre(file, descr, varnam, value, output_flag)

--- a/process/pulse.py
+++ b/process/pulse.py
@@ -1,3 +1,4 @@
+from process import process_output as po
 from process.fortran import (
     constants,
     constraint_variables,
@@ -9,7 +10,6 @@ from process.fortran import (
     pulse_variables,
     times_variables,
 )
-from process.fortran import process_output as po
 
 
 class Pulse:

--- a/process/sctfcoil.py
+++ b/process/sctfcoil.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy import optimize
 
 import process.superconductors as superconductors
+from process import process_output as po
 from process.fortran import (
     build_variables,
     constants,
@@ -21,7 +22,6 @@ from process.fortran import (
     sctfcoil_module,
     tfcoil_variables,
 )
-from process.fortran import process_output as po
 from process.utilities.f2py_string_patch import f2py_compatible_to_string
 
 logger = logging.getLogger(__name__)

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -6,6 +6,9 @@ import numpy as np
 
 import process.physics_functions as physics_funcs
 import process.superconductors as superconductors
+from process import (
+    process_output as po,
+)
 from process.coolprop_interface import FluidProperties
 from process.fortran import (
     build_variables,
@@ -29,9 +32,6 @@ from process.fortran import (
     stellarator_variables,
     structure_variables,
     tfcoil_variables,
-)
-from process.fortran import (
-    process_output as po,
 )
 from process.fortran import (
     stellarator_module as st,

--- a/process/structure.py
+++ b/process/structure.py
@@ -3,13 +3,13 @@ import math
 
 import numpy as np
 
+from process import process_output as po
 from process.fortran import build_variables as bv
 from process.fortran import constants
 from process.fortran import divertor_variables as divv
 from process.fortran import fwbs_variables as fwbsv
 from process.fortran import pfcoil_variables as pfv
 from process.fortran import physics_variables as pv
-from process.fortran import process_output as po
 from process.fortran import structure_variables as stv
 from process.fortran import tfcoil_variables as tfv
 

--- a/process/tfcoil.py
+++ b/process/tfcoil.py
@@ -3,12 +3,12 @@ import copy
 import numpy as np
 
 from process import fortran as ft
+from process import process_output as po
 from process.build import Build
 from process.fortran import build_variables as bv
 from process.fortran import constants
 from process.fortran import error_handling as eh
 from process.fortran import fwbs_variables as fwbsv
-from process.fortran import process_output as po
 from process.fortran import tfcoil_variables as tfv
 from process.sctfcoil import Sctfcoil
 

--- a/process/vacuum.py
+++ b/process/vacuum.py
@@ -3,11 +3,11 @@ import math
 
 import numpy as np
 
+from process import process_output as po
 from process.fortran import build_variables as buv
 from process.fortran import constants
 from process.fortran import error_handling as eh
 from process.fortran import physics_variables as pv
-from process.fortran import process_output as po
 from process.fortran import tfcoil_variables as tfv
 from process.fortran import times_variables as tv
 from process.fortran import vacuum_variables as vacv

--- a/process/water_use.py
+++ b/process/water_use.py
@@ -1,7 +1,7 @@
 import numpy as np
 
+from process import process_output as po
 from process.fortran import constants, heat_transport_variables, water_usage_variables
-from process.fortran import process_output as po
 
 SECDAY = 86400e0
 

--- a/source/fortran/error_handling.f90
+++ b/source/fortran/error_handling.f90
@@ -271,7 +271,7 @@ contains
     !
     ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     use constants, only: iotty, nout
-    use process_output, only: oblnkl, oheadr, ocmmnt, ovarin, ostars
+    use process_output_fortran, only: oblnkl, oheadr, ocmmnt, ovarin, ostars
     implicit none
 
     !  Arguments

--- a/source/fortran/init_module.f90
+++ b/source/fortran/init_module.f90
@@ -81,7 +81,7 @@ contains
 
       use process_input, only: nin
       use constants, only: iotty, mfile, nout, nplot, opt_file, vfile
-      use process_output, only: oheadr
+      use process_output_fortran, only: oheadr
       use global_variables, only: verbose
       implicit none
 

--- a/source/fortran/output.f90
+++ b/source/fortran/output.f90
@@ -332,75 +332,6 @@ contains
     10 format(1x,a,t75,f10.2,t100,f10.2)
   end subroutine dblcol
 
-  subroutine ovarrf(file,descr,varnam,value,output_flag)
-
-    !! Routine to print out the details of a floating-point
-    !! variable using 'F' format
-    !! author: P J Knight, CCFE, Culham Science Centre
-    !! file : input integer : Fortran output unit identifier
-    !! descr : input character string : Description of the variable
-    !! varnam : input character string : Name of the variable
-    !! value : input real : Value of the variable
-    !! output_flag : optional character
-    !! This routine writes out the description, name and value of a
-    !! double precision variable in F format (e.g.
-    !! <CODE>-12345.000</CODE>).
-    !!     !
-    ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-    use numerics, only: name_xc
-		use global_variables, only: verbose
-		use constants, only: pi, mfile, nplot, electron_charge
-    implicit none
-
-    !  Arguments
-
-    integer, intent(in) :: file
-    character(len=*), intent(in) :: descr, varnam
-    real(8), intent(in) :: value
-    character(len=3), intent(in), optional :: output_flag
-
-    !  Local variables
-
-    character(len=72) :: dum72
-    character(len=20) :: dum20
-    character(len=20) :: stripped
-    character(len=3) :: flag
-    ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-    !  Replace descr and varnam with dummy strings of the correct length.
-    !  This counters problems that would occur if the two original strings
-    !  were the wrong length.
-
-    dum72 = descr
-    dum20 = varnam
-    stripped = varnam(2:len(varnam)-1)
-
-    if (present(output_flag)) then
-        flag = output_flag
-    else
-        flag = ''
-    end if
-
-    if (any(name_xc == stripped))  flag = 'ITV'
-
-    if (file /= mfile) then
-       !MDK add label if it is an iteration variable
-       ! The ITV flag overwrites the output_flag
-       if (verbose==1) then
-            write(file,10) dum72, dum20, value, flag
-       else
-            write(file,20) dum72, dum20, value, flag
-       end if
-    end if
-
-10  format(1x,a,t75,a,t100,f13.6, t115, a)
-20  format(1x,a,t75,a,t100,f10.3, t112, a)
-
-    call ovarre(mfile,descr,varnam,value)
-
-  end subroutine ovarrf
-
   ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   subroutine ovarre(file,descr,varnam,value,output_flag)
@@ -599,52 +530,6 @@ contains
 10  format(1x,a,t75,a,t110,a)
 
   end subroutine ovarst
-
-  ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  subroutine ocosts(file,ccode,descr,value)
-
-    !! Routine to print out the code, description and value
-    !! of a cost item
-    !! author: P J Knight, CCFE, Culham Science Centre
-    !! file : input integer : Fortran output unit identifier
-    !! ccode : input character string : Code number/name of the cost item
-    !! descr : input character string : Description of the cost item
-    !! value : input real : Value of the cost item
-    !! This routine writes out the cost code, description and value
-    !! of a cost item.
-    !!     !
-    ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-		use constants, only: pi, mfile, nplot, twopi
-    implicit none
-
-    !  Arguments
-
-    integer, intent(in) :: file
-    character(len=*), intent(in) :: ccode, descr
-    real(8), intent(in) :: value
-
-    !  Local variables
-
-    character(len=30) :: dum20
-    character(len=72) :: dum72
-
-    ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-    !  Replace ccode and descr with dummy strings of the correct length.
-    !  This counters problems that would occur if the two original strings
-    !  were the wrong length.
-
-    dum20 = ccode
-    dum72 = descr
-
-    write(file,10) dum20, dum72, value
-10  format(1x,a,t22,a,t110,f10.2)
-
-    call ovarrf(mfile,descr,ccode,value)
-
-  end subroutine ocosts
 
   ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/source/fortran/output.f90
+++ b/source/fortran/output.f90
@@ -1,6 +1,6 @@
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-module process_output
+module process_output_fortran
 
   !! Module containing routines to produce a uniform output style
   !! author: P J Knight, CCFE, Culham Science Centre
@@ -860,4 +860,4 @@ contains
 
   end function int_to_string3
 
-end module process_output
+end module process_output_fortran

--- a/source/fortran/scan.f90
+++ b/source/fortran/scan.f90
@@ -150,7 +150,7 @@ contains
   subroutine scan_1d_write_point_header(iscan)
     use global_variables, only: iscan_global, xlabel, vlabel
     use constants, only: mfile, nout
-    use process_output, only: ovarin, ostars, oblnkl
+    use process_output_fortran, only: ovarin, ostars, oblnkl
     implicit none
     integer, intent(in) :: iscan
     !! Scan point number
@@ -189,7 +189,7 @@ contains
     use impurity_radiation_module, only: fimp
     use pfcoil_variables, only: whtpf
     use pf_power_variables, only: srcktpm
-    use process_output, only: oblnkl
+    use process_output_fortran, only: oblnkl
     use numerics, only: sqsumsq
     use tfcoil_variables, only: tfareain, wwp2, sig_tf_wp, tfcmw, tcpmax, oacdcp, &
       tfcpmw, fcutfsu, acond, fcoolcp, rcool, whttf, ppump, vcool, wwp1, n_tf_coils, &
@@ -296,7 +296,7 @@ contains
   subroutine scan_1d_write_plot(iscan, outvar)
     use global_variables, only: icase, xlabel
     use constants, only: nplot, mfile
-    use process_output, only: ovarin
+    use process_output_fortran, only: ovarin
     implicit none
 
     integer, intent(inout) :: iscan
@@ -408,7 +408,7 @@ contains
     !! author: J Morris, UKAEA, Culham Science Centre
     ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     use constants, only: mfile
-    use process_output, only: ovarin
+    use process_output_fortran, only: ovarin
     implicit none
 
     !  Set up labels for plotting output
@@ -422,7 +422,7 @@ contains
   end subroutine scan_2d_init
 
   subroutine scan_2d_write_point_header(iscan, iscan_1, iscan_2, iscan_R)
-    use process_output, only: oblnkl, ostars, ovarin
+    use process_output_fortran, only: oblnkl, ostars, ovarin
     use global_variables, only: vlabel, vlabel_2, xlabel, xlabel_2, iscan_global
     use constants, only: nout, mfile
     implicit none
@@ -870,7 +870,7 @@ contains
   use constraints
   use error_handling
   use numerics
-  use process_output
+  use process_output_fortran
   use utilities, only:upper_case
   ! for ipedestal = 2 option
   use global_variables, only: convergence_parameter
@@ -1128,7 +1128,7 @@ subroutine verror(ifail)
   ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   use constants, only: nout, iotty
-  use process_output, only: ocmmnt, oblnkl
+  use process_output_fortran, only: ocmmnt, oblnkl
   implicit none
 
   !  Arguments


### PR DESCRIPTION
Closes #3427 

Makes the entire output interface in Python which often just calls the underlying Fortran function. 

There is a Python implementation of the `ovarre`, `ocosts`, and `ovarrf` functions, with the latter two using the former. This will cause a _slight_ change in the OUT.DAT which won't have `1.234F5` style variables, instead `1.234e5`.

The Fortran implementations of `ocosts` and `ovarrf` are removed. `ovarre`'s Fortran implementation can be removed in the scan conversion #3526. 

[new_large_tokamak_nof.MFILE.DAT.txt](https://github.com/user-attachments/files/18708801/new_large_tokamak_nof.MFILE.DAT.txt)
[new_large_tokamak_nof.OUT.DAT.txt](https://github.com/user-attachments/files/18708802/new_large_tokamak_nof.OUT.DAT.txt)
[old_large_tokamak_nof.MFILE.DAT.txt](https://github.com/user-attachments/files/18708803/old_large_tokamak_nof.MFILE.DAT.txt)
[old_large_tokamak_nof.OUT.DAT.txt](https://github.com/user-attachments/files/18708804/old_large_tokamak_nof.OUT.DAT.txt)


[new_large_tokamak_once_through.MFILE.DAT.txt](https://github.com/user-attachments/files/18708812/new_large_tokamak_once_through.MFILE.DAT.txt)
[new_large_tokamak_once_through.OUT.DAT.txt](https://github.com/user-attachments/files/18708813/new_large_tokamak_once_through.OUT.DAT.txt)
[old_large_tokamak_once_through.MFILE.DAT.txt](https://github.com/user-attachments/files/18708814/old_large_tokamak_once_through.MFILE.DAT.txt)
[old_large_tokamak_once_through.OUT.DAT.txt](https://github.com/user-attachments/files/18708815/old_large_tokamak_once_through.OUT.DAT.txt)


By eye, some of these have more decimal places but @jonmaddock please double check this still respects your 17 sig fig changes.

This also changes the cost output from 
```
(c211)              Site improvements, facilities, land (M$)                                                     35.20
```
to
```
Site improvements, facilities, land (M$)                                (c211)                        3.52000000000000028e+01
```

I also corrected some namespaced outputs that I found along the way e.g. `physics_variables.rmajor.` to `rmajor.`

