### PR TITLE
Corrected obsolete var

### DIFF
--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -268,7 +268,7 @@ OBS_VARS = {
     "li6enrich": "f_blkt_li6_enrichment",
     "nblktmodto": "n_blkt_outboard_modules_toroidal",
     "i_bb_liq": "i_blkt_liquid_breeder_type",
-    "icooldual": "i_blkt_coolant_dual",
+    "icooldual": "i_blkt_dual_coolant",
     "ifci": "i_blkt_liquid_breeder_channel_type",
     "ipump": "i_fw_blkt_shared_coolant",
     "coolwh": "i_blkt_coolant_type",


### PR DESCRIPTION
## Description

Corrected `icooldual: i_blkt_coolant_dual` to `i_blkt_dual_coolant` as updating obsolete vars during a process run would then result in an error.

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
