### PR TITLE
Added new functionality to plot_scans.py allowing axis tick labels to be percentages rather than absolutes

### DIFF
--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -570,7 +570,7 @@ def main(args=None):
                         y_divisions = (y_axis_range[1] - y_axis_range[0]) / 10
                     if y_axis_percentage:
                         if y_max is None:
-                            y_max = max(abs(output_arrays[input_file][output_name]))
+                            y_max = max(np.abs(output_arrays[input_file][output_name]))
                         yticks = mtick.PercentFormatter(y_max)
                         if y_axis_range != []:
                             y_divisions = 5 * math.ceil(y_divisions / 5) * y_max / 100
@@ -586,7 +586,7 @@ def main(args=None):
                         x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
                     if x_axis_percentage:
                         if x_max is None:
-                            x_max = max(abs(scan_var_array[input_file]))
+                            x_max = max(np.abs(scan_var_array[input_file]))
                         xticks = mtick.PercentFormatter(x_max)
                         ax.xaxis.set_major_formatter(xticks)
                         if x_axis_range != []:
@@ -615,7 +615,9 @@ def main(args=None):
                             y_divisions = (y_axis_range[1] - y_axis_range[0]) / 10
                         if y_axis_percentage:
                             if y_max is None:
-                                y_max = max(abs(output_arrays[input_file][output_name]))
+                                y_max = max(
+                                    np.abs(output_arrays[input_file][output_name])
+                                )
                             yticks = mtick.PercentFormatter(y_max)
                             if y_axis_range != []:
                                 y_divisions = (
@@ -639,7 +641,7 @@ def main(args=None):
                             x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
                         if x_axis_percentage:
                             if x_max is None:
-                                x_max = max(abs(scan_var_array[input_file]))
+                                x_max = max(np.abs(scan_var_array[input_file]))
                             xticks = mtick.PercentFormatter(x_max)
                             print("xticks", xticks)
                             if x_axis_range != []:
@@ -678,7 +680,9 @@ def main(args=None):
                             y_divisions = (y_axis_range[1] - y_axis_range[0]) / 10
                         if y_axis_percentage:
                             if y_max is None:
-                                y_max = max(abs(output_arrays[input_file][output_name]))
+                                y_max = max(
+                                    np.abs(output_arrays[input_file][output_name])
+                                )
                             yticks = mtick.PercentFormatter(y_max)
                             if y_axis_range != []:
                                 y_divisions = (
@@ -698,7 +702,7 @@ def main(args=None):
                             x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
                         if x_axis_percentage:
                             if x_max is None:
-                                x_max = max(abs(scan_var_array[input_file]))
+                                x_max = max(np.abs(scan_var_array[input_file]))
                             xticks = mtick.PercentFormatter(x_max)
                             if x_axis_range != []:
                                 x_divisions = (
@@ -739,7 +743,7 @@ def main(args=None):
                         y_divisions = (y_axis_range[1] - y_axis_range[0]) / 10
                     if y_axis_percentage:
                         if y_max is None:
-                            y_max = max(abs(output_arrays[input_file][output_name]))
+                            y_max = max(np.abs(output_arrays[input_file][output_name]))
                         yticks = mtick.PercentFormatter(y_max)
                         if y_axis_range != []:
                             y_divisions = 5 * math.ceil(y_divisions / 5) * y_max / 100
@@ -980,7 +984,7 @@ def main(args=None):
                     y_divisions = (y_axis_range[1] - y_axis_range[0]) / 10
                 if y_axis_percentage:
                     if y_max is None:
-                        y_max = max(abs(y_contour))
+                        y_max = max(np.abs(y_contour))
                     yticks = mtick.PercentFormatter(y_max)
                     if y_axis_range != []:
                         y_divisions = 5 * math.ceil(y_divisions / 5) * y_max / 100
@@ -996,7 +1000,7 @@ def main(args=None):
                     x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
                 if x_axis_percentage:
                     if x_max is None:
-                        x_max = max(abs(x_contour))
+                        x_max = max(np.abs(x_contour))
                     xticks = mtick.PercentFormatter(x_max)
                     if x_axis_range != []:
                         x_divisions = 5 * math.ceil(x_divisions / 5) * x_max / 100
@@ -1004,7 +1008,7 @@ def main(args=None):
                             x_axis_range[0] * x_max / 100,
                             x_axis_range[1] * x_max / 100,
                         )
-                    ax2.xaxis.set_major_formatter(xticks)
+                    ax.xaxis.set_major_formatter(xticks)
                 if x_axis_range != []:
                     plt.xlim(x_range[0], x_range[1])
                     ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))
@@ -1068,7 +1072,7 @@ def main(args=None):
                     y_divisions = (y_axis_range[1] - y_axis_range[0]) / 10
                 if y_axis_percentage:
                     if y_max is None:
-                        y_max = max(abs(y_data))
+                        y_max = max(np.abs(y_data))
                     yticks = mtick.PercentFormatter(y_max)
                     if y_axis_range != []:
                         y_divisions = 5 * math.ceil(y_divisions / 5) * y_max / 100
@@ -1088,7 +1092,7 @@ def main(args=None):
                     x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
                 if x_axis_percentage:
                     if x_max is None:
-                        x_max = max(abs(x_data))
+                        x_max = max(np.abs(x_data))
                     xticks = mtick.PercentFormatter(x_max)
                     if x_axis_range != []:
                         x_divisions = 5 * math.ceil(x_divisions / 5) * x_max / 100
@@ -1096,7 +1100,7 @@ def main(args=None):
                             x_axis_range[0] * x_max / 100,
                             x_axis_range[1] * x_max / 100,
                         )
-                    ax2.xaxis.set_major_formatter(xticks)
+                    ax.xaxis.set_major_formatter(xticks)
                 if x_axis_range != []:
                     plt.xlim(x_range[0], x_range[1])
                     ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -28,6 +28,7 @@ from argparse import RawTextHelpFormatter
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
 import numpy as np
 
 # PROCESS libraries
@@ -116,6 +117,24 @@ def parse_args(args):
     )
 
     parser.add_argument(
+        "-x%",
+        "--x_axis_percent",
+        action="store_true",
+        help=(
+            "Used to set the x axis ticks to percentages in place of absolute \nvalues."
+        ),
+    )
+
+    parser.add_argument(
+        "-y%",
+        "--y_axis_percent",
+        action="store_true",
+        help=(
+            "Used to set the y axis ticks to percentages in place of absolute \nvalues."
+        ),
+    )
+
+    parser.add_argument(
         "-ln",
         "--label_name",
         default="",
@@ -166,6 +185,8 @@ def main(args=None):
     save_format = str(args.save_format)
     term_output = args.term_output
     label_name = str(args.label_name)
+    x_axis_percentage = args.x_axis_percent
+    y_axis_percentage = args.y_axis_percent
     two_dimensional_contour = args.two_dimensional_contour
     stack_plots = args.stack_plots
     # ---------------------------------------
@@ -444,6 +465,12 @@ def main(args=None):
         # Plot section
         # -----------
         if stack_plots:
+            # check stack plots will work
+            if len(output_names) <= 1:
+                print(
+                    "ERROR : For stack plots to be used need more than 1 output variable"
+                )
+                exit()
             fig, axs = plt.subplots(
                 len(output_names),
                 1,
@@ -486,6 +513,18 @@ def main(args=None):
                         color="blue" if len(input_files) == 1 else None,
                         label=labl,
                     )
+                    if y_axis_percentage:
+                        yticks = mtick.PercentFormatter(
+                            max(abs(output_arrays[input_file][output_name]))
+                        )
+                        ax.yaxis.set_major_formatter(yticks)
+                    if x_axis_percentage:
+                        xticks = mtick.PercentFormatter(
+                            max(abs(scan_var_array[input_file]))
+                        )
+                        ax.xaxis.set_major_formatter(xticks)
+                    plt.rc("xtick", labelsize=axis_tick_size)
+                    plt.rc("ytick", labelsize=axis_tick_size)
                     plt.tight_layout()
                 else:
                     if stack_plots:
@@ -496,17 +535,43 @@ def main(args=None):
                             color="blue" if output_names2 != [] else None,
                             label=labl,
                         )
+                        if y_axis_percentage:
+                            yticks = mtick.PercentFormatter(
+                                max(abs(output_arrays[input_file][output_name]))
+                            )
+                            axs[
+                                output_names.index(output_name)
+                            ].yaxis.set_major_formatter(yticks)
+                        if x_axis_percentage:
+                            xticks = mtick.PercentFormatter(
+                                max(abs(scan_var_array[input_file]))
+                            )
+                            axs[
+                                output_names.index(output_name)
+                            ].xaxis.set_major_formatter(xticks)
+                        plt.rc("xtick", labelsize=axis_tick_size)
+                        plt.rc("ytick", labelsize=axis_tick_size)
                         plt.tight_layout()
                     else:
-                        plt.plot(
+                        ax.plot(
                             scan_var_array[input_file],
                             output_arrays[input_file][output_name],
                             "--o",
                             color="blue" if output_names2 != [] else None,
                             label=labl,
                         )
-                        plt.xticks(size=axis_tick_size)
-                        plt.yticks(size=axis_tick_size)
+                        if y_axis_percentage:
+                            yticks = mtick.PercentFormatter(
+                                max(abs(output_arrays[input_file][output_name]))
+                            )
+                            ax.yaxis.set_major_formatter(yticks)
+                        if x_axis_percentage:
+                            xticks = mtick.PercentFormatter(
+                                max(abs(scan_var_array[input_file]))
+                            )
+                            ax.xaxis.set_major_formatter(xticks)
+                        plt.rc("xtick", labelsize=axis_tick_size)
+                        plt.rc("ytick", labelsize=axis_tick_size)
                         plt.tight_layout()
                 if output_names2 != []:
                     ax2.plot(
@@ -525,6 +590,18 @@ def main(args=None):
                         fontsize=axis_font_size,
                         color="red" if len(input_files) == 1 else "black",
                     )
+                    if y_axis_percentage:
+                        yticks = mtick.PercentFormatter(
+                            max(abs(output_arrays[input_file][output_name]))
+                        )
+                        ax2.yaxis.set_major_formatter(yticks)
+                    if x_axis_percentage:
+                        xticks = mtick.PercentFormatter(
+                            max(abs(scan_var_array[input_file]))
+                        )
+                        ax2.xaxis.set_major_formatter(xticks)
+                    plt.rc("xtick", labelsize=axis_tick_size)
+                    plt.rc("ytick", labelsize=axis_tick_size)
                     plt.tight_layout()
             if output_names2 != []:
                 ax2.yaxis.grid(True)
@@ -546,6 +623,8 @@ def main(args=None):
                     ),
                     fontsize=axis_font_size,
                 )
+                plt.rc("xtick", labelsize=axis_tick_size)
+                plt.rc("ytick", labelsize=axis_tick_size)
                 if len(input_files) != 1:
                     plt.legend(loc="best", fontsize=legend_size)
                 plt.tight_layout()
@@ -568,6 +647,8 @@ def main(args=None):
                     ),
                     fontsize=axis_font_size,
                 )
+                plt.rc("xtick", labelsize=axis_tick_size)
+                plt.rc("ytick", labelsize=axis_tick_size)
                 if len(input_files) > 1:
                     plt.legend(
                         loc="lower center",
@@ -612,6 +693,8 @@ def main(args=None):
                     ),
                     fontsize=axis_font_size,
                 )
+                plt.rc("xtick", labelsize=axis_tick_size)
+                plt.rc("ytick", labelsize=axis_tick_size)
                 plt.title(
                     f"{meta[output_name].latex if output_name in meta else {output_name}} vs "
                     f"{meta[scan_var_name].latex if scan_var_name in meta else {scan_var_name}}",
@@ -705,18 +788,20 @@ def main(args=None):
 
                 flat_output_z = output_contour_z.flatten()
                 flat_output_z.sort()
-                plt.contourf(
+                fig, ax = plt.subplots()
+                levels = np.linspace(
+                    next(filter(lambda i: i > 0.0, flat_output_z)),
+                    flat_output_z.max(),
+                    50,
+                )
+                contour = ax.contourf(
                     x_contour,
                     y_contour,
                     output_contour_z,
-                    levels=np.linspace(
-                        next(filter(lambda i: i > 0.0, flat_output_z)),
-                        flat_output_z.max(),
-                        50,
-                    ),
+                    levels=levels,
                 )
 
-                plt.colorbar().set_label(
+                fig.colorbar(contour).set_label(
                     label=(
                         meta[output_name].latex
                         if output_name in meta
@@ -740,6 +825,14 @@ def main(args=None):
                     ),
                     fontsize=axis_font_size,
                 )
+                if y_axis_percentage:
+                    yticks = mtick.PercentFormatter(max(np.abs(y_contour)))
+                    ax.yaxis.set_major_formatter(yticks)
+                if x_axis_percentage:
+                    xticks = mtick.PercentFormatter(max(np.abs(x_contour)))
+                    ax.xaxis.set_major_formatter(xticks)
+                plt.rc("xtick", labelsize=axis_tick_size)
+                plt.rc("ytick", labelsize=axis_tick_size)
                 plt.tight_layout()
                 plt.savefig(
                     f"{args.outputdir}/scan_{output_name}_vs_{scan_var_name}_{scan_2_var_name}.{save_format}"
@@ -750,6 +843,7 @@ def main(args=None):
 
             else:
                 # Converged indexes, for normal 2D line plot
+                fig, ax = plt.subplots()
                 for conv_j in (
                     conv_ij
                 ):  # conv_j is an array element containing the converged scan numbers
@@ -770,7 +864,7 @@ def main(args=None):
                     labl = f"{meta[scan_var_name].latex if scan_var_name in meta else {scan_var_name}} = {scan_1_var_array[0]}"
 
                     # Plot the graph
-                    plt.plot(scan_2_var_array, output_array, "--o", label=labl)
+                    ax.plot(scan_2_var_array, output_array, "--o", label=labl)
 
                 plt.grid(True)
                 plt.ylabel(
@@ -790,8 +884,21 @@ def main(args=None):
                     fontsize=axis_font_size,
                 )
                 plt.legend(loc="best", fontsize=legend_size)
-                plt.xticks(size=axis_tick_size)
-                plt.yticks(size=axis_tick_size)
+                y_data = [
+                    m_file.data[output_name].get_scan(i + 1) for i in range(n_scan_2)
+                ]
+                if y_axis_percentage:
+                    yticks = mtick.PercentFormatter(max(np.abs(y_data)))
+                    ax.yaxis.set_major_formatter(yticks)
+                x_data = [
+                    m_file.data[scan_2_var_name].get_scan(i + 1)
+                    for i in range(n_scan_2)
+                ]
+                if x_axis_percentage:
+                    xticks = mtick.PercentFormatter(max(np.abs(x_data)))
+                    ax.xaxis.set_major_formatter(xticks)
+                plt.rc("xtick", labelsize=8)
+                plt.rc("ytick", labelsize=8)
                 plt.tight_layout()
                 plt.savefig(
                     f"{args.outputdir}/scan_{output_name}_vs_{scan_var_name}_{scan_2_var_name}.{save_format}"

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -445,7 +445,6 @@ def main(args=None):
                 x_max += [None]
     else:
         x_max = np.float64(x_max_input)
-    print(len(y_max_input), len(output_names))
     if len(y_max_input) != len(output_names):
         y_max = []
         for _ in range(len(output_names)):
@@ -748,7 +747,6 @@ def main(args=None):
                                 y_max[index] = max(
                                     np.abs(output_arrays[input_file][output_name])
                                 )
-                            print(y_max[index], type(y_max[index]))
                             yticks = mtick.PercentFormatter(y_max[index])
                             if y_axis_range != []:
                                 y_divisions = (

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -548,25 +548,24 @@ def main(args=None):
                     )
         # Plot section
         # -----------
-        if stack_plots:
-            # check stack plots will work
-            if len(output_names) <= 1:
-                print(
-                    "ERROR : For stack plots to be used need more than 1 output variable"
-                )
-                exit()
-            fig, axs = plt.subplots(
-                len(output_names),
-                1,
-                figsize=(8.0, (3.5 + (1 * len(output_names)))),
-                sharex=True,
-            )
-            fig.subplots_adjust(hspace=0.0)
-        else:
-            fig, ax = plt.subplots()
-            if output_names2 != []:
-                ax2 = ax.twinx()
         for output_name in output_names:
+            if stack_plots:
+                # check stack plots will work
+                if len(output_names) <= 1:
+                    raise ValueError(
+                        "For stack plots to be used need more than 1 output variable"
+                    )
+                fig, axs = plt.subplots(
+                    len(output_names),
+                    1,
+                    figsize=(8.0, (3.5 + (1 * len(output_names)))),
+                    sharex=True,
+                )
+                fig.subplots_adjust(hspace=0.0)
+            else:
+                fig, ax = plt.subplots()
+                if output_names2 != []:
+                    ax2 = ax.twinx()
             # reset counter for label_name
             kk = 0
 
@@ -590,7 +589,6 @@ def main(args=None):
 
                 # Plot the graph
                 if output_names2 != [] and not stack_plots:
-                    print("A - twin axis")
                     ax.plot(
                         scan_var_array[input_file],
                         output_arrays[input_file][output_name],
@@ -639,7 +637,6 @@ def main(args=None):
                     plt.tight_layout()
                 else:
                     if stack_plots:
-                        print("B - stack")
                         axs[output_names.index(output_name)].plot(
                             scan_var_array[input_file],
                             output_arrays[input_file][output_name],
@@ -681,9 +678,7 @@ def main(args=None):
                             if x_max is None:
                                 x_max = max(np.abs(scan_var_array[input_file]))
                             xticks = mtick.PercentFormatter(x_max)
-                            print("xticks", xticks)
                             if x_axis_range != []:
-                                print("xr", x_axis_range)
                                 x_divisions = (
                                     5 * math.ceil(x_divisions / 5) * x_max / 100
                                 )
@@ -691,7 +686,6 @@ def main(args=None):
                                     x_axis_range[0] * x_max / 100,
                                     x_axis_range[1] * x_max / 100,
                                 )
-                                print("xr", x_axis_range)
                             axs[
                                 output_names.index(output_name)
                             ].xaxis.set_major_formatter(xticks)
@@ -708,7 +702,6 @@ def main(args=None):
                         plt.rc("ytick", labelsize=axis_tick_size)
                         plt.tight_layout()
                     else:
-                        print("C - single var")
                         ax.plot(
                             scan_var_array[input_file],
                             output_arrays[input_file][output_name],
@@ -766,7 +759,6 @@ def main(args=None):
                         plt.rc("ytick", labelsize=axis_tick_size)
                         plt.tight_layout()
                 if output_names2 != []:
-                    print("D - twin axis 2")
                     ax2.plot(
                         scan_var_array[input_file],
                         output_arrays2[input_file][output_name2],

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -443,6 +443,9 @@ def main(args=None):
                 x_max += [np.float64(x_max_input)]
             else:
                 x_max += [None]
+    else:
+        x_max = np.float64(x_max_input)
+    print(len(y_max_input), len(output_names))
     if len(y_max_input) != len(output_names):
         y_max = []
         for _ in range(len(output_names)):
@@ -450,6 +453,8 @@ def main(args=None):
                 y_max += [np.float64(y_max_input)]
             else:
                 y_max += [None]
+    else:
+        y_max = np.float64(y_max_input)
     if (len(y_max2_input) != len(output_names)) and (output_names2 != []):
         y_max2 = []
         for _ in range(len(output_names)):
@@ -457,6 +462,8 @@ def main(args=None):
                 y_max2 += [np.float64(y_max2_input)]
             else:
                 y_max2 += [None]
+    else:
+        y_max2 = np.float64(y_max2_input)
     # -------------
 
     # Case of a set of 1D scans
@@ -741,6 +748,7 @@ def main(args=None):
                                 y_max[index] = max(
                                     np.abs(output_arrays[input_file][output_name])
                                 )
+                            print(y_max[index], type(y_max[index]))
                             yticks = mtick.PercentFormatter(y_max[index])
                             if y_axis_range != []:
                                 y_divisions = (

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -108,11 +108,20 @@ def parse_args(args):
     )
 
     parser.add_argument(
-        "-as",
+        "-afs",
         "--axis_font_size",
         nargs="?",
         default=18,
         help="Axis label font size selection (default=18)",
+        type=int,
+    )
+
+    parser.add_argument(
+        "-ats",
+        "--axis_ticklabel_size",
+        nargs="?",
+        default=16,
+        help="Axis tick label font size selection (default=16)",
         type=int,
     )
 
@@ -351,7 +360,7 @@ def main(args=None):
     # Plot settings
     # -------------
     # Plot cosmetic settings
-    axis_tick_size = 16
+    axis_tick_size = args.axis_ticklabel_size
     legend_size = 12
     axis_font_size = args.axis_font_size
     # -------------

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -438,18 +438,29 @@ def main(args=None):
 
     if len(x_max_input) != len(output_names):
         x_max = []
-        for _ in range(len(output_names)):
+        for i in range(len(output_names)):
             if x_max_input != []:
-                x_max += [np.float64(x_max_input)]
+                j = 0
+                try:
+                    x_max += [float(x_max_input[i])]
+                    j += 1
+                except IndexError:
+                    x_max += [float(x_max_input[j])]
             else:
                 x_max += [None]
     else:
         x_max = np.float64(x_max_input)
+    print(y_max_input)
     if len(y_max_input) != len(output_names):
         y_max = []
-        for _ in range(len(output_names)):
+        for i in range(len(output_names)):
             if y_max_input != []:
-                y_max += [np.float64(y_max_input)]
+                j = 0
+                try:
+                    y_max += [float(y_max_input[i])]
+                    j += 1
+                except IndexError:
+                    y_max += [float(y_max_input[j])]
             else:
                 y_max += [None]
     else:
@@ -457,15 +468,21 @@ def main(args=None):
     if output_names2 != []:
         if len(y_max2_input) != len(output_names):
             y_max2 = []
-            for _ in range(len(output_names)):
+            for i in range(len(output_names)):
                 if y_max2_input != []:
-                    y_max2 += [np.float64(y_max2_input)]
+                    j = 0
+                    try:
+                        y_max2 += [float(y_max2_input[i])]
+                        j += 1
+                    except IndexError:
+                        y_max2 += [float(y_max2_input[j])]
                 else:
                     y_max2 += [None]
         else:
             y_max2 = np.float64(y_max2_input)
     else:
         y_max2 = y_max2_input
+    print(y_max)
     # -------------
 
     # Case of a set of 1D scans

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -659,7 +659,7 @@ def main(args=None):
                     if y_axis_range != []:
                         if y_axis_percentage is False:
                             y_range = y_axis_range
-                        plt.ylim(y_range[0], y_range[1])
+                        ax.set_ylim(y_range[0], y_range[1])
                         ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
                     if x_axis_range != []:
                         x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
@@ -715,7 +715,9 @@ def main(args=None):
                         if y_axis_range != []:
                             if y_axis_percentage is False:
                                 y_range = y_axis_range
-                            plt.ylim(y_range[0], y_range[1])
+                            axs[output_names.index(output_name)].set_ylim(
+                                y_range[0], y_range[1]
+                            )
                             axs[
                                 output_names.index(output_name)
                             ].yaxis.set_major_locator(
@@ -778,7 +780,7 @@ def main(args=None):
                         if y_axis_range != []:
                             if y_axis_percentage is False:
                                 y_range = y_axis_range
-                            plt.ylim(y_range[0], y_range[1])
+                            ax.set_ylim(y_range[0], y_range[1])
                             ax.yaxis.set_major_locator(
                                 mtick.MultipleLocator(y_divisions)
                             )
@@ -844,8 +846,8 @@ def main(args=None):
                     if y_axis_range2 != []:
                         if y_axis_percentage2 is False:
                             y_range2 = y_axis_range2
-                        plt.ylim(y_range2[0], y_range2[1])
-                        ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions2))
+                        ax2.set_ylim(y_range2[0], y_range2[1])
+                        ax2.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions2))
                     plt.rc("xtick", labelsize=axis_tick_size)
                     plt.rc("ytick", labelsize=axis_tick_size)
                     plt.tight_layout()
@@ -1089,7 +1091,7 @@ def main(args=None):
                 if y_axis_range != []:
                     if y_axis_percentage is False:
                         y_range = y_axis_range
-                    plt.ylim(y_range[0], y_range[1])
+                    ax.set_ylim(y_range[0], y_range[1])
                     ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
                 if x_axis_range != []:
                     x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
@@ -1185,7 +1187,7 @@ def main(args=None):
                 if y_axis_range != []:
                     if y_axis_percentage is False:
                         y_range = y_axis_range
-                    plt.ylim(y_range[0], y_range[1])
+                    ax.set_ylim(y_range[0], y_range[1])
                     ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
                 x_data = [
                     m_file.data[scan_2_var_name].get_scan(i + 1)

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -135,12 +135,32 @@ def parse_args(args):
     )
 
     parser.add_argument(
+        "-xm",
+        "--x_axis_max",
+        nargs="?",
+        help=(
+            "Used to set the x value corresponding to 100 percent when \nconverting from absolute to percent values."
+        ),
+        type=float,
+    )
+
+    parser.add_argument(
         "-y%",
         "--y_axis_percent",
         action="store_true",
         help=(
             "Used to set the y axis ticks to percentages in place of absolute \nvalues."
         ),
+    )
+
+    parser.add_argument(
+        "-ym",
+        "--y_axis_max",
+        nargs="?",
+        help=(
+            "Used to set the y value corresponding to 100 percent when \nconverting from absolute to percent values."
+        ),
+        type=float,
     )
 
     parser.add_argument(
@@ -195,7 +215,9 @@ def main(args=None):
     term_output = args.term_output
     label_name = str(args.label_name)
     x_axis_percentage = args.x_axis_percent
+    x_max = args.x_axis_max
     y_axis_percentage = args.y_axis_percent
+    y_max = args.y_axis_max
     two_dimensional_contour = args.two_dimensional_contour
     stack_plots = args.stack_plots
     # ---------------------------------------
@@ -523,14 +545,20 @@ def main(args=None):
                         label=labl,
                     )
                     if y_axis_percentage:
-                        yticks = mtick.PercentFormatter(
-                            max(abs(output_arrays[input_file][output_name]))
-                        )
+                        if y_max is not None:
+                            yticks = mtick.PercentFormatter(y_max)
+                        else:
+                            yticks = mtick.PercentFormatter(
+                                max(abs(output_arrays[input_file][output_name]))
+                            )
                         ax.yaxis.set_major_formatter(yticks)
                     if x_axis_percentage:
-                        xticks = mtick.PercentFormatter(
-                            max(abs(scan_var_array[input_file]))
-                        )
+                        if x_max is not None:
+                            xticks = mtick.PercentFormatter(x_max)
+                        else:
+                            xticks = mtick.PercentFormatter(
+                                max(abs(scan_var_array[input_file]))
+                            )
                         ax.xaxis.set_major_formatter(xticks)
                     plt.rc("xtick", labelsize=axis_tick_size)
                     plt.rc("ytick", labelsize=axis_tick_size)
@@ -545,16 +573,22 @@ def main(args=None):
                             label=labl,
                         )
                         if y_axis_percentage:
-                            yticks = mtick.PercentFormatter(
-                                max(abs(output_arrays[input_file][output_name]))
-                            )
+                            if y_max is not None:
+                                yticks = mtick.PercentFormatter(y_max)
+                            else:
+                                yticks = mtick.PercentFormatter(
+                                    max(abs(output_arrays[input_file][output_name]))
+                                )
                             axs[
                                 output_names.index(output_name)
                             ].yaxis.set_major_formatter(yticks)
                         if x_axis_percentage:
-                            xticks = mtick.PercentFormatter(
-                                max(abs(scan_var_array[input_file]))
-                            )
+                            if x_max is not None:
+                                xticks = mtick.PercentFormatter(x_max)
+                            else:
+                                xticks = mtick.PercentFormatter(
+                                    max(abs(scan_var_array[input_file]))
+                                )
                             axs[
                                 output_names.index(output_name)
                             ].xaxis.set_major_formatter(xticks)
@@ -570,14 +604,20 @@ def main(args=None):
                             label=labl,
                         )
                         if y_axis_percentage:
-                            yticks = mtick.PercentFormatter(
-                                max(abs(output_arrays[input_file][output_name]))
-                            )
+                            if y_max is not None:
+                                yticks = mtick.PercentFormatter(y_max)
+                            else:
+                                yticks = mtick.PercentFormatter(
+                                    max(abs(output_arrays[input_file][output_name]))
+                                )
                             ax.yaxis.set_major_formatter(yticks)
                         if x_axis_percentage:
-                            xticks = mtick.PercentFormatter(
-                                max(abs(scan_var_array[input_file]))
-                            )
+                            if x_max is not None:
+                                xticks = mtick.PercentFormatter(x_max)
+                            else:
+                                xticks = mtick.PercentFormatter(
+                                    max(abs(scan_var_array[input_file]))
+                                )
                             ax.xaxis.set_major_formatter(xticks)
                         plt.rc("xtick", labelsize=axis_tick_size)
                         plt.rc("ytick", labelsize=axis_tick_size)
@@ -600,14 +640,20 @@ def main(args=None):
                         color="red" if len(input_files) == 1 else "black",
                     )
                     if y_axis_percentage:
-                        yticks = mtick.PercentFormatter(
-                            max(abs(output_arrays[input_file][output_name]))
-                        )
+                        if y_max is not None:
+                            yticks = mtick.PercentFormatter(y_max)
+                        else:
+                            yticks = mtick.PercentFormatter(
+                                max(abs(output_arrays[input_file][output_name]))
+                            )
                         ax2.yaxis.set_major_formatter(yticks)
                     if x_axis_percentage:
-                        xticks = mtick.PercentFormatter(
-                            max(abs(scan_var_array[input_file]))
-                        )
+                        if x_max is not None:
+                            xticks = mtick.PercentFormatter(x_max)
+                        else:
+                            xticks = mtick.PercentFormatter(
+                                max(abs(scan_var_array[input_file]))
+                            )
                         ax2.xaxis.set_major_formatter(xticks)
                     plt.rc("xtick", labelsize=axis_tick_size)
                     plt.rc("ytick", labelsize=axis_tick_size)
@@ -835,10 +881,16 @@ def main(args=None):
                     fontsize=axis_font_size,
                 )
                 if y_axis_percentage:
-                    yticks = mtick.PercentFormatter(max(np.abs(y_contour)))
+                    if y_max is not None:
+                        yticks = mtick.PercentFormatter(y_max)
+                    else:
+                        yticks = mtick.PercentFormatter(max(np.abs(y_contour)))
                     ax.yaxis.set_major_formatter(yticks)
                 if x_axis_percentage:
-                    xticks = mtick.PercentFormatter(max(np.abs(x_contour)))
+                    if x_max is not None:
+                        xticks = mtick.PercentFormatter(x_max)
+                    else:
+                        xticks = mtick.PercentFormatter(max(np.abs(x_contour)))
                     ax.xaxis.set_major_formatter(xticks)
                 plt.rc("xtick", labelsize=axis_tick_size)
                 plt.rc("ytick", labelsize=axis_tick_size)
@@ -897,14 +949,20 @@ def main(args=None):
                     m_file.data[output_name].get_scan(i + 1) for i in range(n_scan_2)
                 ]
                 if y_axis_percentage:
-                    yticks = mtick.PercentFormatter(max(np.abs(y_data)))
+                    if y_max is not None:
+                        yticks = mtick.PercentFormatter(y_max)
+                    else:
+                        yticks = mtick.PercentFormatter(max(np.abs(y_data)))
                     ax.yaxis.set_major_formatter(yticks)
                 x_data = [
                     m_file.data[scan_2_var_name].get_scan(i + 1)
                     for i in range(n_scan_2)
                 ]
                 if x_axis_percentage:
-                    xticks = mtick.PercentFormatter(max(np.abs(x_data)))
+                    if x_max is not None:
+                        xticks = mtick.PercentFormatter(x_max)
+                    else:
+                        xticks = mtick.PercentFormatter(max(np.abs(x_data)))
                     ax.xaxis.set_major_formatter(xticks)
                 plt.rc("xtick", labelsize=8)
                 plt.rc("ytick", labelsize=8)

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -558,6 +558,7 @@ def main(args=None):
 
                 # Plot the graph
                 if output_names2 != [] and not stack_plots:
+                    print("A - twin axis")
                     ax.plot(
                         scan_var_array[input_file],
                         output_arrays[input_file][output_name],
@@ -590,18 +591,19 @@ def main(args=None):
                         ax.xaxis.set_major_formatter(xticks)
                         if x_axis_range != []:
                             x_divisions = 5 * math.ceil(x_divisions / 5) * x_max / 100
-                            x_axis_range = (
+                            x_range = (
                                 x_axis_range[0] * x_max / 100,
                                 x_axis_range[1] * x_max / 100,
                             )
                     plt.rc("xtick", labelsize=axis_tick_size)
                     plt.rc("ytick", labelsize=axis_tick_size)
                     if x_axis_range != []:
-                        plt.xlim(x_axis_range[0], x_axis_range[1])
+                        plt.xlim(x_range[0], x_range[1])
                         ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))
                     plt.tight_layout()
                 else:
                     if stack_plots:
+                        print("B - stack")
                         axs[output_names.index(output_name)].plot(
                             scan_var_array[input_file],
                             output_arrays[input_file][output_name],
@@ -628,7 +630,9 @@ def main(args=None):
                             ].yaxis.set_major_formatter(yticks)
                         if y_axis_range != []:
                             plt.ylim(y_axis_range[0], y_axis_range[1])
-                            ax.yaxis.set_major_locator(
+                            axs[
+                                output_names.index(output_name)
+                            ].yaxis.set_major_locator(
                                 mtick.MultipleLocator(y_divisions)
                             )
                         if x_axis_range != []:
@@ -637,26 +641,32 @@ def main(args=None):
                             if x_max is None:
                                 x_max = max(abs(scan_var_array[input_file]))
                             xticks = mtick.PercentFormatter(x_max)
+                            print("xticks", xticks)
                             if x_axis_range != []:
+                                print("xr", x_axis_range)
                                 x_divisions = (
                                     5 * math.ceil(x_divisions / 5) * x_max / 100
                                 )
-                                x_axis_range = (
+                                x_range = (
                                     x_axis_range[0] * x_max / 100,
                                     x_axis_range[1] * x_max / 100,
                                 )
+                                print("xr", x_axis_range)
                             axs[
                                 output_names.index(output_name)
                             ].xaxis.set_major_formatter(xticks)
                         if x_axis_range != []:
-                            plt.xlim(x_axis_range[0], x_axis_range[1])
-                            ax.xaxis.set_major_locator(
+                            plt.xlim(x_range[0], x_range[1])
+                            axs[
+                                output_names.index(output_name)
+                            ].xaxis.set_major_locator(
                                 mtick.MultipleLocator(x_divisions)
                             )
                         plt.rc("xtick", labelsize=axis_tick_size)
                         plt.rc("ytick", labelsize=axis_tick_size)
                         plt.tight_layout()
                     else:
+                        print("C - single var")
                         ax.plot(
                             scan_var_array[input_file],
                             output_arrays[input_file][output_name],
@@ -694,13 +704,13 @@ def main(args=None):
                                 x_divisions = (
                                     5 * math.ceil(x_divisions / 5) * x_max / 100
                                 )
-                                x_axis_range = (
+                                x_range = (
                                     x_axis_range[0] * x_max / 100,
                                     x_axis_range[1] * x_max / 100,
                                 )
                             ax.xaxis.set_major_formatter(xticks)
                         if x_axis_range != []:
-                            plt.xlim(x_axis_range[0], x_axis_range[1])
+                            plt.xlim(x_range[0], x_range[1])
                             ax.xaxis.set_major_locator(
                                 mtick.MultipleLocator(x_divisions)
                             )
@@ -708,6 +718,7 @@ def main(args=None):
                         plt.rc("ytick", labelsize=axis_tick_size)
                         plt.tight_layout()
                 if output_names2 != []:
+                    print("D - twin axis 2")
                     ax2.plot(
                         scan_var_array[input_file],
                         output_arrays2[input_file][output_name2],
@@ -740,22 +751,6 @@ def main(args=None):
                     if y_axis_range != []:
                         plt.ylim(y_axis_range[0], y_axis_range[1])
                         ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
-                    if x_axis_range != []:
-                        x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
-                    if x_axis_percentage:
-                        if x_max is None:
-                            x_max = max(abs(scan_var_array[input_file]))
-                        xticks = mtick.PercentFormatter(x_max)
-                        if x_axis_range != []:
-                            x_divisions = 5 * math.ceil(x_divisions / 5) * x_max / 100
-                            x_axis_range = (
-                                x_axis_range[0] * x_max / 100,
-                                x_axis_range[1] * x_max / 100,
-                            )
-                        ax2.xaxis.set_major_formatter(xticks)
-                    if x_axis_range != []:
-                        plt.xlim(x_axis_range[0], x_axis_range[1])
-                        ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))
                     plt.rc("xtick", labelsize=axis_tick_size)
                     plt.rc("ytick", labelsize=axis_tick_size)
                     plt.tight_layout()
@@ -1005,13 +1000,13 @@ def main(args=None):
                     xticks = mtick.PercentFormatter(x_max)
                     if x_axis_range != []:
                         x_divisions = 5 * math.ceil(x_divisions / 5) * x_max / 100
-                        x_axis_range = (
+                        x_range = (
                             x_axis_range[0] * x_max / 100,
                             x_axis_range[1] * x_max / 100,
                         )
                     ax2.xaxis.set_major_formatter(xticks)
                 if x_axis_range != []:
-                    plt.xlim(x_axis_range[0], x_axis_range[1])
+                    plt.xlim(x_range[0], x_range[1])
                     ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))
                 plt.rc("xtick", labelsize=axis_tick_size)
                 plt.rc("ytick", labelsize=axis_tick_size)
@@ -1097,13 +1092,13 @@ def main(args=None):
                     xticks = mtick.PercentFormatter(x_max)
                     if x_axis_range != []:
                         x_divisions = 5 * math.ceil(x_divisions / 5) * x_max / 100
-                        x_axis_range = (
+                        x_range = (
                             x_axis_range[0] * x_max / 100,
                             x_axis_range[1] * x_max / 100,
                         )
                     ax2.xaxis.set_major_formatter(xticks)
                 if x_axis_range != []:
-                    plt.xlim(x_axis_range[0], x_axis_range[1])
+                    plt.xlim(x_range[0], x_range[1])
                     ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))
                 plt.rc("xtick", labelsize=8)
                 plt.rc("ytick", labelsize=8)

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -450,7 +450,6 @@ def main(args=None):
                 x_max += [None]
     else:
         x_max = np.float64(x_max_input)
-    print(y_max_input)
     if len(y_max_input) != len(output_names):
         y_max = []
         for i in range(len(output_names)):
@@ -482,7 +481,6 @@ def main(args=None):
             y_max2 = np.float64(y_max2_input)
     else:
         y_max2 = y_max2_input
-    print(y_max)
     # -------------
 
     # Case of a set of 1D scans
@@ -844,10 +842,10 @@ def main(args=None):
                             )
                         ax2.yaxis.set_major_formatter(yticks2)
                     if y_axis_range2 != []:
-                        if y_axis_percentage is False:
+                        if y_axis_percentage2 is False:
                             y_range2 = y_axis_range2
                         plt.ylim(y_range2[0], y_range2[1])
-                        ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
+                        ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions2))
                     plt.rc("xtick", labelsize=axis_tick_size)
                     plt.rc("ytick", labelsize=axis_tick_size)
                     plt.tight_layout()

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -162,6 +162,15 @@ def parse_args(args):
     )
 
     parser.add_argument(
+        "-y2%",
+        "--y_axis_2_percent",
+        action="store_true",
+        help=(
+            "Used to set the y axis ticks to percentages in place of absolute \nvalues. For the twinned axis if present."
+        ),
+    )
+
+    parser.add_argument(
         "-ym",
         "--y_axis_max",
         nargs="?",
@@ -172,10 +181,28 @@ def parse_args(args):
     )
 
     parser.add_argument(
+        "-ym2",
+        "--y_axis_2_max",
+        nargs="?",
+        help=(
+            "Used to set the y value corresponding to 100 percent when \nconverting from absolute to percent values."
+            "For the twinned axis if present."
+        ),
+        type=float,
+    )
+
+    parser.add_argument(
         "-yr",
         "--y_axis_range",
         default="",
         help=("Used to set the range for y axis"),
+    )
+
+    parser.add_argument(
+        "-yr2",
+        "--y_axis_2_range",
+        default="",
+        help=("Used to set the range for y axis. For the twinned axis if present."),
     )
 
     parser.add_argument(
@@ -233,6 +260,8 @@ def main(args=None):
     x_max = args.x_axis_max
     y_axis_percentage = args.y_axis_percent
     y_max = args.y_axis_max
+    y_axis_percentage2 = args.y_axis_2_percent
+    y_max2 = args.y_axis_2_max
     two_dimensional_contour = args.two_dimensional_contour
     stack_plots = args.stack_plots
     # ---------------------------------------
@@ -406,6 +435,9 @@ def main(args=None):
     y_axis_range = list(filter(None, args.y_axis_range.split(" ")))
     if y_axis_range != []:
         y_axis_range = list(np.float64(y_axis_range))
+    y_axis_range2 = list(filter(None, args.y_axis_2_range.split(" ")))
+    if y_axis_range2 != []:
+        y_axis_range2 = list(np.float64(y_axis_range2))
     # -------------
 
     # Case of a set of 1D scans
@@ -574,13 +606,15 @@ def main(args=None):
                         yticks = mtick.PercentFormatter(y_max)
                         if y_axis_range != []:
                             y_divisions = 5 * math.ceil(y_divisions / 5) * y_max / 100
-                            y_axis_range = (
+                            y_range = (
                                 y_axis_range[0] * y_max / 100,
                                 y_axis_range[1] * y_max / 100,
                             )
                         ax.yaxis.set_major_formatter(yticks)
                     if y_axis_range != []:
-                        plt.ylim(y_axis_range[0], y_axis_range[1])
+                        if y_axis_percentage is False:
+                            y_range = y_axis_range
+                        plt.ylim(y_range[0], y_range[1])
                         ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
                     if x_axis_range != []:
                         x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
@@ -598,6 +632,8 @@ def main(args=None):
                     plt.rc("xtick", labelsize=axis_tick_size)
                     plt.rc("ytick", labelsize=axis_tick_size)
                     if x_axis_range != []:
+                        if x_axis_percentage is False:
+                            x_range = x_axis_range
                         plt.xlim(x_range[0], x_range[1])
                         ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))
                     plt.tight_layout()
@@ -623,7 +659,7 @@ def main(args=None):
                                 y_divisions = (
                                     5 * math.ceil(y_divisions / 5) * y_max / 100
                                 )
-                                y_axis_range = (
+                                y_range = (
                                     y_axis_range[0] * y_max / 100,
                                     y_axis_range[1] * y_max / 100,
                                 )
@@ -631,7 +667,9 @@ def main(args=None):
                                 output_names.index(output_name)
                             ].yaxis.set_major_formatter(yticks)
                         if y_axis_range != []:
-                            plt.ylim(y_axis_range[0], y_axis_range[1])
+                            if y_axis_percentage is False:
+                                y_range = y_axis_range
+                            plt.ylim(y_range[0], y_range[1])
                             axs[
                                 output_names.index(output_name)
                             ].yaxis.set_major_locator(
@@ -658,6 +696,8 @@ def main(args=None):
                                 output_names.index(output_name)
                             ].xaxis.set_major_formatter(xticks)
                         if x_axis_range != []:
+                            if x_axis_percentage is False:
+                                x_range = x_axis_range
                             plt.xlim(x_range[0], x_range[1])
                             axs[
                                 output_names.index(output_name)
@@ -688,13 +728,15 @@ def main(args=None):
                                 y_divisions = (
                                     5 * math.ceil(y_divisions / 5) * y_max / 100
                                 )
-                                y_axis_range = (
+                                y_range = (
                                     y_axis_range[0] * y_max / 100,
                                     y_axis_range[1] * y_max / 100,
                                 )
                             ax.yaxis.set_major_formatter(yticks)
                         if y_axis_range != []:
-                            plt.ylim(y_axis_range[0], y_axis_range[1])
+                            if y_axis_percentage is False:
+                                y_range = y_axis_range
+                            plt.ylim(y_range[0], y_range[1])
                             ax.yaxis.set_major_locator(
                                 mtick.MultipleLocator(y_divisions)
                             )
@@ -714,6 +756,8 @@ def main(args=None):
                                 )
                             ax.xaxis.set_major_formatter(xticks)
                         if x_axis_range != []:
+                            if x_axis_percentage is False:
+                                x_range = x_axis_range
                             plt.xlim(x_range[0], x_range[1])
                             ax.xaxis.set_major_locator(
                                 mtick.MultipleLocator(x_divisions)
@@ -739,21 +783,25 @@ def main(args=None):
                         fontsize=axis_font_size,
                         color="red" if len(input_files) == 1 else "black",
                     )
-                    if y_axis_range != []:
-                        y_divisions = (y_axis_range[1] - y_axis_range[0]) / 10
-                    if y_axis_percentage:
-                        if y_max is None:
-                            y_max = max(np.abs(output_arrays[input_file][output_name]))
-                        yticks = mtick.PercentFormatter(y_max)
-                        if y_axis_range != []:
-                            y_divisions = 5 * math.ceil(y_divisions / 5) * y_max / 100
-                            y_axis_range = (
-                                y_axis_range[0] * y_max / 100,
-                                y_axis_range[1] * y_max / 100,
+                    if y_axis_range2 != []:
+                        y_divisions2 = (y_axis_range2[1] - y_axis_range2[0]) / 10
+                    if y_axis_percentage2:
+                        if y_max2 is None:
+                            y_max2 = max(np.abs(output_arrays[input_file][output_name]))
+                        yticks2 = mtick.PercentFormatter(y_max2)
+                        if y_axis_range2 != []:
+                            y_divisions2 = (
+                                5 * math.ceil(y_divisions2 / 5) * y_max2 / 100
                             )
-                        ax2.yaxis.set_major_formatter(yticks)
-                    if y_axis_range != []:
-                        plt.ylim(y_axis_range[0], y_axis_range[1])
+                            y_range2 = (
+                                y_axis_range2[0] * y_max / 100,
+                                y_axis_range2[1] * y_max / 100,
+                            )
+                        ax2.yaxis.set_major_formatter(yticks2)
+                    if y_axis_range2 != []:
+                        if y_axis_percentage is False:
+                            y_range2 = y_axis_range2
+                        plt.ylim(y_range2[0], y_range2[1])
                         ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
                     plt.rc("xtick", labelsize=axis_tick_size)
                     plt.rc("ytick", labelsize=axis_tick_size)
@@ -988,13 +1036,15 @@ def main(args=None):
                     yticks = mtick.PercentFormatter(y_max)
                     if y_axis_range != []:
                         y_divisions = 5 * math.ceil(y_divisions / 5) * y_max / 100
-                        y_axis_range = (
+                        y_range = (
                             y_axis_range[0] * y_max / 100,
                             y_axis_range[1] * y_max / 100,
                         )
                     ax.yaxis.set_major_formatter(yticks)
                 if y_axis_range != []:
-                    plt.ylim(y_axis_range[0], y_axis_range[1])
+                    if y_axis_percentage is False:
+                        y_range = y_axis_range
+                    plt.ylim(y_range[0], y_range[1])
                     ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
                 if x_axis_range != []:
                     x_divisions = (x_axis_range[1] - x_axis_range[0]) / 10
@@ -1010,6 +1060,8 @@ def main(args=None):
                         )
                     ax.xaxis.set_major_formatter(xticks)
                 if x_axis_range != []:
+                    if x_axis_percentage is False:
+                        x_range = x_axis_range
                     plt.xlim(x_range[0], x_range[1])
                     ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))
                 plt.rc("xtick", labelsize=axis_tick_size)
@@ -1076,13 +1128,15 @@ def main(args=None):
                     yticks = mtick.PercentFormatter(y_max)
                     if y_axis_range != []:
                         y_divisions = 5 * math.ceil(y_divisions / 5) * y_max / 100
-                        y_axis_range = (
+                        y_range = (
                             y_axis_range[0] * y_max / 100,
                             y_axis_range[1] * y_max / 100,
                         )
                     ax.yaxis.set_major_formatter(yticks)
                 if y_axis_range != []:
-                    plt.ylim(y_axis_range[0], y_axis_range[1])
+                    if y_axis_percentage is False:
+                        y_range = y_axis_range
+                    plt.ylim(y_range[0], y_range[1])
                     ax.yaxis.set_major_locator(mtick.MultipleLocator(y_divisions))
                 x_data = [
                     m_file.data[scan_2_var_name].get_scan(i + 1)
@@ -1102,6 +1156,8 @@ def main(args=None):
                         )
                     ax.xaxis.set_major_formatter(xticks)
                 if x_axis_range != []:
+                    if x_axis_percentage is False:
+                        x_range = x_axis_range
                     plt.xlim(x_range[0], x_range[1])
                     ax.xaxis.set_major_locator(mtick.MultipleLocator(x_divisions))
                 plt.rc("xtick", labelsize=8)

--- a/process/io/plot_scans.py
+++ b/process/io/plot_scans.py
@@ -454,15 +454,18 @@ def main(args=None):
                 y_max += [None]
     else:
         y_max = np.float64(y_max_input)
-    if (len(y_max2_input) != len(output_names)) and (output_names2 != []):
-        y_max2 = []
-        for _ in range(len(output_names)):
-            if y_max2_input != []:
-                y_max2 += [np.float64(y_max2_input)]
-            else:
-                y_max2 += [None]
+    if output_names2 != []:
+        if len(y_max2_input) != len(output_names):
+            y_max2 = []
+            for _ in range(len(output_names)):
+                if y_max2_input != []:
+                    y_max2 += [np.float64(y_max2_input)]
+                else:
+                    y_max2 += [None]
+        else:
+            y_max2 = np.float64(y_max2_input)
     else:
-        y_max2 = np.float64(y_max2_input)
+        y_max2 = y_max2_input
     # -------------
 
     # Case of a set of 1D scans
@@ -811,7 +814,7 @@ def main(args=None):
                     if y_axis_percentage2:
                         if y_max2[index] is None:
                             y_max2[index] = max(
-                                np.abs(output_arrays[input_file][output_name])
+                                np.abs(output_arrays2[input_file][output_name2])
                             )
                         yticks2 = mtick.PercentFormatter(y_max2[index])
                         if y_axis_range2 != []:


### PR DESCRIPTION
closes #1875 

## Description

Added two new arguments to plot_scans.py: "--x_axis_percent" ("-x%") and "--y_axis_percent" ("-y%").

These will change the axis tick labels from absolute values to percentage values (based upon the maximum value from MFILE).

This was checked for the different plot options available in plot_scans:

[2Dcontour.pdf](https://github.com/user-attachments/files/19206422/2Dcontour.pdf)
[2dplot.pdf](https://github.com/user-attachments/files/19206423/2dplot.pdf)
[plot.pdf](https://github.com/user-attachments/files/19206424/plot.pdf)
[stackplot.pdf](https://github.com/user-attachments/files/19206425/stackplot.pdf)
[twinaxisplot.pdf](https://github.com/user-attachments/files/19206426/twinaxisplot.pdf)

Additionally, the tick label size was not functional for all plots so switched out the command used so that it now works, also added a new argument "--axis_ticklabel_size" ("-ats") that allows for it to be varied from the default, necessary for some cases when using percentages for the x axis.

Also added arguments: "--x_axis_range", "--x_axis_max", "--y_axis_range", "--x_axis_max" to allow for more options for graphs, these work with the percentage axes turned on or off. For the percentages cases the max and range values are as a percent rather than an absolute.

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
