### PR TITLE
Check for string in MFile output with both quote characters

### DIFF
--- a/process/io/mfile.py
+++ b/process/io/mfile.py
@@ -353,7 +353,7 @@ def sort_value(value_words: list[str]) -> str | float:
     :return: string or float representation of value list
     :rtype: Union[str, float]
     """
-    if '"' in value_words[0]:
+    if any(c in value_words[0] for c in ['"', "'"]):
         # First "word" begins with ": return words as single str
         return " ".join(value_words).strip().strip('"').strip()
     try:


### PR DESCRIPTION
Originally we just checked if something was a string if it started with a `"`. We now additionally check if a single quote is used `'`.