### PR TITLE
Remove unused pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-      - id: check-docstring-first
       - id: check-merge-conflict
-      - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.3
     hooks:


### PR DESCRIPTION
These pre-commit checks should now be caught by `ruff` and in some cases may conflict with it.
