### PR TITLE
📝 Add naming conventions for limit variables in documentation

### DIFF
--- a/documentation/proc-pages/development/standards.md
+++ b/documentation/proc-pages/development/standards.md
@@ -102,6 +102,11 @@ $$
 
 This means the variable represents the fraction of the TF coil area taken up by the winding pack.
 
+!!! note "Naming conventions with limit variables"
+
+    For naming variables which represent either upper or lower limits the words `_max` and `_min` should be used in the variable name. Though if a variable represents the highest of a measured value then the variable name should use the word `_peak`.
+
+
 --------------
 
 #### System designations


### PR DESCRIPTION
This pull request includes a small change to the `documentation/proc-pages/development/standards.md` file. The change adds a note on naming conventions for limit variables, specifying the use of `_max`, `_min`, and `_peak` in variable names.

* [`documentation/proc-pages/development/standards.md`](diffhunk://#diff-81a4fdc94aa7c6c4866edaa2c369fbf7eeeb5f8715db4203d2f91cdd8c095c53R105-R109): Added a note on naming conventions for limit variables, specifying `_max`, `_min`, and `_peak` for upper, lower, and highest measured values respectively.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
