### PR TITLE
Constraint OSQP version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup_kwargs = {
         "numpy>=1.23,<2",
         "scipy>=1.10",
         "cvxpy!=1.3.0,!=1.3.1",
+        "osqp<1.0",
         "pandas>=2.0",
         "tables",
         "SALib",


### PR DESCRIPTION
Constrains OSQP version to be less than 1.0 until we can investigate and verify the changes caused by their new major release.