### PR TITLE
change test to assert instead of returning a value

### DIFF
--- a/tests/unit/test_mfile2dict.py
+++ b/tests/unit/test_mfile2dict.py
@@ -34,7 +34,7 @@ def test_parser_succeed(read_mfile):
 
 
 def test_value_read(read_mfile):
-    return isinstance(read_mfile.get_parameter_value("lsa"), int)
+    assert isinstance(read_mfile.get_parameter_value("lsa"), int)
 
 
 def test_write_json(read_mfile, temporary_dir):


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

Searched through the tests directory to find instances where tests were returning something instead of asserting. Only found that `test_value_read` in test_mfile2dict.py was returning a value, so have changed this to use an assert.

Closes #3597 

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
