### PR TITLE
Replace stellarator only variable for first wall coolant channel with general use variable 

### DIFF
--- a/process/input.py
+++ b/process/input.py
@@ -153,8 +153,6 @@ INPUT_VARIABLES = {
     "abktflnc": InputVariable(fortran.cost_variables, float, range=(0.1, 100.0)),
     "adivflnc": InputVariable(fortran.cost_variables, float, range=(0.1, 100.0)),
     "admv": InputVariable(fortran.buildings_variables, float, range=(1.0e4, 1.0e6)),
-    "afwi": InputVariable(fortran.fwbs_variables, float, range=(0.001, 0.05)),
-    "afwo": InputVariable(fortran.fwbs_variables, float, range=(0.001, 0.05)),
     "airtemp": InputVariable(fortran.water_usage_variables, float, range=(-15.0, 40.0)),
     "alfapf": InputVariable(fortran.pfcoil_variables, float, range=(1e-12, 1.0)),
     "alstroh": InputVariable(

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -1409,10 +1409,14 @@ class Stellarator:
                 bfwo = 0.5e0 * build_variables.dr_fw_outboard
 
                 f_a_fw_coolant_inboard = (
-                    fwbs_variables.afwi * fwbs_variables.afwi / (bfwi * bfwi)
+                    fwbs_variables.radius_fw_channel
+                    * fwbs_variables.radius_fw_channel
+                    / (bfwi * bfwi)
                 )  # inboard FW coolant void fraction
                 f_a_fw_coolant_outboard = (
-                    fwbs_variables.afwo * fwbs_variables.afwo / (bfwo * bfwo)
+                    fwbs_variables.radius_fw_channel
+                    * fwbs_variables.radius_fw_channel
+                    / (bfwo * bfwo)
                 )  # outboard FW coolant void fraction
 
                 #  First wall decay length (m) - improved calculation required

--- a/source/fortran/fwbs_variables.f90
+++ b/source/fortran/fwbs_variables.f90
@@ -300,14 +300,6 @@ module fwbs_variables
   !! - =2 pressurized water
   !#TODO: change switch name to satisfy convention
 
-  real(dp) :: afwi
-  !! inner radius of inboard first wall/blanket coolant channels (stellarator only) [m]
-  !#TODO move to stellarator?
-
-  real(dp) :: afwo
-  !! inner radius of outboard first wall/blanket coolant channels (stellarator only) [m]
-  !#TODO move to stellarator?
-
   character(len=6) :: i_fw_coolant_type
   !! switch for first wall coolant (can be different from blanket coolant):
   !!
@@ -736,8 +728,6 @@ module fwbs_variables
     i_thermal_electric_conversion = 0
     secondary_cycle_liq = 4
     i_blkt_coolant_type = 1
-    afwi = 0.008D0
-    afwo = 0.008D0
     i_fw_coolant_type = 'helium'
     dr_fw_wall = 0.003D0
     radius_fw_channel = 0.006D0

--- a/tests/integration/ref_dicts.json
+++ b/tests/integration/ref_dicts.json
@@ -223,8 +223,6 @@
         "admvol": 0.0,
         "m_fuel_amu": 0.0,
         "radius_fw_channel": 0.006,
-        "afwi": 0.008,
-        "afwo": 0.008,
         "aintmass": 0.0,
         "m_ions_total_amu": 0.0,
         "airtemp": 15.0,
@@ -8793,8 +8791,6 @@
         "admvol": "volume of administration buildings (m3)",
         "m_fuel_amu": "average mass of fuel portion of ions (amu)",
         "radius_fw_channel": "radius of first wall cooling channels (m)",
-        "afwi": "inner radius of inboard first wall/blanket coolant channels (stellarator only) (m)",
-        "afwo": "inner radius of outboard first wall/blanket coolant channels (stellarator only) (m)",
         "aintmass": "intercoil structure mass (kg)",
         "m_ions_total_amu": "average mass of all ions (amu)",
         "airtemp": "ambient air temperature (degrees Celsius)",
@@ -11560,14 +11556,6 @@
         "radius_fw_channel": {
             "lb": 0.001,
             "ub": 0.5
-        },
-        "afwi": {
-            "lb": 0.001,
-            "ub": 0.05
-        },
-        "afwo": {
-            "lb": 0.001,
-            "ub": 0.05
         },
         "airtemp": {
             "lb": -15.0,
@@ -18080,8 +18068,6 @@
             "i_shield_mat",
             "i_thermal_electric_conversion",
             "i_blkt_coolant_type",
-            "afwi",
-            "afwo",
             "i_fw_coolant_type",
             "dr_fw_wall",
             "radius_fw_channel",
@@ -19988,8 +19974,6 @@
         "adivflnc": "real_variable",
         "admv": "real_variable",
         "radius_fw_channel": "real_variable",
-        "afwi": "real_variable",
-        "afwo": "real_variable",
         "airtemp": "real_variable",
         "alfapf": "real_variable",
         "alphaj": "real_variable",

--- a/tests/regression/input_files/helias_5b.IN.DAT
+++ b/tests/regression/input_files/helias_5b.IN.DAT
@@ -134,6 +134,7 @@ i_coolant_pumping = 0     *Switch for pumping power (0: User sets pump power dir
 i_thermal_electric_conversion = 2     *Switch for power conversion cycle (2: user input thermal-electric efficiency)
 vfblkt   = 0.10         *Coolant void fraction in blanket (blktmodel=0)
 vfshld   = 0.60         *Coolant void fraction in shield
+radius_fw_channel = 0.008 *Inner radius of first wall coolant channel (m) is 0.008 for stellarator
 
 *-------------Heat Transport Variables-------------*
 

--- a/tests/regression/input_files/stellarator_helias_once_through.IN.DAT
+++ b/tests/regression/input_files/stellarator_helias_once_through.IN.DAT
@@ -206,6 +206,7 @@ declblkt = 0.075 * neutron power deposition decay length of blanket structural m
 declfw   = 0.075 * neutron power deposition decay length of first wall structural material [m] (stellarators only)
 declshld = 0.075 * neutron power deposition decay length of shield structural material [m] (stellarators only)
 etahtp   = 1. * electrical efficiency of primary coolant pumps
+radius_fw_channel = 0.008 *Inner radius of first wall coolant channel (m) is 0.008 for stellarator
 
 *-----------------Global Variables-----------------*
 


### PR DESCRIPTION
Closes #3109 

## Description

In stellarator there were variables afwi and afwo for the coolant inner channel radius for the FW inboard and outboard respectively. These variables seemed to have the same value in all the stellarator files and is comparable to the tokamak variable radius_fw_channel which is the inner channel radius for the FW (inboard and outboard).

For this reason, and to also allow for the potential of using the dcll blanket model with the stellarator, these variables were replaced with the tokamak variable radius_fw_channel.

Also had to make a change to the stellarator regression file as the default value for afwi and afwo was 0.008 rather than the default of radius_fw_channel which is 0.006.

Closes #3109 

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
