### PR TITLE
Rename scaled itv bounds

### DIFF
--- a/process/optimiser.py
+++ b/process/optimiser.py
@@ -33,8 +33,8 @@ class Optimiser:
         # Trim maximum size arrays down to actually used size
         n = numerics.nvar
         x = numerics.xcm[:n]
-        bndl = numerics.bondl[:n]
-        bndu = numerics.bondu[:n]
+        bndl = numerics.itv_scaled_lower_bounds[:n]
+        bndu = numerics.itv_scaled_upper_bounds[:n]
 
         # Define total number of constraints and equality constraints
         m = numerics.neqns + numerics.nineqns

--- a/process/scan.py
+++ b/process/scan.py
@@ -335,8 +335,8 @@ class Scan:
             name = f2py_compatible_to_string(numerics.lablxc[numerics.ixc[i] - 1])
             solution_vector_table.append([name, numerics.xcs[i], numerics.xcm[i]])
 
-            xminn = 1.01 * numerics.bondl[i]
-            xmaxx = 0.99 * numerics.bondu[i]
+            xminn = 1.01 * numerics.itv_scaled_lower_bounds[i]
+            xmaxx = 0.99 * numerics.itv_scaled_upper_bounds[i]
 
             if numerics.xcm[i] < xminn or numerics.xcm[i] > xmaxx:
                 if not written_warning:
@@ -359,7 +359,7 @@ class Scan:
                 process_output.write(
                     constants.nout,
                     f"   {name:<30}= {xcval} is at or {location} its {bound} bound:"
-                    f" {numerics.bondu[i] * numerics.scafc[i]}",
+                    f" {numerics.itv_scaled_upper_bounds[i] * numerics.scafc[i]}",
                 )
 
             process_output.ovarre(
@@ -374,8 +374,11 @@ class Scan:
             else:
                 xnorm = min(
                     max(
-                        (numerics.xcm[i] - numerics.bondl[i])
-                        / (numerics.bondu[i] - numerics.bondl[i]),
+                        (numerics.xcm[i] - numerics.itv_scaled_lower_bounds[i])
+                        / (
+                            numerics.itv_scaled_upper_bounds[i]
+                            - numerics.itv_scaled_lower_bounds[i]
+                        ),
                         0.0,
                     ),
                     1.0,

--- a/source/fortran/iteration_variables.f90
+++ b/source/fortran/iteration_variables.f90
@@ -4424,7 +4424,7 @@ contains
     !!     !
     ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    use numerics, only: nvar, bondl, bondu, scale, ixc, boundl, boundu
+    use numerics, only: nvar, itv_scaled_lower_bounds, itv_scaled_upper_bounds, scale, ixc, boundl, boundu
 
     implicit none
 
@@ -4435,8 +4435,8 @@ contains
     ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     do i = 1,nvar
-       bondl(i) = boundl(ixc(i))*scale(i)
-       bondu(i) = boundu(ixc(i))*scale(i)
+       itv_scaled_lower_bounds(i) = boundl(ixc(i))*scale(i)
+       itv_scaled_upper_bounds(i) = boundu(ixc(i))*scale(i)
     end do
 
   end subroutine boundxc

--- a/source/fortran/numerics.f90
+++ b/source/fortran/numerics.f90
@@ -407,11 +407,21 @@ module numerics
   ! !!  boundu(ipnvars) /../ : upper bounds used on ixc variables
 
   real(dp), dimension(ipnvars) :: bondl
+  !! Upper bound of the ixc variables scaled to (divided by)
+  !! the initial value of the corresponding ixc
+
   real(dp), dimension(ipnvars) :: bondu
+  !! Lower bound of the ixc variables scaled to (divided by)
+  !! the initial value of the corresponding ixc
+
   real(dp), dimension(ipnvars) :: rcm
   real(dp), dimension(ipnvars) :: resdl
   real(dp), dimension(ipnvars) :: scafc
+  !! The initial value of each ixc variable
+
   real(dp), dimension(ipnvars) :: scale
+  !! The reciprocal of the initial value of each ixc variable
+
   real(dp), dimension(ipnvars) :: xcm
   real(dp), dimension(ipnvars) :: xcs
   real(dp), dimension(ipvlam)  :: vlam

--- a/source/fortran/numerics.f90
+++ b/source/fortran/numerics.f90
@@ -406,12 +406,12 @@ module numerics
   real(dp), dimension(ipnvars) :: boundu
   ! !!  boundu(ipnvars) /../ : upper bounds used on ixc variables
 
-  real(dp), dimension(ipnvars) :: bondl
-  !! Upper bound of the ixc variables scaled to (divided by)
+  real(dp), dimension(ipnvars) :: itv_scaled_lower_bounds
+  !! Lower bound of the ixc variables scaled to (divided by)
   !! the initial value of the corresponding ixc
 
-  real(dp), dimension(ipnvars) :: bondu
-  !! Lower bound of the ixc variables scaled to (divided by)
+  real(dp), dimension(ipnvars) :: itv_scaled_upper_bounds
+  !! Upper bound of the ixc variables scaled to (divided by)
   !! the initial value of the corresponding ixc
 
   real(dp), dimension(ipnvars) :: rcm
@@ -585,8 +585,8 @@ contains
     ! Issue #287 These bounds now defined in initial.f90
     boundu = 9.d99
 
-    bondl = 0.0D0
-    bondu = 0.0D0
+    itv_scaled_lower_bounds = 0.0D0
+    itv_scaled_upper_bounds = 0.0D0
     rcm = 0.0D0
     resdl = 0.0D0
     scafc = 0.0D0


### PR DESCRIPTION
The _scaled_ itv lower and upper bounds were too similar to their non-scaled counterparts, leading to bugs and confusion (e.g. when I was converting scan). 