### PR TITLE
Run regression input file even where no reference exists

### DIFF
--- a/tests/regression/test_process_input_files.py
+++ b/tests/regression/test_process_input_files.py
@@ -284,12 +284,14 @@ def test_input_file(
         scenario.scenario_name, tmp_path
     )
 
+    scenario.run(solver_name)
+
     # reference MFile cannot be found?
-    # should the file be allowed to run just to test it converges (with a warning about no comparison)?
+    # raise an error after the file is run so that any errors while running the input file
+    # are raised first.
     if reference_mfile is None:
-        pytest.skip(
-            reason=f"A reference input file cannot be found for {scenario.scenario_name}"
+        raise RuntimeError(
+            "No reference input file exists (so cannot compare results). The input file ran without any exceptions."
         )
 
-    scenario.run(solver_name)
     scenario.compare(reference_mfile, reg_tolerance, opt_params_only)


### PR DESCRIPTION
We now run an input file even when no reference exists. This is important because, when new input files are added, a reference does not exist but the file may encounter errors (e.g. obsolete variables).

The output of running `pytest tests/regression/ -k once` is now (when I have added an input file with no reference):
```
============================================================ short test summary info =============================================================
FAILED tests/regression/test_process_input_files.py::test_input_file[no_reference_once_through] - RuntimeError: No reference input file exists (so cannot compare results). The input file ran without any exceptions.
============================================= 1 failed, 3 passed, 5 deselected, 9 warnings in 5.80s ==============================================
```