### PR TITLE
3569 some variables removed from output

### DIFF
--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -1554,3 +1554,21 @@ class CCFE_HCPB:
             "(etaiso)",
             fwbs_variables.etaiso,
         )
+        po.ovarre(
+            self.outfile,
+            "First wall area (m2)",
+            "(a_fw_total)",
+            build_variables.a_fw_total,
+        )
+        po.ovarre(
+            self.outfile,
+            "Divertor area (m2)",
+            "(divsur)",
+            divertor_variables.divsur,
+        )
+        po.ovarre(
+            self.outfile,
+            "Divertor mass (kg)",
+            "(divmas)",
+            divertor_variables.divmas,
+        )

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -207,7 +207,7 @@ OBS_VARS = {
     "iblanket": "i_blanket_type",
     "fw_wall": "dr_fw_wall",
     "fwpressure": "pres_fw_coolant",
-    "fwoutlet": "temp_fw_coolant_outlet",
+    "fwoutlet": "temp_fw_coolant_out",
     "afw": "radius_fw_channel",
     "peaking_factor": "f_fw_peak",
     "fwinlet": "temp_fw_coolant_in",


### PR DESCRIPTION
## Description

Adds back in some useful variables that have been removed from the output.
- FW area - `a_fw_total`
- Divertor area - `divsur`
- Divertor mass - `divmas`

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
