### PR TITLE
Update FW docs part 1

### DIFF
--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -149,10 +149,10 @@ This function is used to calculate the first wall heating, it assumes the same c
 
 11. Set the effective heat transfer area equal to the pipe diameter
 
-12. Caclualte the temperature drop in the first wall material
+12. Calculate the temperature drop in the first wall material
 
     $$
-    \Delta T_{\text{FW}} = \frac{\text{Oneload} \times \mathtt{dr_fw}}{k 2r_{\text{channel}}}
+    \Delta T_{\text{FW}} = \frac{\text{Oneload} \times \texttt{dr_fw}}{k 2r_{\text{channel}}}
     $$
 
 13. Maximum distance traveled by surface heat load = $\texttt{diagonal}$
@@ -203,7 +203,7 @@ where $\texttt{tkfw}$ is the thermal conductivity of the first wall material and
     \mathrm{Re} = \frac{\rho v \left(2r_{\text{channel}}\right)}{\mu}
     $$
 
-    were $\rho$ is the coolant density and $\mu$ is the coolant viscosity.
+    where $\rho$ is the coolant density and $\mu$ is the coolant viscosity.
 
 2. **Calculate the Prandtl number:**
 
@@ -216,7 +216,7 @@ where $\texttt{tkfw}$ is the thermal conductivity of the first wall material and
 3. **Calculate the Darcy friction factor using the [`darcy_friction_haaland()`](#fw-coolant-friction--darcy_friction_haaland) method:**
 
     $$
-    f = \mathtt{darcy\_friction\_haaland()}
+    f = \texttt{darcy_friction_haaland()}
     $$
 
 4. **Calculate the Nusselt number using the [Gnielinski correlation](https://en.wikipedia.org/wiki/Nusselt_number#Gnielinski_correlation):**

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -136,7 +136,47 @@ where $\texttt{tkfw}$ is the thermal conductivity of the first wall material and
 
 ### FW heat transfer | `heat_transfer()`
 
-The temperature difference between the channel inner wall (film temperature) and the bulk coolant is calculated using the heat transfer coefficient, which is derived using the [Gnielinski correlation](https://en.wikipedia.org/wiki/Nusselt_number#Gnielinski_correlation). 
+1. **Calculate the Reynolds number:**
+
+    $$
+    \mathrm{Re} = \frac{\rho v \left(2r_{\text{channel}}\right)}{\mu}
+    $$
+
+    were $\rho$ is the coolant density and $\mu$ is the coolant viscosity.
+
+2. **Calculate the Prandtl number:**
+
+    $$
+    \mathrm{Pr} = \frac{c_{\text{p}}\mu}{k}
+    $$
+
+    were $c_{\text{p}}$ is the coolant heat capacity and $k$ is the coolant thermal conductivity.
+
+3. **Calculate the Darcy friction factor using the [`darcy_friction_haaland()`](#fw-coolant-friction--darcy_friction_haaland) method:**
+
+    $$
+    f = \mathtt{darcy\_friction\_haaland()}
+    $$
+
+4. **Calculate the Nusselt number using the [Gnielinski correlation](https://en.wikipedia.org/wiki/Nusselt_number#Gnielinski_correlation):**
+
+    $$
+    \mathrm{Nu_D}  = \frac{\left(f/8\right)\left(\mathrm{Re}-1000\right)\mathrm{Pr}}{1+12.7\left(f/8\right)^{0.5}\left(\mathrm{Pr}^{2/3}-1\right)}
+    $$
+
+    The relation is valid for:
+
+    $$
+    0.5 \le \mathrm{Pr} \le 2000 \\
+    3000 \le \mathrm{Re} \le 5 \times 10^6
+    $$
+
+5. **Calculate the heat transfer coefficient with the Nusselt number:**
+
+    $$
+    h = \frac{\mathrm{Nu_D}k}{2r_{\text{channel}}}
+    $$
+
 
 --------------
 

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -144,6 +144,9 @@ The temperature difference between the channel inner wall (film temperature) and
 
  The pressure drop is based on the Darcy fraction factor, using the [Haaland equation](https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Haaland_equation), an approximation to the implicit Colebrook–White equation. 
 
+$$
+\frac{1}{\sqrt{f}} = -1.8 \log{\left[ \left(\frac{\epsilon / D}{3.7}\right)^{1.11} \frac{6.9}{\text{Re}} \right]}
+$$
 
 ------------
 

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -140,7 +140,7 @@ The temperature difference between the channel inner wall (film temperature) and
 
 --------------
 
-### FW coolant friction | `friction()`
+### FW coolant friction | `darcy_friction_haaland()`
 
  The pressure drop is based on the Darcy fraction factor, using the [Haaland equation](https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Haaland_equation), an approximation to the implicit Colebrook–White equation. 
 

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -78,7 +78,11 @@ Summary of key variables and switches:
 The default thermo-hydraulic model assumes that a solid breeder is in use, with both the first wall and the breeding blanket using helium as a coolant.
 This can be changed using the switches detailed in the following subsection. 
 
-### First wall
+
+--------------
+
+## First wall
+
 <img
     title="First walld"
     src="../../images/first_wall.png"
@@ -89,6 +93,9 @@ This can be changed using the switches detailed in the following subsection.
 Figure 1: *First wall concept with coolant channels*
 
 The first wall is assumed to be thermally separate from the blanket (Figure 1).  No separation has been made between the structural part of the first wall and the armour.  A simple heuristic model has been used to estimate the peak temperature, as follows.
+
+### Calculate FW temperature | `fw_temp()`
+
 
 Minimum distance travelled by surface heat load = $\texttt{fw} \_ \texttt{wall}$
 
@@ -125,10 +132,33 @@ $$
 
 where $\texttt{tkfw}$ is the thermal conductivity of the first wall material and $\texttt{onedload}$ is the heat load per unit length.
 
-The temperature difference between the channel inner wall (film temperature) and the bulk coolant is calculated using the heat transfer coefficient, which is derived using the [Gnielinski correlation](https://en.wikipedia.org/wiki/Nusselt_number#Gnielinski_correlation).  The pressure drop is based on the Darcy fraction factor, using the [Haaland equation](https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Haaland_equation), an approximation to the implicit Colebrook–White equation.  The thermal conductivity of Eurofer is used, from "Fusion Demo Interim Structural Design Criteria - Appendix A Material Design Limit Data", F. Tavassoli, TW4-TTMS-005-D01, 2004"
+-------------
+
+### FW heat transfer | `heat_transfer()`
+
+The temperature difference between the channel inner wall (film temperature) and the bulk coolant is calculated using the heat transfer coefficient, which is derived using the [Gnielinski correlation](https://en.wikipedia.org/wiki/Nusselt_number#Gnielinski_correlation). 
+
+--------------
+
+### FW coolant friction | `friction()`
+
+ The pressure drop is based on the Darcy fraction factor, using the [Haaland equation](https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Haaland_equation), an approximation to the implicit Colebrook–White equation. 
+
+
+------------
+
+### FW thermal conductivity | `fw_thermal_conductivity()`
+
+The thermal conductivity of Eurofer is used, from "Fusion Demo Interim Structural Design Criteria - Appendix A Material Design Limit Data", F. Tavassoli, TW4-TTMS-005-D01, 2004"
+
+
+
 
 !!! Note "Note" 
     The pressure drop calculation is only performed for i_coolant_pumping = 2, as for 3 it is used as an input, as explained in the heat transport section.
+
+-------------
+
 
 ### Model Switches
 

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -149,13 +149,15 @@ The temperature difference between the channel inner wall (film temperature) and
 
 ### FW thermal conductivity | `fw_thermal_conductivity()`
 
-The thermal conductivity of Eurofer is used, from "Fusion Demo Interim Structural Design Criteria - Appendix A Material Design Limit Data", F. Tavassoli, TW4-TTMS-005-D01, 2004"
+The thermal conductivity of the first wall is assumed to be that of Eurofer97 using the relation below[^1] [^2]:
+ 
+$$
+K_{\text{Eurofer97}} = 5.4308 + 0.13565T - 0.00023862T^2 + 1.3393 \times 10^{-7} T^3
+$$
 
+!!! warning Thermal conductivity validity bounds
 
-
-
-!!! Note "Note" 
-    The pressure drop calculation is only performed for i_coolant_pumping = 2, as for 3 it is used as an input, as explained in the heat transport section.
+    The sources for the stated thermal conductivity relation above state that the relation is only valid up to 800K [^1] [^2].
 
 -------------
 
@@ -217,4 +219,9 @@ There are three model options, chosen by the user to match their selected blanke
 
 |         Variable         |   Units   | Itvar. | Usage       | Default | Description                                                         |
 | :----------------------: | :-------: | ------ | ----------- | ------- | ------------------------------------------------------------------- |
-| `bz_channel_conduct_liq` | A V-1 m-1 | 72     | i_blkt_liquid_breeder_channel_type = 0, 2 | 8.33D5  | Liquid metal coolant/breeder thin conductor or FCI wall conductance |
+| `bz_channel_conduct_liq` | A V-1 m-1 | 72     | ifci = 0, 2 | 8.33D5  | Liquid metal coolant/breeder thin conductor or FCI wall conductance |
+
+
+[^1]: A. A. Tavassoli et al., “Materials design data for reduced activation martensitic steel type EUROFER,” Journal of Nuclear Materials, vol. 329–333, pp. 257–262, Aug. 2004, doi: https://doi.org/10.1016/j.jnucmat.2004.04.020.
+
+[^2]: Tavassoli, F. "Fusion Demo Interim Structural Design Criteria (DISDC)/Appendix A Material Design Limit Data/A3. S18E Eurofer Steel." CEA, EFDA_TASK_TW4-TTMS-005-D01 (2004).

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -84,7 +84,7 @@ This can be changed using the switches detailed in the following subsection.
 ## First wall
 
 <img
-    title="First walld"
+    title="First wall"
     src="../../images/first_wall.png"
     alt="First wall"
     width="90%"
@@ -94,80 +94,84 @@ Figure 1: *First wall concept with coolant channels*
 
 The first wall is assumed to be thermally separate from the blanket (Figure 1).  No separation has been made between the structural part of the first wall and the armour.  A simple heuristic model has been used to estimate the peak temperature, as follows.
 
+----------------
+
 ### Calculate FW temperature | `fw_temp()`
 
 This function is used to calculate the first wall heating, it assumes the same coolant and geometry parameters for the inboard and outboard first wall though with different possible heat loads.
 
-1. The coolant properties at the inlet and outlet of the first wall are found for the required coolant type set using `i_fw_coolant_type`, the specificed inlet and outlet temperatures, `temp_fw_coolant_in` & `temp_fw_coolant_out` and the specified fixed pressure for the coolant, `pres_fw_coolant`.
+1. The coolant properties at the inlet and outlet of the first wall are determined using:
+    - `i_fw_coolant_type` (coolant type),
+    - `temp_fw_coolant_in` & `temp_fw_coolant_out` (inlet and outlet temperatures),
+    - `pres_fw_coolant` (fixed coolant pressure).
 
-2. Calculate the average coolant density and heat capacity factor by taking the averages of the inlet and outlet.
+2. Calculate the average coolant density and heat capacity by averaging the inlet and outlet values.
 
-3. Calculate the heat load per unit length (W/m) of a first wall segment with its own cooling pipe
+3. Compute the heat load per unit length $[\text{W/m}]$ of a first wall segment with its own cooling pipe:
 
-$$
-Load = \left(\mathtt{pden\_fw\_nuclear} \Delta r_{FW} + \mathtt{pflux\_fw\_rad}\right) \times \mathtt{dx\_fw\_module}
-$$
+    $$
+    \text{Load} = \left(\mathtt{pden\_fw\_nuclear} \Delta r_{FW} + \mathtt{pflux\_fw\_rad}\right) \times \mathtt{dx\_fw\_module}
+    $$
 
-4. Calculate the mean mass flow rate.
+4. Determine the mean mass flow rate:
 
-$$
-\dot{m} = \frac{L_{FW} \times Load}{c_{average} \left(T_{out} - T_{in}\right)}
-$$
+    $$
+    \dot{m} = \frac{L_{\text{FW}} \times \text{Load}}{c_{\text{average}} \left(T_{\text{out}} - T_{\text{in}}\right)}
+    $$
 
-5. Calculate the mass flux in a single channel
+5. Calculate the mass flux in a single channel:
 
+    $$
+    \text{Mass flux} = \frac{\dot{m}}{A_{\text{channel}}}
+    $$
 
-$$
-mass flux  = \frac{\dot{m}}{A_{\text{channel}}}
-$$
+6. Compute the coolant velocity:
 
-6. Calculate the coolant velocity
+    $$
+    \mathtt{vel\_fw\_coolant\_average} = \frac{\text{Mass flux}}{\rho_{\text{outlet}}}
+    $$
 
-$$
-\mathtt{vel\_fw\_coolant\_average} = \frac{mass flux}{\rho_{outlet}}
-$$
+7. Estimate the mean temperature between the outlet coolant and the peak FW structure temperature:
 
-7. Mean temperature between outlet coolant and peak FW structure temperature. Is the estimate from the previous iteration of the wall surface temperature
+    $$
+    \mathtt{temp_k} = \frac{T_{\text{outlet}} + T_{\text{FW,peak}}}{2}
+    $$
 
-$$
-\mathtt{temp_k} = \frac{T_{\text{outlet}}+ T_{\text{FW,peak}}}{2}
-$$
+8. Calculate the FW thermal conductivity at $\mathtt{temp_k}$ using the [`fw_thermal_conductivity()`](#fw-thermal-conductivity--fw_thermal_conductivity) function.
 
-8. Calculate the FW thermal conductivity at the $\mathtt{temp_k}$ temperature using the `fw_thermal_conductivity()` function
+9. Determine the heat transfer coefficient using the [`heat_transfer()`](#fw-heat-transfer--heat_transfer) function.
 
-9. Calculate the heat transfer coefficient with the `heat_transfer()` function.
+10. Compute the worst-case load.
 
-10. Calculate worst case load
-
-$$
-oneload = \mathtt{f\_fw\_peak} \times \frac{\mathtt{pden\_fw\_nuclear} \times \mathtt{dx\_fw\_module} \times \frac{\Delta r_{FW}}{4}}{\mathtt{pflux\_fw\_rad} \times \times \mathtt{dx\_fw\_module}}
-$$
+    $$
+    \text{Oneload} = \mathtt{f\_fw\_peak} \times \frac{\mathtt{pden\_fw\_nuclear} \times \mathtt{dx\_fw\_module} \times \frac{\Delta r_{FW}}{4}}{\mathtt{pflux\_fw\_rad} \times \times \mathtt{dx\_fw\_module}}
+    $$
 
 11. Set the effective heat transfer area equal to the pipe diameter
 
 12. Caclualte the temperature drop in the first wall material
 
-$$
-\Delta T_{\text{FW}} = \frac{oneload \times \mathtt{dr_fw}}{k 2r_{\text{channel}}}
-$$
+    $$
+    \Delta T_{\text{FW}} = \frac{\text{Oneload} \times \mathtt{dr_fw}}{k 2r_{\text{channel}}}
+    $$
 
 13. Maximum distance traveled by surface heat load = $\texttt{diagonal}$
 
-$$
-\texttt{diagonal}=\sqrt{(\texttt{radius_fw_channel}+\texttt{fw} \_ \texttt{wall})^2 + \left(\frac{\texttt{dx_fw_module}}{2}-\texttt{radius_fw_channel}\right)^2 }
-$$
+    $$
+    \texttt{diagonal}=\sqrt{(\texttt{radius_fw_channel}+\texttt{fw} \_ \texttt{wall})^2 + \left(\frac{\texttt{dx_fw_module}}{2}-\texttt{radius_fw_channel}\right)^2 }
+    $$
 
 14. Typical distance travelled by surface heat load:
 
-$$
-\texttt{mean} \_ \texttt{distance}=\frac{\texttt{fw} \_ \texttt{wall}+\texttt{diagonal}}{2}
-$$
+    $$
+    \texttt{mean} \_ \texttt{distance}=\frac{\texttt{fw} \_ \texttt{wall}+\texttt{diagonal}}{2}
+    $$
 
 15. 
 
-$$ 
-\texttt{mean\_width} = \frac{\texttt{dx_fw_module} + \pi \times \texttt{radius_fw_channel}}{2}
-$$
+    $$ 
+    \texttt{mean_width} = \frac{\texttt{dx_fw_module} + \pi \times \texttt{radius_fw_channel}}{2}
+    $$
 
 ------------------
 

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -96,33 +96,90 @@ The first wall is assumed to be thermally separate from the blanket (Figure 1). 
 
 ### Calculate FW temperature | `fw_temp()`
 
+This function is used to calculate the first wall heating, it assumes the same coolant and geometry parameters for the inboard and outboard first wall though with different possible heat loads.
 
-Minimum distance travelled by surface heat load = $\texttt{fw} \_ \texttt{wall}$
+1. The coolant properties at the inlet and outlet of the first wall are found for the required coolant type set using `i_fw_coolant_type`, the specificed inlet and outlet temperatures, `temp_fw_coolant_in` & `temp_fw_coolant_out` and the specified fixed pressure for the coolant, `pres_fw_coolant`.
 
-Maximum distance travelled by surface heat load = $\texttt{diagonal}$
+2. Calculate the average coolant density and heat capacity factor by taking the averages of the inlet and outlet.
+
+3. Calculate the heat load per unit length (W/m) of a first wall segment with its own cooling pipe
+
+$$
+Load = \left(\mathtt{pden\_fw\_nuclear} \Delta r_{FW} + \mathtt{pflux\_fw\_rad}\right) \times \mathtt{dx\_fw\_module}
+$$
+
+4. Calculate the mean mass flow rate.
+
+$$
+\dot{m} = \frac{L_{FW} \times Load}{c_{average} \left(T_{out} - T_{in}\right)}
+$$
+
+5. Calculate the mass flux in a single channel
+
+
+$$
+mass flux  = \frac{\dot{m}}{A_{\text{channel}}}
+$$
+
+6. Calculate the coolant velocity
+
+$$
+\mathtt{vel\_fw\_coolant\_average} = \frac{mass flux}{\rho_{outlet}}
+$$
+
+7. Mean temperature between outlet coolant and peak FW structure temperature. Is the estimate from the previous iteration of the wall surface temperature
+
+$$
+\mathtt{temp_k} = \frac{T_{\text{outlet}}+ T_{\text{FW,peak}}}{2}
+$$
+
+8. Calculate the FW thermal conductivity at the $\mathtt{temp_k}$ temperature using the `fw_thermal_conductivity()` function
+
+9. Calculate the heat transfer coefficient with the `heat_transfer()` function.
+
+10. Calculate worst case load
+
+$$
+oneload = \mathtt{f\_fw\_peak} \times \frac{\mathtt{pden\_fw\_nuclear} \times \mathtt{dx\_fw\_module} \times \frac{\Delta r_{FW}}{4}}{\mathtt{pflux\_fw\_rad} \times \times \mathtt{dx\_fw\_module}}
+$$
+
+11. Set the effective heat transfer area equal to the pipe diameter
+
+12. Caclualte the temperature drop in the first wall material
+
+$$
+\Delta T_{\text{FW}} = \frac{oneload \times \mathtt{dr_fw}}{k 2r_{\text{channel}}}
+$$
+
+13. Maximum distance traveled by surface heat load = $\texttt{diagonal}$
 
 $$
 \texttt{diagonal}=\sqrt{(\texttt{radius_fw_channel}+\texttt{fw} \_ \texttt{wall})^2 + \left(\frac{\texttt{dx_fw_module}}{2}-\texttt{radius_fw_channel}\right)^2 }
 $$
 
-Typical distance travelled by surface heat load:
+14. Typical distance travelled by surface heat load:
 
 $$
 \texttt{mean} \_ \texttt{distance}=\frac{\texttt{fw} \_ \texttt{wall}+\texttt{diagonal}}{2}
 $$
 
+15. 
 
+$$ 
+\texttt{mean\_width} = \frac{\texttt{dx_fw_module} + \pi \times \texttt{radius_fw_channel}}{2}
 $$
-\texttt{diagonal}=\sqrt{(\texttt{radius_fw_channel}+\texttt{fw} \_ \texttt{wall})^2 + \left(\frac{\texttt{dx_fw_module}}{2}-\texttt{radius_fw_channel}\right)^2 }
-$$
+
+------------------
+
+Minimum distance traveled by surface heat load = $\texttt{fw} \_ \texttt{wall}$
+
+
 
 The energy travels over a cross-section which is initially $= \texttt{dx_fw_module}$
 It spreads out, arriving at the coolant pipe over an area of half the circumference.
 We use the mean of these values:
 
-$$ 
-\texttt{mean} \_ \texttt{width} = \frac{\texttt{dx_fw_module} + \pi \times \texttt{radius_fw_channel}}{2}
-$$
+
 
 The temperature difference between the plasma-facing surface and the coolant is then:
 

--- a/documentation/proc-pages/eng-models/fw-blanket.md
+++ b/documentation/proc-pages/eng-models/fw-blanket.md
@@ -64,7 +64,7 @@ Summary of key variables and switches:
 |        width (m)         | `radius_fw_channel` (radius, cicular) | `radius_fw_channel`                    | `a_bz_liq`, `b_bz_liq` (rectangular) |
 |    wall thickness (m)    |        `dr_fw_wall`        | dr_fw_wall                  | `th_wall_secondary`                  |
 |        dx_fw_module (m)         |         `dx_fw_module`         | ---                      | ---                                  |
-|    roughness epsilon     |       `roughness`       | ---                      | ---                                  |
+|    roughness epsilon     |       `roughness_fw_channel`       | ---                      | ---                                  |
 |     peak FW temp (K)     |         `temp_fw_peak`         | ---                      | ---                                  |
 |     maximum temp (K)     |       `temp_fw_max`       | ---                      | ---                                  |
 |        FCI switch        |           ---           | ---                      | `i_blkt_liquid_breeder_channel_type`                               |

--- a/process/blanket_library.py
+++ b/process/blanket_library.py
@@ -1503,7 +1503,7 @@ class BlanketLibrary:
             width (m)                   radius_fw_channel (radius, cicular)   radius_fw_channel                 a_bz_liq, b_bz_liq (rectangular)
             wall thickness (m)          dr_fw_wall                 dr_fw_wall             th_wall_secondary
             dx_fw_module (m)                   dx_fw_module
-            roughness epsilon           roughness
+            roughness epsilon           roughness_fw_channel
             peak FW temp (K)            temp_fw_peak
             maximum temp (K)            temp_fw_max
             FCI switch                  ---                     ---                 i_blkt_liquid_breeder_channel_type
@@ -2009,8 +2009,8 @@ class BlanketLibrary:
             po.ovarre(
                 self.outfile,
                 "Roughness of first wall cooling channels (m)",
-                "(roughness)",
-                fwbs_variables.roughness,
+                "(roughness_fw_channel)",
+                fwbs_variables.roughness_fw_channel,
             )
             po.ovarrf(
                 self.outfile,

--- a/process/blanket_library.py
+++ b/process/blanket_library.py
@@ -2475,7 +2475,7 @@ class BlanketLibrary:
         # N.B. friction function Uses Haaland approx. which assumes a filled circular pipe.
         # Use dh which allows us to do fluid calculations for non-cicular tubes
         # (dh is estimate appropriate for fully developed flow).
-        lamda = self.fw.friction(
+        lamda = self.fw.darcy_friction_haaland(
             reyn, fwbs_variables.roughness_fw_channel, fwbs_variables.radius_fw_channel
         )
 

--- a/process/blanket_library.py
+++ b/process/blanket_library.py
@@ -2475,7 +2475,9 @@ class BlanketLibrary:
         # N.B. friction function Uses Haaland approx. which assumes a filled circular pipe.
         # Use dh which allows us to do fluid calculations for non-cicular tubes
         # (dh is estimate appropriate for fully developed flow).
-        lamda = self.fw.friction(reyn)
+        lamda = self.fw.friction(
+            reyn, fwbs_variables.roughness_fw_channel, fwbs_variables.radius_fw_channel
+        )
 
         # Pressure drop coefficient
 

--- a/process/dcll.py
+++ b/process/dcll.py
@@ -91,12 +91,6 @@ class DCLL:
         self.blanket_library = blanket_library
 
     def run(self, output: bool):
-        # MDK (27/11/2015)
-        build_variables.dr_fw_inboard = (
-            2 * fwbs_variables.radius_fw_channel + 2 * fwbs_variables.dr_fw_wall
-        )
-        build_variables.dr_fw_outboard = build_variables.dr_fw_inboard
-
         self.blanket_library.component_volumes()
         self.blanket_library.primary_coolant_properties(output=output)
         self.blanket_library.liquid_breeder_properties(output)

--- a/process/fw.py
+++ b/process/fw.py
@@ -707,7 +707,7 @@ def init_fwbs_variables():
     fwbs_variables.temp_fw_coolant_out = 823.0
     fwbs_variables.pres_fw_coolant = 15.5e6
     fwbs_variables.temp_fw_peak = 873.0
-    fwbs_variables.roughness = 1.0e-6
+    fwbs_variables.roughness_fw_channel = 1.0e-6
     fwbs_variables.len_fw_channel = 4.0
     fwbs_variables.f_fw_peak = 1.0
     fwbs_variables.pres_blkt_coolant = 15.50e6

--- a/process/fw.py
+++ b/process/fw.py
@@ -32,6 +32,14 @@ class Fw:
             fwbs_variables.dx_fw_module,
         )
 
+        self.set_fw_geometry()
+
+    def set_fw_geometry(self):
+        build_variables.dr_fw_inboard = (
+            2 * fwbs_variables.radius_fw_channel + 2 * fwbs_variables.dr_fw_wall
+        )
+        build_variables.dr_fw_outboard = build_variables.dr_fw_inboard
+
     def fw_temp(
         self,
         output: bool,

--- a/process/fw.py
+++ b/process/fw.py
@@ -437,7 +437,7 @@ class Fw:
 
         # Bracketed term in Haaland equation
         bracket = (
-            fwbs_variables.roughness / fwbs_variables.radius_fw_channel / 3.7
+            fwbs_variables.roughness_fw_channel / fwbs_variables.radius_fw_channel / 3.7
         ) ** 1.11 + 6.9 / reynolds
 
         # Calculate Darcy friction factor

--- a/process/fw.py
+++ b/process/fw.py
@@ -342,16 +342,30 @@ class Fw:
             mflow_fw_coolant,
         )
 
-    def fw_thermal_conductivity(self, t):
-        """Calculates the thermal conductivity of the first wall
-        t : input real : property temperature (K)
-        Calculates the thermal conductivity of Eurofer (W/m/K).
+    def fw_thermal_conductivity(self, temp: float) -> float:
         """
-        # Eurofer correlation, from "Fusion Demo Interim Structural Design Criteria -
-        # Appendix A Material Design Limit Data", F. Tavassoli, TW4-TTMS-005-D01, 2004
-        # t in Kelvin
+        Calculates the thermal conductivity of the first wall material (Eurofer97).
+
+        :param t: Property temperature in Kelvin (K).
+        :type t: float
+        :return: Thermal conductivity of Eurofer97 in W/m/K.
+        :rtype: float
+
+        :notes:
+            Valid up to about 800 K
+
+        :references:
+            - A. A. Tavassoli et al., “Materials design data for reduced activation martensitic steel type EUROFER,”
+            Journal of Nuclear Materials, vol. 329-333, pp. 257-262, Aug. 2004,
+            doi: https://doi.org/10.1016/j.jnucmat.2004.04.020.
+
+            - Tavassoli, F. "Fusion Demo Interim Structural Design Criteria (DISDC)/Appendix A Material Design Limit Data/A3. S18E Eurofer Steel."
+              CEA, EFDA_TASK_TW4-TTMS-005-D01 (2004)
+        """
+
+        # temp in Kelvin
         return (
-            (5.4308 + 0.13565 * t - 0.00023862 * t * t + 1.3393e-7 * t * t * t)
+            (5.4308 + 0.13565 * temp - 0.00023862 * temp**2 + 1.3393e-7 * temp**3)
             * fwbs_variables.fw_th_conductivity
             / 28.34
         )

--- a/process/fw.py
+++ b/process/fw.py
@@ -396,7 +396,11 @@ class Fw:
         pr = cf * viscf / kf
 
         # Calculate Darcy friction factor, using Haaland equation
-        f = self.friction(reynolds)
+        f = self.friction(
+            reynolds,
+            fwbs_variables.roughness_fw_channel,
+            fwbs_variables.radius_fw_channel,
+        )
 
         # Calculate the Nusselt number
         nusselt = (
@@ -425,19 +429,33 @@ class Fw:
 
         return heat_transfer
 
-    def friction(self, reynolds):
-        """Calculate Darcy friction factor, using Haaland equation
-        author: M Kovari, CCFE, Culham Science Centre
-        reynolds : input real : Reynolds number
-        darcy_friction : output real : Darcy friction factor
-        Darcy friction factor, using Haaland equation, an approximation to the
-        implicit Colebrook-White equationGnielinski correlation.
-        https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Haaland_equation
+    def friction(
+        self, reynolds: float, roughness_fw_channel: float, radius_fw_channel: float
+    ) -> float:
+        """
+        Calculate Darcy friction factor using the Haaland equation.
+
+        :param reynolds: Reynolds number.
+            :type reynolds: float
+            :param roughness_fw_channel: Roughness of the first wall coolant channel (m).
+            :type roughness_fw_channel: float
+            :param radius_fw_channel: Radius of the first wall coolant channel (m).
+            :type radius_fw_channel: float
+
+            :return: Darcy friction factor.
+            :rtype: float
+
+        :Notes:
+            The Haaland equation is an approximation to the implicit Colebrook-White equation.
+            It is used to calculate the Darcy friction factor for turbulent flow in pipes.
+
+        :References:
+            - https://en.wikipedia.org/wiki/Darcy_friction_factor_formulae#Haaland_equation
         """
 
         # Bracketed term in Haaland equation
         bracket = (
-            fwbs_variables.roughness_fw_channel / fwbs_variables.radius_fw_channel / 3.7
+            roughness_fw_channel / radius_fw_channel / 3.7
         ) ** 1.11 + 6.9 / reynolds
 
         # Calculate Darcy friction factor

--- a/process/fw.py
+++ b/process/fw.py
@@ -396,7 +396,7 @@ class Fw:
         pr = cf * viscf / kf
 
         # Calculate Darcy friction factor, using Haaland equation
-        f = self.friction(
+        f = self.darcy_friction_haaland(
             reynolds,
             fwbs_variables.roughness_fw_channel,
             fwbs_variables.radius_fw_channel,
@@ -429,7 +429,7 @@ class Fw:
 
         return heat_transfer
 
-    def friction(
+    def darcy_friction_haaland(
         self, reynolds: float, roughness_fw_channel: float, radius_fw_channel: float
     ) -> float:
         """

--- a/process/fw.py
+++ b/process/fw.py
@@ -45,18 +45,23 @@ class Fw:
         """
         Thermo-hydraulic calculations for the first wall.
 
-        Args:
-            output (bool): Flag to indicate if output is required.
-            radius_fw_channel (float): First wall coolant channel radius (m).
-            dr_fw (float): First wall thickness (m).
-            a_fw (float): Area of first wall section under consideration (m^2).
-            prad_incident (float): Surface heat flux on first wall (MW).
-            pnuc_deposited (float): Nuclear power deposited in FW (MW).
-            label (str): Information string.
+        :param output: Flag to indicate if output is required.
+        :type output: bool
+        :param radius_fw_channel: First wall coolant channel radius (m).
+        :type radius_fw_channel: float
+        :param dr_fw: First wall thickness (m).
+        :type dr_fw: float
+        :param a_fw: Area of first wall section under consideration (m^2).
+        :type a_fw: float
+        :param prad_incident: Radiation surface heat flux on first wall (MW).
+        :type prad_incident: float
+        :param pnuc_deposited: Nuclear power deposited in FW (MW).
+        :type pnuc_deposited: float
+        :param label: Information string.
+        :type label: str
 
-        Returns:
-            tuple: Contains peak first wall temperature (K), coolant specific heat capacity at constant pressure (J/kg/K),
-               coolant density (kg/m^3), and coolant mass flow rate in a single channel (kg/s).
+        :returns: Contains peak first wall temperature (K), coolant specific heat capacity at constant pressure (J/kg/K),
+        :rtype: tuple
 
         Detailed thermal hydraulic model for the blanket (first wall + breeding zone).
         Given the heating incident on the first wall, and the coolant outlet temperature,
@@ -103,9 +108,6 @@ class Fw:
             inlet_coolant_properties.density + outlet_coolant_properties.density
         ) / 2
 
-        # kfmean = (kfi + kfo) / 2  # coolant thermal conductivity (W/m.K)
-        # viscfmean = (viscfi + viscfo) / 2  # coolant viscosity (Pa.s)
-
         # Mean properties (inlet + outlet)/2
         # Average coolant specific heat capacity (J/K)
         heatcap_fw_coolant_average = (
@@ -131,7 +133,7 @@ class Fw:
         # Conditions at the outlet, where the temperature is highest
         # -----------------------------------------------------------
 
-        # coolant velocity (m/s)
+        # Coolant velocity (m/s)
         vel_fw_coolant_average = mflux_fw_coolant / outlet_coolant_properties.density
 
         # Mean temperature of the wall material on the plasma side of the coolant 'temp_fw_peak'
@@ -187,16 +189,11 @@ class Fw:
             + pflux_fw_rad * fwbs_variables.dx_fw_module
         )
 
-        # Note I do NOT assume that the channel covers the full width of the first wall:
         # Effective area for heat transfer (m2)
         effective_area_for_heat_transfer = 2 * radius_fw_channel
 
         # Temperature drop in first-wall material (K)
-        deltat_solid_1D = (
-            onedload
-            * fwbs_variables.dr_fw_wall
-            / (tkfw * effective_area_for_heat_transfer)
-        )
+        deltat_solid_1D = onedload * dr_fw / (tkfw * effective_area_for_heat_transfer)
 
         # Model C: A more realistic model !
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -205,7 +202,7 @@ class Fw:
         # dr_fw_wall | Minimum distance travelled by surface heat load (m)
         diagonal = np.sqrt(
             (fwbs_variables.dx_fw_module / 2 - radius_fw_channel) ** 2
-            + (radius_fw_channel + fwbs_variables.dr_fw_wall) ** 2
+            + (radius_fw_channel + dr_fw) ** 2
         )
 
         # Mean distance travelled by surface heat (m)

--- a/process/fw.py
+++ b/process/fw.py
@@ -432,11 +432,11 @@ class Fw:
             (f / 8.0)
             * (reynolds - 1000.0)
             * pr
-            / (1 + 12.7 * np.sqrt(f / 8.0) * (pr**0.6667 - 1.0))
+            / (1 + 12.7 * np.sqrt(f / 8.0) * (pr ** (2 / 3) - 1.0))
         )
 
-        # Calculate the heat transfer coefficient (W/m2K)
-        heat_transfer = nusselt * thermcond_coolant / (2.0 * radius_channel)
+        # Calculate the heat transfer coefficient (W/m^2K)
+        heat_transfer_coefficient = nusselt * thermcond_coolant / (2.0 * radius_channel)
 
         # Check that Reynolds number is in valid range for the Gnielinski correlation
         if (reynolds <= 3000.0) or (reynolds > 5.0e6):
@@ -452,7 +452,7 @@ class Fw:
         if f <= 0.0:
             error_handling.report_error(227)
 
-        return heat_transfer
+        return heat_transfer_coefficient
 
     def darcy_friction_haaland(
         self, reynolds: float, roughness_fw_channel: float, radius_fw_channel: float

--- a/process/fw.py
+++ b/process/fw.py
@@ -352,8 +352,8 @@ class Fw:
         """
         Calculates the thermal conductivity of the first wall material (Eurofer97).
 
-        :param t: Property temperature in Kelvin (K).
-        :type t: float
+        :param temp: Property temperature in Kelvin (K).
+        :type temp: float
         :return: Thermal conductivity of Eurofer97 in W/m/K.
         :rtype: float
 

--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -40,11 +40,8 @@ class CCFE_HCPB:
         self.blanket_library = blanket_library
 
     def run(self, output: bool):
-        # MDK (27/11/2015)
-        build_variables.dr_fw_inboard = (
-            2 * fwbs_variables.radius_fw_channel + 2 * fwbs_variables.dr_fw_wall
-        )
-        build_variables.dr_fw_outboard = build_variables.dr_fw_inboard
+        ccfe_hcpb_module.ip = int(output)
+        ccfe_hcpb_module.ofile = self.outfile
 
         # Coolant type
         fwbs_variables.i_blkt_coolant_type = 1

--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -40,9 +40,6 @@ class CCFE_HCPB:
         self.blanket_library = blanket_library
 
     def run(self, output: bool):
-        ccfe_hcpb_module.ip = int(output)
-        ccfe_hcpb_module.ofile = self.outfile
-
         # Coolant type
         fwbs_variables.i_blkt_coolant_type = 1
         # Note that the first wall coolant is now input separately.

--- a/process/input.py
+++ b/process/input.py
@@ -1120,7 +1120,9 @@ INPUT_VARIABLES = {
     "robotics_w": InputVariable(
         fortran.buildings_variables, float, range=(10.0, 1000.0)
     ),
-    "roughness": InputVariable(fortran.fwbs_variables, float, range=(0.0, 0.01)),
+    "roughness_fw_channel": InputVariable(
+        fortran.fwbs_variables, float, range=(0.0, 0.01)
+    ),
     "routr": InputVariable(fortran.pfcoil_variables, float, range=(-3.0, 3.0)),
     "row": InputVariable(fortran.buildings_variables, float, range=(0.0, 10.0)),
     "rpf1": InputVariable(fortran.pfcoil_variables, float, range=(0.0, 3.0)),

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -330,6 +330,7 @@ OBS_VARS = {
     "iprofile": None,
     "powfmax": "p_fusion_total_max_mw",
     "ffuspow": "fp_fusion_total_max_mw",
+    "roughness": "roughness_fw_channel",
 }
 
 OBS_VARS_HELP = {

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -347,6 +347,12 @@ class Stellarator:
             build_variables.dr_blkt_inboard + build_variables.dr_blkt_outboard
         )
 
+        # First Wall
+        build_variables.dr_fw_inboard = (
+            2.0e0 * fwbs_variables.radius_fw_channel + 2.0e0 * fwbs_variables.dr_fw_wall
+        )
+        build_variables.dr_fw_outboard = build_variables.dr_fw_inboard
+
         build_variables.dr_bore = physics_variables.rmajor - (
             build_variables.dr_cs
             + build_variables.dr_cs_tf_gap

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -347,12 +347,6 @@ class Stellarator:
             build_variables.dr_blkt_inboard + build_variables.dr_blkt_outboard
         )
 
-        # First Wall
-        build_variables.dr_fw_inboard = (
-            2.0e0 * fwbs_variables.radius_fw_channel + 2.0e0 * fwbs_variables.dr_fw_wall
-        )
-        build_variables.dr_fw_outboard = build_variables.dr_fw_inboard
-
         build_variables.dr_bore = physics_variables.rmajor - (
             build_variables.dr_cs
             + build_variables.dr_cs_tf_gap

--- a/source/fortran/fwbs_variables.f90
+++ b/source/fortran/fwbs_variables.f90
@@ -317,7 +317,7 @@ module fwbs_variables
   real(dp) :: temp_fw_peak
   !! peak first wall temperature [K]
 
-  real(dp) :: roughness
+  real(dp) :: roughness_fw_channel
   !! first wall channel roughness epsilon [m]
 
   real(dp) :: len_fw_channel

--- a/tests/integration/test_blanket_library_int.py
+++ b/tests/integration/test_blanket_library_int.py
@@ -188,7 +188,7 @@ def test_pressure_drop(monkeypatch, blanket_library_fixture):
     monkeypatch.setattr(fwbs, "radius_fw_channel", 1.0)
     monkeypatch.setattr(fwbs, "a_bz_liq", 1.0)
     monkeypatch.setattr(fwbs, "b_bz_liq", 1.0)
-    monkeypatch.setattr(fwbs, "roughness", 1.0e-6)
+    monkeypatch.setattr(fwbs, "roughness_fw_channel", 1.0e-6)
 
     # input = ip, ofile, i_ps, num_90, num_180, l_pipe, den, vsc, vv, label
     assert blanket_library_fixture.pressure_drop(

--- a/tests/regression/input_files/st_regression.IN.DAT
+++ b/tests/regression/input_files/st_regression.IN.DAT
@@ -2290,7 +2290,7 @@ i_fw_coolant_type = helium
 * 'water'
 * JUSTIFICATION: Not yet set.
 
-*roughness = 
+*roughness_fw_channel = 
 * DESCRIPTION:   First wall channel roughness epsilon [m] (default = 1.0D-6)
 * JUSTIFICATION: Not yet set.
 

--- a/tests/unit/test_blanket_library.py
+++ b/tests/unit/test_blanket_library.py
@@ -1652,7 +1652,7 @@ class PressureDropParam(NamedTuple):
     radius_fw_channel: Any = None
     a_bz_liq: Any = None
     b_bz_liq: Any = None
-    roughness: Any = None
+    roughness_fw_channel: Any = None
     ip: Any = None
     ofile: Any = None
     i_ps: Any = None
@@ -1673,7 +1673,7 @@ class PressureDropParam(NamedTuple):
             radius_fw_channel=0.0060000000000000001,
             a_bz_liq=0.20000000000000001,
             b_bz_liq=0.20000000000000001,
-            roughness=9.9999999999999995e-07,
+            roughness_fw_channel=9.9999999999999995e-07,
             ip=0,
             ofile=11,
             i_ps=1,
@@ -1705,7 +1705,9 @@ def test_pressure_drop(pressuredropparam, monkeypatch, blanket_library_fixture):
     )
     monkeypatch.setattr(fwbs_variables, "a_bz_liq", pressuredropparam.a_bz_liq)
     monkeypatch.setattr(fwbs_variables, "b_bz_liq", pressuredropparam.b_bz_liq)
-    monkeypatch.setattr(fwbs_variables, "roughness", pressuredropparam.roughness)
+    monkeypatch.setattr(
+        fwbs_variables, "roughness_fw_channel", pressuredropparam.roughness_fw_channel
+    )
 
     pressure_drop_out = blanket_library_fixture.pressure_drop(
         i_ps=pressuredropparam.i_ps,

--- a/tests/unit/test_fw.py
+++ b/tests/unit/test_fw.py
@@ -166,11 +166,11 @@ def test_fw_temp(fwtempparam, monkeypatch, fw):
     assert massrate == pytest.approx(fwtempparam.expected_massrate, rel=1e-4)
 
 
-def test_friction(monkeypatch, fw):
+def test_darcy_friction_haaland(monkeypatch, fw):
     monkeypatch.setattr(fwbs_variables, "radius_fw_channel", 0.1)
     monkeypatch.setattr(fwbs_variables, "roughness_fw_channel", 1e-6)
 
-    assert fw.friction(5500) == pytest.approx(0.0366668931278784)
+    assert fw.darcy_friction_haaland(5500) == pytest.approx(0.0366668931278784)
 
 
 def test_heat_transfer(fw):

--- a/tests/unit/test_fw.py
+++ b/tests/unit/test_fw.py
@@ -168,7 +168,7 @@ def test_fw_temp(fwtempparam, monkeypatch, fw):
 
 def test_friction(monkeypatch, fw):
     monkeypatch.setattr(fwbs_variables, "radius_fw_channel", 0.1)
-    monkeypatch.setattr(fwbs_variables, "roughness", 1e-6)
+    monkeypatch.setattr(fwbs_variables, "roughness_fw_channel", 1e-6)
 
     assert fw.friction(5500) == pytest.approx(0.0366668931278784)
 

--- a/tests/unit/test_fw.py
+++ b/tests/unit/test_fw.py
@@ -166,21 +166,21 @@ def test_fw_temp(fwtempparam, monkeypatch, fw):
     assert massrate == pytest.approx(fwtempparam.expected_massrate, rel=1e-4)
 
 
-def test_darcy_friction_haaland(monkeypatch, fw):
-    monkeypatch.setattr(fwbs_variables, "radius_fw_channel", 0.1)
-    monkeypatch.setattr(fwbs_variables, "roughness_fw_channel", 1e-6)
-
-    assert fw.darcy_friction_haaland(5500) == pytest.approx(0.0366668931278784)
+def test_darcy_friction_haaland(fw):
+    assert fw.darcy_friction_haaland(5500, 1e-6, 0.1) == pytest.approx(
+        0.0366668931278784
+    )
 
 
 def test_heat_transfer(fw):
     assert fw.heat_transfer(
-        masflx=112.19853108876258,
-        rhof=8.8673250601290707,
-        radius=0.0060000000000000001,
-        cf=5184.9330299967578,
-        viscf=4.0416219836935569e-05,
-        kf=0.3211653052986152,
+        mflux_coolant=112.19853108876258,
+        den_coolant=8.8673250601290707,
+        radius_channel=0.0060000000000000001,
+        heatcap_coolant=5184.9330299967578,
+        visc_coolant=4.0416219836935569e-05,
+        thermcond_coolant=0.3211653052986152,
+        roughness_fw_channel=6e-8,
     ) == pytest.approx(1929.221015448999)
 
 

--- a/tests/unit/test_fw.py
+++ b/tests/unit/test_fw.py
@@ -78,7 +78,7 @@ class FwTempParam(NamedTuple):
             area=612.23369764444396,
             prad_incident=97.271629070225231,
             label="Inboard first wall",
-            expected_tpeakfw=827.22264979106728,
+            expected_tpeakfw=846.4965128389427,
             expected_cfmean=5188.6731857247905,
             expected_rhofmean=5.7616377393642955,
             expected_massrate=0.0054299309578952218,
@@ -100,7 +100,7 @@ class FwTempParam(NamedTuple):
             area=988.92586580655245,
             prad_incident=176.95628839065773,
             label="Outboard first wall",
-            expected_tpeakfw=829.53877268685892,
+            expected_tpeakfw=850.851622254886,
             expected_cfmean=5188.6731857247905,
             expected_rhofmean=5.7616377393642955,
             expected_massrate=0.005816503189155049,
@@ -181,7 +181,7 @@ def test_heat_transfer(fw):
         visc_coolant=4.0416219836935569e-05,
         thermcond_coolant=0.3211653052986152,
         roughness_fw_channel=6e-8,
-    ) == pytest.approx(1929.221015448999)
+    ) == pytest.approx(1929.2042015869506)
 
 
 def test_fw_thermal_conductivity(monkeypatch, fw):


### PR DESCRIPTION
## Description
This pull request includes changes to the documentation and codebase related to the first wall (FW) thermo-hydraulic model and calculations. The changes primarily focus on updating variable names, improving documentation clarity, and enhancing the calculation methods.

------------

### 🔄  Variable changes

`roughness` -> `roughness_fw_channel`

-------------------

### Documentation Updates:
* Updated variable names in `documentation/proc-pages/eng-models/fw-blanket.md` to reflect the new naming conventions, such as changing `roughness` to `roughness_fw_channel` and adding detailed descriptions of the FW temperature calculation and heat transfer processes. 

### Codebase Updates:
* Updated `process/blanket_library.py` to use the new variable `roughness_fw_channel` in the `thermo_hydraulic_model` and `pressure_drop` methods. 
* Added a new method `set_fw_geometry` in `process/fw.py` to set the geometry parameters for the first wall and updated the `fw_temp` method to use the new variable names and improve the calculation process. 

These changes enhance the clarity and accuracy of the first wall thermo-hydraulic model documentation and improve the consistency and reliability of the related codebase.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
