### PR TITLE
Iteration variable names too long

### DIFF
--- a/process/utilities/f2py_string_patch.py
+++ b/process/utilities/f2py_string_patch.py
@@ -41,16 +41,15 @@ def string_to_f2py_compatible(
         )
 
     if string:
+        warning_msg = (
+            f"String '{string}' of length {len(string)} is being set on a Fortran variable "
+            f"with length {target_size}"
+        )
         if len(string) > target_size and except_length:
-            raise RuntimeError(
-                f"String {string} of length {len(string)} is trying to initiate as {target} with length {target_size}"
-            )
+            raise RuntimeError(warning_msg)
         if len(string) > target_size:
             warnings.warn(
-                (
-                    f"String {string} of length {len(string)} is trying to initiate as {target} with length"
-                    f"{target_size}. String string will be truncated!"
-                ),
+                f"{warning_msg}. The string will be truncated!",
                 stacklevel=2,
             )
 

--- a/source/fortran/numerics.f90
+++ b/source/fortran/numerics.f90
@@ -383,7 +383,7 @@ module numerics
   !! <LI> (175) EMPTY : Description
   ! Issue 287 iteration variables are now defined in module define_iteration_variables in iteration variables.f90
 
-  character*14, dimension(ipnvars) :: name_xc
+  character*32, dimension(ipnvars) :: name_xc
 
   real(dp) :: sqsumsq
   !!  sqsumsq : sqrt of the sum of the square of the constraint residuals


### PR DESCRIPTION
Updates the error/warning message when a variable that is too long is set across the fortran interface. 

Increases the max length of each iteration variable name to 32 (the longest was 31 characters).