### PR TITLE
:art: Add divertor plotting functionality to poloidal cross-section

### DIFF
--- a/process/build.py
+++ b/process/build.py
@@ -826,8 +826,6 @@ class Build:
         determine the maximum height.
         TART option: Peng SOFT paper
         """
-        if physics_variables.itart == 1:
-            return 1.75e0 * physics_variables.rminor
         #  Conventional tokamak divertor model
         #  options for seperate upper and lower physics_variables.triangularity
 
@@ -1478,7 +1476,9 @@ class Build:
                     self.outfile,
                     "ERROR: null value not supported, check i_single_null value.",
                 )
-        return divht
+        return (
+            1.75e0 * physics_variables.rminor if physics_variables.itart == 1 else divht
+        )
 
     def ripple_amplitude(self, ripmax: float, r_tf_outboard_mid: float) -> float:
         """

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -335,6 +335,7 @@ def poloidal_cross_section(axis, mfile_data, scan, demo_ranges, colour_scheme):
     plot_shield(axis, mfile_data, scan, colour_scheme)
     plot_blanket(axis, mfile_data, scan, colour_scheme)
     plot_firstwall(axis, mfile_data, scan, colour_scheme)
+    plot_divertor(axis, mfile_data, scan)
 
     plot_plasma(axis, mfile_data, scan, colour_scheme)
     plot_centre_cross(axis, mfile_data, scan)
@@ -2010,6 +2011,98 @@ def plot_tf_wp(axis, mfile_data, scan: int) -> None:
         axis.set_xlabel("Radial distance [m]")
         axis.set_ylabel("Toroidal distance [m]")
         axis.legend(bbox_to_anchor=(1.05, 1.0), loc="upper left")
+
+
+def plot_divertor(axis, mfile_data, scan: int) -> None:
+    """
+    Plots inboard and outboard divertor plates and strike points.
+    Author: C. Ashe
+
+    Parameters
+    ----------
+    axis : matplotlib.axes object
+        Axis object to plot to.
+    mfile_data : MFILE data object
+        Object containing data for the plot.
+    scan : int
+        Scan number to use.
+
+    Returns
+    -------
+    None
+    """
+    # Plot the outboard divertor
+    i_single_null = mfile_data.data["i_single_null"].get_scan(scan)
+
+    r_outer_plate_top = mfile_data.data["rplto"].get_scan(scan)
+    z_outer_plate_top = mfile_data.data["zplto"].get_scan(scan)
+    r_outer_plate_bottom = mfile_data.data["rplbo"].get_scan(scan)
+    z_outer_plate_bottom = mfile_data.data["zplbo"].get_scan(scan)
+
+    # Plot the outboard lower plate
+    axis.plot(
+        [r_outer_plate_top, r_outer_plate_bottom],
+        [z_outer_plate_top, z_outer_plate_bottom],
+        color="black",
+    )
+
+    r_inner_plate_top = mfile_data.data["rplti"].get_scan(scan)
+    z_inner_plate_top = mfile_data.data["zplti"].get_scan(scan)
+    r_inner_plate_bottom = mfile_data.data["rplbi"].get_scan(scan)
+    z_inner_plate_bottom = mfile_data.data["zplbi"].get_scan(scan)
+
+    # Plot the inboard lower plate
+    axis.plot(
+        [r_inner_plate_top, r_inner_plate_bottom],
+        [z_inner_plate_top, z_inner_plate_bottom],
+        color="black",
+    )
+
+    r_outer_strike = mfile_data.data["rspo"].get_scan(scan)
+    z_outer_strike = mfile_data.data["zspo"].get_scan(scan)
+
+    r_inner_strike = mfile_data.data["rspi"].get_scan(scan)
+    z_inner_strike = mfile_data.data["zspi"].get_scan(scan)
+
+    # Plot the outer strike point
+    axis.plot(
+        r_outer_strike,
+        z_outer_strike,
+        "ro",
+        markersize=2.5,
+    )  # Plot outer strike point as red dot
+
+    # Plot the inner strike point
+    axis.plot(
+        r_inner_strike,
+        z_inner_strike,
+        "ro",
+        markersize=2.5,
+    )  # Plot inner strike point as red dot
+
+    # If their is 2 divertors
+    if i_single_null == 0:
+        # Plot the outer top plate
+        axis.plot(
+            [r_outer_plate_top, r_outer_plate_bottom],
+            [-z_outer_plate_top, -z_outer_plate_bottom],
+            color="black",
+        )
+
+        # Plot the inner top plate
+        axis.plot(
+            [r_inner_plate_top, r_inner_plate_bottom],
+            [-z_inner_plate_top, -z_inner_plate_bottom],
+            color="black",
+        )
+
+        # Plot the outer strike point
+        axis.plot(
+            r_outer_strike, -z_outer_strike, "ro", markersize=2.5
+        )  # Plot outer strike point as red dot
+
+        # Plot the inner strike point
+        axis.plot(r_inner_strike, -z_inner_strike, "ro", markersize=2.5)
 
 
 def plot_tf_turn(axis, mfile_data, scan: int) -> None:


### PR DESCRIPTION
This pull request introduces a new function to plot divertor components in the `process/io/plot_proc.py` file. The most important changes include the addition of the `plot_divertor` function and its integration into the `poloidal_cross_section` function.

### Enhancements to plotting functionality:

* [`process/io/plot_proc.py`](diffhunk://#diff-de8cbbae67807864f29d871a0d586c28f774d3f52eb7ef4c91612b72d05588b6R2016-R2093): Added a new function `plot_divertor` to plot inboard and outboard divertor plates and strike points. This function includes detailed docstrings and plotting logic for the divertor components.
* [`process/io/plot_proc.py`](diffhunk://#diff-de8cbbae67807864f29d871a0d586c28f774d3f52eb7ef4c91612b72d05588b6R338): Modified the `poloidal_cross_section` function to call the new `plot_divertor` function, ensuring the divertor components are included in the poloidal cross-section plots.
* Divertor plates are given with black lines and red dots show the calculated strike point positions

For `large_tokamak` with a single divertor:

![image](https://github.com/user-attachments/assets/73a86cb7-75db-4fe5-9245-b10676cab3ad)

-------------------------

For `large_tokamak` with a double divertor:

![image](https://github.com/user-attachments/assets/e74da17c-f7b5-4ef6-9193-f9f8e025bda9)

---------------------

:bug: Bugs

- In the `divgeom()` function the calculation of the divertor properties and output is never done for a spherical tokamak (`itart=1`) as an early return statemet breaks from the function. This has now been moved to the end of the function which allows the divertor geometry to now be plotted in the output and so can now be plotted.
```python
determine the maximum height.
        TART option: Peng SOFT paper
        """
        if physics_variables.itart == 1:
            return 1.75e0 * physics_variables.rminor
        #  Conventional tokamak divertor model
```

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
