### PR TITLE
Update how the various magnetic fields in pf_coil.py are handled

### DIFF
--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -1171,10 +1171,16 @@ class PFCoil:
             pfv.z_pf_coil_middle[pfv.n_cs_pf_coils - 1],
             pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1],
             pfv.z_pf_coil_middle[pfv.n_cs_pf_coils - 1],
-            pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1]
-            - pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1],
-            pfv.z_pf_coil_upper[pfv.n_cs_pf_coils - 1]
-            - pfv.z_pf_coil_lower[pfv.n_cs_pf_coils - 1],
+            0.5
+            * (
+                pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1]
+                - pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1]
+            ),
+            0.5
+            * (
+                pfv.z_pf_coil_upper[pfv.n_cs_pf_coils - 1]
+                - pfv.z_pf_coil_lower[pfv.n_cs_pf_coils - 1]
+            ),
             current,
         )
         br_outer, bz_outer, psi_outer = semianalytic(
@@ -1182,17 +1188,22 @@ class PFCoil:
             pfv.z_pf_coil_middle[pfv.n_cs_pf_coils - 1],
             pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1],
             pfv.z_pf_coil_middle[pfv.n_cs_pf_coils - 1],
-            pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1]
-            - pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1],
-            pfv.z_pf_coil_upper[pfv.n_cs_pf_coils - 1]
-            - pfv.z_pf_coil_lower[pfv.n_cs_pf_coils - 1],
+            0.5
+            * (
+                pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1]
+                - pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1]
+            ),
+            0.5
+            * (
+                pfv.z_pf_coil_upper[pfv.n_cs_pf_coils - 1]
+                - pfv.z_pf_coil_lower[pfv.n_cs_pf_coils - 1]
+            ),
             current,
         )
 
         # Peak field due to other PF coils plus plasma
         timepoint = 5
         bri, bro, bzi, bzo = self.peakb(pfv.n_cs_pf_coils - 1, 99 - 1, timepoint)
-
         pfv.b_cs_peak_flat_top_end = abs(bzi + bz_inner)
 
         # Peak field on outboard side of central Solenoid
@@ -1209,10 +1220,16 @@ class PFCoil:
             pfv.z_pf_coil_middle[pfv.n_cs_pf_coils - 1],
             pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1],
             pfv.z_pf_coil_middle[pfv.n_cs_pf_coils - 1],
-            pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1]
-            - pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1],
-            pfv.z_pf_coil_upper[pfv.n_cs_pf_coils - 1]
-            - pfv.z_pf_coil_lower[pfv.n_cs_pf_coils - 1],
+            0.5
+            * (
+                pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1]
+                - pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1]
+            ),
+            0.5
+            * (
+                pfv.z_pf_coil_upper[pfv.n_cs_pf_coils - 1]
+                - pfv.z_pf_coil_lower[pfv.n_cs_pf_coils - 1]
+            ),
             current,
         )
         br_outer, bz_outer, psi_outer = semianalytic(
@@ -1220,15 +1237,20 @@ class PFCoil:
             pfv.z_pf_coil_middle[pfv.n_cs_pf_coils - 1],
             pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1],
             pfv.z_pf_coil_middle[pfv.n_cs_pf_coils - 1],
-            pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1]
-            - pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1],
-            pfv.z_pf_coil_upper[pfv.n_cs_pf_coils - 1]
-            - pfv.z_pf_coil_lower[pfv.n_cs_pf_coils - 1],
+            0.5
+            * (
+                pfv.r_pf_coil_outer[pfv.n_cs_pf_coils - 1]
+                - pfv.r_pf_coil_inner[pfv.n_cs_pf_coils - 1]
+            ),
+            0.5
+            * (
+                pfv.z_pf_coil_upper[pfv.n_cs_pf_coils - 1]
+                - pfv.z_pf_coil_lower[pfv.n_cs_pf_coils - 1]
+            ),
             current,
         )
         timepoint = 2
         bri, bro, bzi, bzo = self.peakb(pfv.n_cs_pf_coils - 1, 99 - 1, timepoint)
-
         pfv.b_cs_peak_pulse_start = abs(bz_inner + bzi)
 
         # Maximum field values
@@ -1332,7 +1354,6 @@ class PFCoil:
         if pfv.i_pf_conductor == 0:
             # Allowable coil overall current density at EOF
             # (superconducting coils only)
-
             (
                 jcritwp,
                 pfv.jcableoh_eof,
@@ -1363,7 +1384,6 @@ class PFCoil:
             pfv.j_cs_critical_flat_top_end = jcritwp * pfv.awpoh / pfv.a_cs_poloidal
 
             # Allowable coil overall current density at BOP
-
             (
                 jcritwp,
                 pfv.jcableoh_bop,
@@ -1483,8 +1503,8 @@ class PFCoil:
                 if jj == i:
                     rp = np.array([pfv.r_pf_coil_inner[i], pfv.r_pf_coil_outer[i]])
                     zp = np.array([pfv.z_pf_coil_middle[jj], pfv.z_pf_coil_middle[jj]])
-                    dr = pfv.r_pf_coil_outer[i] - pfv.r_pf_coil_inner[i]
-                    dz = pfv.z_pf_coil_upper[jj] - pfv.z_pf_coil_lower[jj]
+                    dr = 0.5 * (pfv.r_pf_coil_outer[i] - pfv.r_pf_coil_inner[i])
+                    dz = 0.5 * (pfv.z_pf_coil_upper[jj] - pfv.z_pf_coil_lower[jj])
                     self_current = current
                     self_rc = pfv.r_pf_coil_middle[jj]
                     self_zc = pfv.z_pf_coil_middle[jj]
@@ -3087,7 +3107,6 @@ class PFCoil:
                 arguments = (isumat, jsc, bmax, strain, bc20m, tc0m, c0)
             else:
                 arguments = (isumat, jsc, bmax, strain, bc20m, tc0m)
-
             another_estimate = 2 * thelium
             t_zero_margin, root_result = optimize.newton(
                 superconductors.current_density_margin,

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -1518,7 +1518,6 @@ class PFCoil:
         pf.xind[:kk] = mutual_inductance(
             pf.rfxf[:kk],
             pf.zfxf[:kk],
-            pf.cfxf[:kk],
             pfv.r_pf_coil_inner[i],
             pfv.z_pf_coil_middle[i],
         )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup_kwargs = {
     "install_requires": [
         "numpy>=1.23,<2",
         "scipy>=1.10",
+        "numba-scipy @ git+https://github.com/numba/numba-scipy@23c3b33440ea1fe0f84d05d269fb4a3df4b92787",
         "cvxpy!=1.3.0,!=1.3.1",
         "osqp<1.0",
         "pandas>=2.0",
@@ -52,7 +53,10 @@ setup_kwargs = {
         "test": ["pytest>=5.4.1", "requests>=2.30", "testbook>=0.4"],
         "examples": ["pillow>=5.1.0", "jupyter==1.0.0", "pdf2image==1.16.0"],
     },
-    "entry_points": {"console_scripts": ["process=process.main:main"]},
+    "entry_points": {
+        "console_scripts": ["process=process.main:main"],
+        "numba_extensions": ["init = numba_scipy:_init_extension"],
+    },
     "extra_link_args": EXTRA_ARGS,
 }
 


### PR DESCRIPTION
## Description

Closes https://github.com/ukaea/PROCESS/issues/1883 

Replaced various magnetic field methods: the CS self field (bfmax), the general PF coil self field, all coil field contributions to other coils.

CS check:

Reference Bluemira plot for k, B0 and Bmax for a current of 1.0. Here B0 is the central point of the CS coil ie r->0 whilst Bmax is at the inner edge of the CS coil.

![bluemira_cs](https://github.com/user-attachments/assets/5b30e4ad-da0d-4424-baa3-a9630983a72b)

The changes to the code result in the following plot for PROCESS (same params as Bluemira with current at 1.0).

![process_cs_new](https://github.com/user-attachments/assets/12ae6d1f-2129-4a70-b4ae-658398e87f4f)

The original result for PROCESS before the changes are:

![process_cs_old](https://github.com/user-attachments/assets/036fb478-0ddb-4b85-bd09-a602327b03f9)

These results all seem similar to each other but there are some differences. Firstly, the old process method has curves that differ compared to the other 2, most noticeable in the k and Bm graphs. There is a slight difference from Bluemira to the PROCESS new method even though they should be near identical. In terms of improvement it is most beneficial in the regions of higher alpha or beta.


## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
