### PR TITLE
Refactor `iprofile`

### DIFF
--- a/documentation/proc-pages/physics-models/plasma_beta/plasma_beta.md
+++ b/documentation/proc-pages/physics-models/plasma_beta/plasma_beta.md
@@ -116,43 +116,50 @@ By default, $\beta$ is defined with respect to the total equilibrium B-field. Th
 
 ### Setting the Beta $g$ Coefficient
 
-Switch `iprofile` determines how the beta $g$ coefficient `beta_norm_max` should
+Switch `i_beta_norm_max` determines how the beta $g$ coefficient `beta_norm_max` should
 be calculated. The following switch options are available below:
 
 #### User Input
 
-This can be activated by stating `iprofile = 0` in the input file.
+The user can specify the maximum allowed value of $\beta_{\text{N}}$ directly by stating `i_beta_norm_max = 0` in the input file.
 
-`alphaj`, `ind_plasma_internal_norm` and `beta_norm_max` are inputs.
+```python
+IN.DAT
+
+i_beta_norm_max = 0
+beta_norm_max = 3.0
+
+
+```
 
 ---------
 
 #### Wesson Relation
 
-This can be activated by stating `iprofile = 1` in the input file.
+This can be activated by stating `i_beta_norm_max = 1` in the input file.
 
-`alphaj`, `ind_plasma_internal_norm` and `beta_norm_max` are calculated consistently. 
-
-`beta_norm_max` is calculated using:  
+`beta_norm_max` is set to `beta_norm_max_wesson` using:  
 
 $$
-g = 4l_i
+\texttt{beta_norm_max_wesson} = g = 4l_i
 $$
 
 This relation is based off of data taken from DIII-D shots[^7].
 
 This is only recommended for high aspect ratio tokamaks[^3].
 
+**It is recommended to use this switch with `i_alphaj = 1` and `i_ind_plasma_internal_norm = 1` as they are self consistent with each other.**
+
 ---------
 
 #### Original Scaling Law
 
-This can be activated by stating `iprofile = 2` in the input file.
+This can be activated by stating `i_beta_norm_max = 2` in the input file.
 
-`alphaj` and `ind_plasma_internal_norm` are inputs. `beta_norm_max` calculated using:
+`beta_norm_max` is set to `beta_norm_max_original_scaling` using:  
 
 $$
-g=2.7(1+5\epsilon^{3.5})
+\texttt{beta_norm_max_original_scaling} = g =2.7(1+5\epsilon^{3.5})
 $$ 
 
 <!DOCTYPE html>
@@ -222,13 +229,18 @@ $$
 
 #### Menard Beta Relation
 
-This can be activated by stating `iprofile = 3` in the input file.
+This can be activated by stating `i_beta_norm_max = 3` in the input file.
 
-`alphaj` and `ind_plasma_internal_norm` are inputs. `beta_norm_max` calculated using[^4]:
+`beta_norm_max` is set to `beta_norm_max_menard` using[^4]:
+
 
 $$
-g=3.12+3.5\epsilon^{1.7}
+\texttt{beta_norm_max_menard} = g =3.12+3.5\epsilon^{1.7}
 $$
+
+**This is only recommended for spherical tokamaks**
+
+**It is recommended to use this switch with `i_ind_plasma_internal_norm = 2` as they are self consistent with each other.**
 
 <!DOCTYPE html>
 <html lang="en">
@@ -295,27 +307,12 @@ $$
 
 ---------
 
-#### Menard Inductance Relation
-
-This can be activated by stating `iprofile = 4` in the input file.
-
-`alphaj` and `beta_norm_max` are inputs. `ind_plasma_internal_norm` calculated from elongation [^4]. This is only recommended for spherical tokamaks.
-
----------
-
-#### Menard Beta & Inductance Relation
-
-This can be activated by stating `iprofile = 5` in the input file.
-
-`alphaj` is an input.  `ind_plasma_internal_norm` calculated from elongation and `beta_norm_max` calculated using $g=3.12+3.5\epsilon^{1.7}$ [^4]. This is only recommended for spherical tokamaks.
-
----------
-
 #### Tholerus Relation
 
-This can be activated by stating `iprofile = 6` in the input file.
+This can be activated by stating `i_beta_norm_max = 4` in the input file.
 
-`alphaj` and `c_beta` are inputs.  `ind_plasma_internal_norm` calculated from elongation and `beta_norm_max` calculated using 
+`beta_norm_max` is set to `beta_norm_max_tholerus` using[^5]:
+
 
 $$
 C_{\beta}\approx\frac{(g-3.7)F_p}{12.5-3.5 F_p}
@@ -323,13 +320,9 @@ $$
 
 where $F_p$ is the pressure peaking, $F_p = p_{\text{ax}} / \langle p \rangle$ and $C_{\beta}$ is the destabilization parameter (default 0.5)[^5].  
 
-<u> This is only recommended for spherical tokamaks </u>
+**This is only recommended for spherical tokamaks**
 
 ---------
-
-Further details on the calculation of `alphaj` and `ind_plasma_internal_norm` is given in [Plasma Current](./plasma_current.md).
-
-----------------------
 
 ## Key Constraints
 
@@ -373,7 +366,7 @@ This constraint can be activated by stating `icc = 24` in the input file.
 It is the general setting of the $\beta$ limit depending on the $\beta_{\text{N}}$ value calculated in the [beta limit](#beta-limit) calculations.
 
 The upper limit value of beta is calculated by `calculate_beta_limit()`. The beta
-coefficient $g$ can be set using `beta_norm_max`, depending on the setting of [`iprofile`](#setting-the-beta--coefficient). It can be set directly or follow some relation.
+coefficient $g$ can be set using `beta_norm_max`, depending on the setting of [`i_beta_norm_max`](#setting-the-beta--coefficient). It can be set directly or follow some relation.
 
 The scaling value `fbeta_max` can be varied also.
 

--- a/documentation/proc-pages/physics-models/plasma_beta/plasma_beta.md
+++ b/documentation/proc-pages/physics-models/plasma_beta/plasma_beta.md
@@ -114,7 +114,7 @@ By default, $\beta$ is defined with respect to the total equilibrium B-field. Th
 
 ------------
 
-### Setting the Beta $g$ Coefficient
+### Setting the Beta g Coefficient
 
 Switch `i_beta_norm_max` determines how the beta $g$ coefficient `beta_norm_max` should
 be calculated. The following switch options are available below:
@@ -148,7 +148,7 @@ This relation is based off of data taken from DIII-D shots[^7].
 
 This is only recommended for high aspect ratio tokamaks[^3].
 
-**It is recommended to use this switch with [`i_alphaj = 1`](../plasma_current/plasma_current.md#wesson-relation) and [`i_ind_plasma_internal_norm = 1`](../plasma_current/plasma_inductance.md#wesson-relation) as they are self consistent with each other.**
+**It is recommended to use this switch with [`i_alphaj = 1`](../plasma_current/plasma_current.md#wesson-relation) and [`i_ind_plasma_internal_norm = 1`](../plasma_current/plasma_inductance.md#wesson-relation) as they are self-consistent with each other.**
 
 ---------
 
@@ -240,7 +240,7 @@ $$
 
 **This is only recommended for spherical tokamaks**
 
-**It is recommended to use this switch with [`i_ind_plasma_internal_norm = 2`](../plasma_current/plasma_inductance.md#menard-inductance-relation) as they are self consistent with each other.**
+**It is recommended to use this switch with [`i_ind_plasma_internal_norm = 2`](../plasma_current/plasma_inductance.md#menard-inductance-relation) as they are self-consistent with each other.**
 
 <!DOCTYPE html>
 <html lang="en">

--- a/documentation/proc-pages/physics-models/plasma_beta/plasma_beta.md
+++ b/documentation/proc-pages/physics-models/plasma_beta/plasma_beta.md
@@ -148,7 +148,7 @@ This relation is based off of data taken from DIII-D shots[^7].
 
 This is only recommended for high aspect ratio tokamaks[^3].
 
-**It is recommended to use this switch with `i_alphaj = 1` and `i_ind_plasma_internal_norm = 1` as they are self consistent with each other.**
+**It is recommended to use this switch with [`i_alphaj = 1`](../plasma_current/plasma_current.md#wesson-relation) and [`i_ind_plasma_internal_norm = 1`](../plasma_current/plasma_inductance.md#wesson-relation) as they are self consistent with each other.**
 
 ---------
 
@@ -240,7 +240,7 @@ $$
 
 **This is only recommended for spherical tokamaks**
 
-**It is recommended to use this switch with `i_ind_plasma_internal_norm = 2` as they are self consistent with each other.**
+**It is recommended to use this switch with [`i_ind_plasma_internal_norm = 2`](../plasma_current/plasma_inductance.md#menard-inductance-relation) as they are self consistent with each other.**
 
 <!DOCTYPE html>
 <html lang="en">

--- a/documentation/proc-pages/physics-models/plasma_current/plasma_current.md
+++ b/documentation/proc-pages/physics-models/plasma_current/plasma_current.md
@@ -588,7 +588,7 @@ This relation is based off of data taken from DIII-D shots[^15].
 
 This is only recommended for high aspect ratio tokamaks[^13].
 
-**It is recommended to use this switch with [`i_ind_plasma_internal_norm = 1`](../plasma_current/plasma_inductance.md#wesson-relation) and [`i_beta_norm_max = 1`](../plasma_beta/plasma_beta.md#wesson-relation) as they are self consistent with each other.**
+**It is recommended to use this switch with [`i_ind_plasma_internal_norm = 1`](../plasma_current/plasma_inductance.md#wesson-relation) and [`i_beta_norm_max = 1`](../plasma_beta/plasma_beta.md#wesson-relation) as they are self-consistent with each other.**
 
 -----------
 

--- a/documentation/proc-pages/physics-models/plasma_current/plasma_current.md
+++ b/documentation/proc-pages/physics-models/plasma_current/plasma_current.md
@@ -550,39 +550,47 @@ $$
 B_{\text{p}} = B_{\text{T}}\frac{F_1 + F_2}{2\pi \overline{q}}
 $$
 
-------------
-
-### 5. Plasma Current Profile Consistency
-
-A limited degree of self-consistency between the plasma current profile and other parameters can be 
-enforced by setting switch `iprofile = 1`. This sets the current 
-profile peaking factor $\alpha_J$ (`alphaj`),  the normalised internal inductance $l_i$ (`ind_plasma_internal_norm`) and beta limit $g$-factor (`beta_norm_max`) using the 
-safety factor on axis `q0` and the cylindrical safety factor $q_*$ (`qstar`):   
-
-$$\begin{aligned}
-\alpha_J = \frac{q*}{q_0} - 1
-\end{aligned}$$
-
-$$\begin{aligned}
-l_i = \rm{ln}(1.65+0.89\alpha_J)
-\end{aligned}$$
-
-$$\begin{aligned}
-g = 4 l_i
-\end{aligned}$$
-
-It is recommended that current scaling law `i_plasma_current = 4` is used if `iprofile = 1`. 
-This relation is only applicable to large aspect ratio tokamaks.
-
-For spherical tokamaks, the normalised internal inductance can be set from the elongation using `iprofile = 4` or `iprofile = 5` or `iprofile = 6`[^11]:
-
-$$\begin{aligned}
-l_i = 3.4 - \kappa_x
-\end{aligned}$$
-
-Further description of `iprofile` is given in [Beta Limit](../plasma_beta.md).
 
 -----------------------
+
+## Setting the current profile index
+
+The value of the current profile indez $\alpha_{\text{J}}$ can be set with the `i_alphaj` switch.
+
+
+### User input
+
+
+The user can specify the value of $\alpha_{\text{J}}$ directly by stating `i_alphaj = 0` in the input file.
+
+```python
+IN.DAT
+
+i_alphaj = 0
+alphaj = 1.0
+
+
+```
+
+-----------
+
+### Wesson relation
+
+This can be activated by stating `i_alphaj = 1` in the input file.
+
+`alphaj` is set to `alphaj_wesson` using:  
+
+$$
+\texttt{alphaj_wesson} = \frac{q^*}{q_0} - 1
+$$
+
+This relation is based off of data taken from DIII-D shots[^15].
+
+This is only recommended for high aspect ratio tokamaks[^13].
+
+**It is recommended to use this switch with [`i_ind_plasma_internal_norm = 1`](../plasma_current/plasma_inductance.md#wesson-relation) and [`i_beta_norm_max = 1`](../plasma_beta/plasma_beta.md#wesson-relation) as they are self consistent with each other.**
+
+-----------
 
 ## _plasc_bpol
 
@@ -710,6 +718,11 @@ http://doi.org/10.1098/rsta.2017.0437
 [^13]: Wesson, J. and Campbell, D. J. (2004) Tokamaks. Clarendon Press (International series of monographs on physics). Available at: https://books.google.co.uk/books?id=iPlAwZI6HIYC.
 [^14]: Stuart I. Muldrew, Hanni Lux, Geof Cunningham, Tim C. Hender, Sebastien Kahn, Peter J. Knight, Bhavin Patel, Garry M. Voss, Howard R. Wilson,“PROCESS”: Systems studies of spherical tokamaks, Fusion Engineering and Design, Volume 154, 2020,
 111530, ISSN 0920-3796, https://doi.org/10.1016/j.fusengdes.2020.111530.
+[^15]: T. T. S et al., “Profile Optimization and High Beta Discharges and Stability of High Elongation Plasmas in the DIII-D Tokamak,” Osti.gov, Oct. 1990. https://www.osti.gov/biblio/6194284 (accessed Dec. 19, 2024).
+
+
+
+
 
 
 

--- a/documentation/proc-pages/physics-models/plasma_current/plasma_inductance.md
+++ b/documentation/proc-pages/physics-models/plasma_current/plasma_inductance.md
@@ -36,7 +36,7 @@ This relation is based off of data taken from DIII-D shots[^1].
 
 This is only recommended for high aspect ratio tokamaks[^2].
 
-**It is recommended to use this switch with [`i_alphaj = 1`](../plasma_current/plasma_current.md#setting-the-current-profile-index) and [`i_beta_norm_max = 1`](../plasma_beta/plasma_beta.md#wesson-relation) as they are self consistent with each other.**
+**It is recommended to use this switch with [`i_alphaj = 1`](../plasma_current/plasma_current.md#setting-the-current-profile-index) and [`i_beta_norm_max = 1`](../plasma_beta/plasma_beta.md#wesson-relation) as they are self-consistent with each other.**
 
 
 ---------
@@ -55,7 +55,7 @@ $$
 
 **This is only recommended for spherical tokamaks**
 
-**It is recommended to use this switch with [`i_beta_norm_max = 3`](../plasma_beta/plasma_beta.md#menard-beta-relation) as they are self consistent with each other.**
+**It is recommended to use this switch with [`i_beta_norm_max = 3`](../plasma_beta/plasma_beta.md#menard-beta-relation) as they are self-consistent with each other.**
 
 [^1]: T. T. S et al., “Profile Optimization and High Beta Discharges and Stability of High Elongation Plasmas in the DIII-D Tokamak,” Osti.gov, Oct. 1990. https://www.osti.gov/biblio/6194284 (accessed Dec. 19, 2024).
 

--- a/documentation/proc-pages/physics-models/plasma_current/plasma_inductance.md
+++ b/documentation/proc-pages/physics-models/plasma_current/plasma_inductance.md
@@ -1,0 +1,65 @@
+# Plasma Inductance
+
+## Setting the normalised internal inductance
+
+The value of the normalised internal inductance $l_i$ can be set with the `i_ind_plasma_internal_norm` switch.
+
+----------
+
+### User input
+
+
+The user can specify the value of $l_i$ directly by stating `i_ind_plasma_internal_norm = 0` in the input file.
+
+```python
+IN.DAT
+
+i_ind_plasma_internal_norm = 0
+ind_plasma_internal_norm = 1.0
+
+
+```
+
+----------
+
+### Wesson relation
+
+This can be activated by stating `i_ind_plasma_internal_normx = 1` in the input file.
+
+`ind_plasma_internal_norm` is set to `ind_plasma_internal_norm_wesson` using:  
+
+$$
+\texttt{ind_plasma_internal_norm_wesson} = \ln{\left(1.65+0.89\alpha_{\text{J}}\right)}
+$$
+
+This relation is based off of data taken from DIII-D shots[^1].
+
+This is only recommended for high aspect ratio tokamaks[^2].
+
+**It is recommended to use this switch with [`i_alphaj = 1`](../plasma_current/plasma_current.md#setting-the-current-profile-index) and [`i_beta_norm_max = 1`](../plasma_beta/plasma_beta.md#wesson-relation) as they are self consistent with each other.**
+
+
+---------
+
+
+#### Menard Inductance Relation
+
+This can be activated by stating `ind_plasma_internal_norm = 2` in the input file.
+
+`ind_plasma_internal_norm` is set to `ind_plasma_internal_norm_menard` using[^3]:
+
+
+$$
+\texttt{ind_plasma_internal_norm_menard} = 3.4 - \kappa
+$$
+
+**This is only recommended for spherical tokamaks**
+
+**It is recommended to use this switch with [`i_beta_norm_max = 3`](../plasma_beta/plasma_beta.md#menard-beta-relation) as they are self consistent with each other.**
+
+[^1]: T. T. S et al., “Profile Optimization and High Beta Discharges and Stability of High Elongation Plasmas in the DIII-D Tokamak,” Osti.gov, Oct. 1990. https://www.osti.gov/biblio/6194284 (accessed Dec. 19, 2024).
+
+[^2]: Tokamaks 4th Edition, Wesson, page 116
+
+[^3]: J. E. Menard et al., “Fusion nuclear science facilities and pilot plants based on the spherical tokamak,” Nuclear Fusion, vol. 56, no. 10, p. 106023, Aug. 2016, doi: https://doi.org/10.1088/0029-5515/56/10/106023.
+

--- a/documentation/proc-pages/physics-models/profiles/plasma_profiles.md
+++ b/documentation/proc-pages/physics-models/profiles/plasma_profiles.md
@@ -37,7 +37,7 @@ be described as 1/2-D.  The relevant profile index variables are
 
 ???+ note "Plasma current profile"
 
-    While PROCESS assumes a standard parabolic profile to be the shape of the current profile as per the 1989 ITER physics guidelines[^2] , it does not calculate its shape or values apart from the core value. The profile peaking factor `alphaj` is calculated in the plasma current calculation relating to `iprofile` found [here](../plasma_current.md).The on-axis current density is analytically calculated in [`calculate_profile_factors()`](#calculate_profile_factors) Only the temeprature and density profiles are calculated fully withing the `PlasmaProfiles` class.
+    While PROCESS assumes a standard parabolic profile to be the shape of the current profile as per the 1989 ITER physics guidelines[^2] , it does not calculate its shape or values apart from the core value. The profile peaking factor `alphaj` is calculated after the plasma current calculation relating to `i_alphaj` found [here](../plasma_current/plasma_current.md#setting-the-current-profile-index).The on-axis current density is analytically calculated in [`calculate_profile_factors()`](#calculate_profile_factors) Only the temeprature and density profiles are calculated fully withing the `PlasmaProfiles` class.
 
 The graph below is for a standard parabolic profile. You can vary the core value (`n0`) and the profile index (`alphan`) to see how the function behaves
 

--- a/examples/data/csv_output_large_tokamak_MFILE.DAT
+++ b/examples/data/csv_output_large_tokamak_MFILE.DAT
@@ -1609,9 +1609,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/examples/data/large_tokamak_1_MFILE.DAT
+++ b/examples/data/large_tokamak_1_MFILE.DAT
@@ -1603,9 +1603,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/examples/data/large_tokamak_2_MFILE.DAT
+++ b/examples/data/large_tokamak_2_MFILE.DAT
@@ -1603,9 +1603,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/examples/data/large_tokamak_3_MFILE.DAT
+++ b/examples/data/large_tokamak_3_MFILE.DAT
@@ -1604,9 +1604,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/examples/data/large_tokamak_4_MFILE.DAT
+++ b/examples/data/large_tokamak_4_MFILE.DAT
@@ -1604,9 +1604,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/examples/data/large_tokamak_IN.DAT
+++ b/examples/data/large_tokamak_IN.DAT
@@ -414,9 +414,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/examples/data/large_tokamak_nof_2_MFILE.DAT
+++ b/examples/data/large_tokamak_nof_2_MFILE.DAT
@@ -1482,7 +1482,6 @@ rhopedt  = 0.94 * r/a of temperature pedestal (`ipedestal==1`)
 tbeta    = 2.0 * temperature profile index beta  (`ipedestal==1)
 teped    = 5.5 * electron temperature of pedestal (keV) (`ipedestal==1')
 tesep    = 0.1 * electron temperature at separatrix (keV) (`ipedestal==1`) calculated if reinke
-iprofile = 1 * switch for current profile consistency;
 i_confinement_time      = 34 * switch for energy confinement time scaling law (see description in `tauscl`)
 i_plasma_geometry   = 0 * switch for plasma cross-sectional shape calculation;
 kappa    = 1.85 * plasma separatrix elongation (calculated if `ishape = 1-5; 7 or 9-10`)

--- a/examples/data/large_tokamak_nof_MFILE.DAT
+++ b/examples/data/large_tokamak_nof_MFILE.DAT
@@ -1613,9 +1613,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/examples/data/large_tokamak_once_through_IN.DAT
+++ b/examples/data/large_tokamak_once_through_IN.DAT
@@ -338,7 +338,6 @@ rhopedt  = 0.94 * r/a of temperature pedestal (`ipedestal==1`)
 tbeta    = 2.0 * temperature profile index beta  (`ipedestal==1)
 teped    = 5.5 * electron temperature of pedestal (keV) (`ipedestal==1')
 tesep    = 0.1 * electron temperature at separatrix (keV) (`ipedestal==1`) calculated if reinke
-iprofile = 1 * switch for current profile consistency;
 i_confinement_time      = 34 * switch for energy confinement time scaling law (see description in `tauscl`)
 i_plasma_geometry   = 0 * switch for plasma cross-sectional shape calculation;
 kappa    = 1.85 * plasma separatrix elongation (calculated if `ishape = 1-5; 7 or 9-10`)

--- a/examples/data/scan_MFILE.DAT
+++ b/examples/data/scan_MFILE.DAT
@@ -9253,7 +9253,6 @@ rhopedt  = 0.94 * R/a of temperature pedestal (ipedestal=1)
 tbeta    = 2.0 * Temperature profile index beta  (ipedestal=1)
 teped    = 5.5 * Electron temperature of pedestal (kev) (ipedestal=1)
 tesep    = 0.1 * Electron temperature at separatrix (kev) (ipedestal=1)
-iprofile = 1 * Switch for current profile consistency;
 i_confinement_time      = 34 * Switch for energy confinement time scaling law
 i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: use input kappa & triang
 *kappa = 1.7808

--- a/examples/data/scan_example_file_IN.DAT
+++ b/examples/data/scan_example_file_IN.DAT
@@ -414,9 +414,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
                   - Pfirsch-Schlüter Current: physics-models/plasma_current/pfirsch_schlüter_current_drive.md
                   - Inductive Current:
                       - Inductive Current: physics-models/plasma_current/inductive_plasma_current.md
+                      - Plasma Inductance: physics-models/plasma_current/plasma_inductance.md
                       - Plasma Resistive Heating: physics-models/plasma_current/plasma_resistive_heating.md
               - Confinement time: physics-models/plasma_confinement.md
               - L-H transition: physics-models/plasma_h_mode.md

--- a/process/input.py
+++ b/process/input.py
@@ -1540,7 +1540,6 @@ INPUT_VARIABLES = {
     "ipnet": InputVariable(fortran.cost_variables, int, choices=[0, 1]),
     "ipowerflow": InputVariable(fortran.heat_transport_variables, int, choices=[0, 1]),
     "iprimshld": InputVariable(fortran.heat_transport_variables, int, choices=[0, 1]),
-    "iprofile": InputVariable(fortran.physics_variables, int, range=(0, 6)),
     "i_beta_norm_max": InputVariable(fortran.physics_variables, int, range=(0, 4)),
     "i_ind_plasma_internal_norm": InputVariable(
         fortran.physics_variables, int, range=(0, 2)

--- a/process/input.py
+++ b/process/input.py
@@ -1541,6 +1541,7 @@ INPUT_VARIABLES = {
     "ipowerflow": InputVariable(fortran.heat_transport_variables, int, choices=[0, 1]),
     "iprimshld": InputVariable(fortran.heat_transport_variables, int, choices=[0, 1]),
     "iprofile": InputVariable(fortran.physics_variables, int, range=(0, 6)),
+    "i_beta_norm_max": InputVariable(fortran.physics_variables, int, range=(0, 4)),
     "i_fw_blkt_shared_coolant": InputVariable(
         fortran.fwbs_variables, int, choices=[0, 1, 2]
     ),

--- a/process/input.py
+++ b/process/input.py
@@ -1542,6 +1542,9 @@ INPUT_VARIABLES = {
     "iprimshld": InputVariable(fortran.heat_transport_variables, int, choices=[0, 1]),
     "iprofile": InputVariable(fortran.physics_variables, int, range=(0, 6)),
     "i_beta_norm_max": InputVariable(fortran.physics_variables, int, range=(0, 4)),
+    "i_ind_plasma_internal_norm": InputVariable(
+        fortran.physics_variables, int, range=(0, 2)
+    ),
     "i_fw_blkt_shared_coolant": InputVariable(
         fortran.fwbs_variables, int, choices=[0, 1, 2]
     ),

--- a/process/input.py
+++ b/process/input.py
@@ -1545,6 +1545,7 @@ INPUT_VARIABLES = {
     "i_ind_plasma_internal_norm": InputVariable(
         fortran.physics_variables, int, range=(0, 2)
     ),
+    "i_alphaj": InputVariable(fortran.physics_variables, int, range=(0, 1)),
     "i_fw_blkt_shared_coolant": InputVariable(
         fortran.fwbs_variables, int, choices=[0, 1, 2]
     ),

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -327,6 +327,7 @@ OBS_VARS = {
     "pdivtlim": "p_plasma_separatrix_min_mw",
     "i_hldiv": "i_div_heat_load",
     "ignite": "i_plasma_ignited",
+    "iprofile": None,
 }
 
 OBS_VARS_HELP = {

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -333,6 +333,7 @@ OBS_VARS = {
 OBS_VARS_HELP = {
     "iculdl": "(use IDENSL=3 for equivalent model to ICULDL=0). ",
     "dz_blkt_upper": "WARNING. BLNKTTH is now always calculated rather than input - please remove it from the input file. ",
+    "iprofile": "Use i_beta_norm_max, i_alphaj and i_ind_plasma_internal_norm instead. See docs for setup. ",
 }
 
 kallenbach_list = [

--- a/process/physics.py
+++ b/process/physics.py
@@ -8181,6 +8181,10 @@ def init_physics_variables():
     physics_variables.nd_beam_ions = 0.0
     physics_variables.beam_density_out = 0.0
     physics_variables.beta_norm_max = 3.5
+    physics_variables.beta_norm_max_wesson = 0.0
+    physics_variables.beta_norm_max_menard = 0.0
+    physics_variables.beta_norm_max_original_scaling = 0.0
+    physics_variables.beta_norm_max_tholerus = 0.0
     physics_variables.dnelimt = 0.0
     physics_variables.nd_ions_total = 0.0
     physics_variables.dnla = 0.0

--- a/process/physics.py
+++ b/process/physics.py
@@ -3804,7 +3804,7 @@ class Physics:
                     "OP ",
                 )
 
-                if physics_variables.iprofile == 1:
+                if physics_variables.i_alphaj == 1:
                     po.ovarrf(
                         self.outfile,
                         "Current density profile factor",
@@ -4067,7 +4067,7 @@ class Physics:
         )
         po.osubhd(self.outfile, "Normalised Beta Information :")
         if stellarator_variables.istell == 0:
-            if physics_variables.iprofile == 1:
+            if physics_variables.i_beta_norm_max != 0:
                 po.ovarrf(
                     self.outfile,
                     "Beta g coefficient",
@@ -8331,7 +8331,6 @@ def init_physics_variables():
     physics_variables.tbeta = 2.0
     physics_variables.teped = 1.0
     physics_variables.tesep = 0.1
-    physics_variables.iprofile = 1
     physics_variables.i_beta_norm_max = 1
     physics_variables.i_rad_loss = 1
     physics_variables.i_confinement_time = 34

--- a/process/physics.py
+++ b/process/physics.py
@@ -2451,40 +2451,30 @@ class Physics:
 
         # Calculate physics_variables.beta limit
 
-        if physics_variables.iprofile == 1:
-            # T. T. S et al., “Profile Optimization and High Beta Discharges and Stability of High Elongation Plasmas in the DIII-D Tokamak,”
-            # Osti.gov, Oct. 1990. https://www.osti.gov/biblio/6194284 (accessed Dec. 19, 2024).
+        # Define a dictionary of lambda functions for beta_norm_max calculations
+        beta_norm_max_calculations = {
+            1: lambda: 4.0e0 * physics_variables.ind_plasma_internal_norm,
+            2: lambda: 2.7e0 * (1.0e0 + 5.0e0 * physics_variables.eps**3.5e0),
+            3: lambda: 3.12e0 + 3.5e0 * physics_variables.eps**1.7e0,
+            4: lambda: 3.7e0
+            + (
+                (
+                    physics_variables.c_beta
+                    / (physics_variables.p0 / physics_variables.vol_avg_pressure)
+                )
+                * (
+                    12.5e0
+                    - 3.5e0
+                    * (physics_variables.p0 / physics_variables.vol_avg_pressure)
+                )
+            ),
+        }
 
-            physics_variables.beta_norm_max = (
-                4.0e0 * physics_variables.ind_plasma_internal_norm
-            )
-
-        if physics_variables.iprofile == 2:
-            # Original scaling law
-            physics_variables.beta_norm_max = 2.7e0 * (
-                1.0e0 + 5.0e0 * physics_variables.eps**3.5e0
-            )
-
-        if physics_variables.iprofile == 3 or physics_variables.iprofile == 5:
-            # J. E. Menard et al., “Fusion nuclear science facilities and pilot plants based on the spherical tokamak,”
-            # Nuclear Fusion, vol. 56, no. 10, p. 106023, Aug. 2016,
-            # doi: https://doi.org/10.1088/0029-5515/56/10/106023.
-
-            physics_variables.beta_norm_max = (
-                3.12e0 + 3.5e0 * physics_variables.eps**1.7e0
-            )
-
-        if physics_variables.iprofile == 6:
-            # Method used for STEP plasma scoping
-            # E. Tholerus et al., “Flat-top plasma operational space of the STEP power plant,”
-            # Nuclear Fusion, Aug. 2024, doi: https://doi.org/10.1088/1741-4326/ad6ea2.
-
-            # Pressure peaking factor (Fp) is defined as the ratio of the peak pressure to the average pressure
-            fp = physics_variables.p0 / physics_variables.vol_avg_pressure
-
-            physics_variables.beta_norm_max = 3.7e0 + (
-                (physics_variables.c_beta / fp) * (12.5e0 - 3.5e0 * fp)
-            )
+        # Calculate beta_norm_max based on iprofile
+        if int(physics_variables.i_beta_norm_max) in beta_norm_max_calculations:
+            physics_variables.beta_norm_max = beta_norm_max_calculations[
+                int(physics_variables.i_beta_norm_max)
+            ]()
 
         # calculate_beta_limit() returns the beta_max for beta
         physics_variables.beta_max = calculate_beta_limit(
@@ -8253,7 +8243,7 @@ def init_physics_variables():
     physics_variables.teped = 1.0
     physics_variables.tesep = 0.1
     physics_variables.iprofile = 1
-    physics_variables.i_beta_norm_max = 0
+    physics_variables.i_beta_norm_max = 1
     physics_variables.i_rad_loss = 1
     physics_variables.i_confinement_time = 34
     physics_variables.i_plasma_wall_gap = 1

--- a/process/physics.py
+++ b/process/physics.py
@@ -1606,7 +1606,7 @@ class Physics:
             physics_variables.triang95,
         )
 
-        if physics_variables.iprofile == 1:
+        if physics_variables.i_alphaj == 1:
             # Ensure current profile consistency, if required
             # This is as described in Hartmann and Zohm only if i_plasma_current = 4 as well...
 
@@ -1614,11 +1614,12 @@ class Physics:
             physics_variables.alphaj = (
                 physics_variables.qstar / physics_variables.q0 - 1.0
             )
+
+        if physics_variables.i_ind_plasma_internal == 1:
             physics_variables.ind_plasma_internal_norm = np.log(
                 1.65 + 0.89 * physics_variables.alphaj
             )
-
-        if physics_variables.iprofile in [4, 5, 6]:
+        elif physics_variables.i_ind_plasma_internal == 2:
             # Spherical Tokamak relation for internal inductance
             # Menard et al. (2016), Nuclear Fusion, 56, 106023
             physics_variables.ind_plasma_internal_norm = 3.4 - physics_variables.kappa

--- a/process/physics.py
+++ b/process/physics.py
@@ -1601,14 +1601,25 @@ class Physics:
             physics_variables.triang95,
         )
 
-        if physics_variables.i_alphaj == 1:
-            # Ensure current profile consistency, if required
-            # This is as described in Hartmann and Zohm only if i_plasma_current = 4 as well...
+        # Ensure current profile consistency, if required
+        # This is as described in Hartmann and Zohm only if i_plasma_current = 4 as well...
 
-            # Tokamaks 4th Edition, Wesson, page 116
-            physics_variables.alphaj = (
-                physics_variables.qstar / physics_variables.q0 - 1.0
-            )
+        # Tokamaks 4th Edition, Wesson, page 116
+        physics_variables.alphaj_wesson = (
+            physics_variables.qstar / physics_variables.q0 - 1.0
+        )
+
+        # Map calculation methods to a dictionary
+        alphaj_calculations = {
+            0: physics_variables.alphaj,
+            1: physics_variables.alphaj_wesson,
+        }
+
+        # Calculate beta_norm_max based on i_beta_norm_max
+        if int(physics_variables.i_alphaj) in alphaj_calculations:
+            physics_variables.alphaj = alphaj_calculations[
+                int(physics_variables.i_alphaj)
+            ]
 
         physics_variables.ind_plasma_internal_norm_wesson = np.log(
             1.65 + 0.89 * physics_variables.alphaj
@@ -3808,6 +3819,16 @@ class Physics:
                         "(alphaj)",
                         physics_variables.alphaj,
                     )
+                po.ocmmnt(self.outfile, "Current profile index scalings:")
+                po.oblnkl(self.outfile)
+                po.ovarrf(
+                    self.outfile,
+                    "J. Wesson plasma current profile index",
+                    "(alphaj_wesson)",
+                    physics_variables.alphaj_wesson,
+                    "OP ",
+                )
+                po.oblnkl(self.outfile)
                 po.ovarrf(
                     self.outfile,
                     "On-axis plasma current density (A/m2)",

--- a/process/physics.py
+++ b/process/physics.py
@@ -1620,6 +1620,11 @@ class Physics:
             physics_variables.alphaj = alphaj_calculations[
                 int(physics_variables.i_alphaj)
             ]
+        else:
+            raise ProcessValueError(
+                "Illegal value of i_alphaj",
+                i_alphaj=physics_variables.i_alphaj,
+            )
 
         physics_variables.ind_plasma_internal_norm_wesson = np.log(
             1.65 + 0.89 * physics_variables.alphaj
@@ -1647,6 +1652,11 @@ class Physics:
                 ind_plasma_internal_norm_calculations[
                     int(physics_variables.i_ind_plasma_internal_norm)
                 ]
+            )
+        else:
+            raise ProcessValueError(
+                "Illegal value of i_ind_plasma_internal_norm",
+                i_ind_plasma_internal_norm=physics_variables.i_ind_plasma_internal_norm,
             )
 
         # Calculate density and temperature profile quantities
@@ -2539,6 +2549,11 @@ class Physics:
             physics_variables.beta_norm_max = beta_norm_max_calculations[
                 int(physics_variables.i_beta_norm_max)
             ]
+        else:
+            raise ProcessValueError(
+                "Illegal value of i_beta_norm_max",
+                i_beta_norm_max=physics_variables.i_beta_norm_max,
+            )
 
         # calculate_beta_limit() returns the beta_max for beta
         physics_variables.beta_max = calculate_beta_limit(

--- a/process/physics.py
+++ b/process/physics.py
@@ -8334,6 +8334,7 @@ def init_physics_variables():
     physics_variables.f_nd_alpha_electron = 0.1
     physics_variables.f_nd_protium_electrons = 0.0
     physics_variables.ind_plasma_internal_norm = 0.9
+    physics_variables.i_ind_plasma_internal_norm = 0
     physics_variables.ind_plasma = 0.0
     physics_variables.rmajor = 8.14
     physics_variables.rminor = 0.0

--- a/process/physics.py
+++ b/process/physics.py
@@ -8252,6 +8252,7 @@ def init_physics_variables():
     physics_variables.teped = 1.0
     physics_variables.tesep = 0.1
     physics_variables.iprofile = 1
+    physics_variables.i_beta_norm_max = 0
     physics_variables.i_rad_loss = 1
     physics_variables.i_confinement_time = 34
     physics_variables.i_plasma_wall_gap = 1

--- a/process/physics.py
+++ b/process/physics.py
@@ -8154,6 +8154,7 @@ def init_physics_variables():
     physics_variables.m_plasma_electron = 0.0
     physics_variables.m_plasma = 0.0
     physics_variables.alphaj = 1.0
+    physics_variables.i_alphaj = 0
     physics_variables.alphan = 0.25
     physics_variables.alphap = 0.0
     physics_variables.alpha_rate_density_total = 0.0

--- a/process/physics.py
+++ b/process/physics.py
@@ -1610,14 +1610,33 @@ class Physics:
                 physics_variables.qstar / physics_variables.q0 - 1.0
             )
 
-        if physics_variables.i_ind_plasma_internal_norm == 1:
-            physics_variables.ind_plasma_internal_norm = np.log(
-                1.65 + 0.89 * physics_variables.alphaj
+        physics_variables.ind_plasma_internal_norm_wesson = np.log(
+            1.65 + 0.89 * physics_variables.alphaj
+        )
+
+        # Spherical Tokamak relation for internal inductance
+        # Menard et al. (2016), Nuclear Fusion, 56, 106023
+        physics_variables.ind_plasma_internal_norm_menard = (
+            3.4 - physics_variables.kappa
+        )
+
+        # Map calculation methods to a dictionary
+        ind_plasma_internal_norm_calculations = {
+            0: physics_variables.ind_plasma_internal_norm,
+            1: physics_variables.ind_plasma_internal_norm_wesson,
+            2: physics_variables.ind_plasma_internal_norm_menard,
+        }
+
+        # Calculate beta_norm_max based on i_beta_norm_max
+        if (
+            int(physics_variables.i_ind_plasma_internal_norm)
+            in ind_plasma_internal_norm_calculations
+        ):
+            physics_variables.ind_plasma_internal_norm = (
+                ind_plasma_internal_norm_calculations[
+                    int(physics_variables.i_ind_plasma_internal_norm)
+                ]
             )
-        elif physics_variables.i_ind_plasma_internal_norm == 2:
-            # Spherical Tokamak relation for internal inductance
-            # Menard et al. (2016), Nuclear Fusion, 56, 106023
-            physics_variables.ind_plasma_internal_norm = 3.4 - physics_variables.kappa
 
         # Calculate density and temperature profile quantities
         # If physics_variables.ipedestal = 1 then set pedestal density to
@@ -3798,13 +3817,6 @@ class Physics:
                 )
                 po.ovarrf(
                     self.outfile,
-                    "Plasma normalised internal inductance",
-                    "(ind_plasma_internal_norm)",
-                    physics_variables.ind_plasma_internal_norm,
-                    "OP ",
-                )
-                po.ovarrf(
-                    self.outfile,
                     "Vertical field at plasma (T)",
                     "(bvert)",
                     physics_variables.bvert,
@@ -3869,7 +3881,30 @@ class Physics:
                     physics_variables.q95_min,
                     "OP ",
                 )
-
+            po.ovarrf(
+                self.outfile,
+                "Plasma normalised internal inductance",
+                "(ind_plasma_internal_norm)",
+                physics_variables.ind_plasma_internal_norm,
+                "OP ",
+            )
+            po.oblnkl(self.outfile)
+            po.ocmmnt(self.outfile, "Plasma normalised internal inductance scalings:")
+            po.oblnkl(self.outfile)
+            po.ovarrf(
+                self.outfile,
+                "J. Wesson plasma normalised internal inductance",
+                "(ind_plasma_internal_norm_wesson)",
+                physics_variables.ind_plasma_internal_norm_wesson,
+                "OP ",
+            )
+            po.ovarrf(
+                self.outfile,
+                "J. Menard plasma normalised internal inductance",
+                "(ind_plasma_internal_norm_menard)",
+                physics_variables.ind_plasma_internal_norm_menard,
+                "OP ",
+            )
         else:
             po.ovarrf(
                 self.outfile,
@@ -8358,6 +8393,8 @@ def init_physics_variables():
     physics_variables.f_nd_alpha_electron = 0.1
     physics_variables.f_nd_protium_electrons = 0.0
     physics_variables.ind_plasma_internal_norm = 0.9
+    physics_variables.ind_plasma_internal_norm_wesson = 0.0
+    physics_variables.ind_plasma_internal_norm_menard = 0.0
     physics_variables.i_ind_plasma_internal_norm = 0
     physics_variables.ind_plasma = 0.0
     physics_variables.rmajor = 8.14

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -427,6 +427,9 @@ module physics_variables
   integer :: i_beta_norm_max
   !! Switch for beta_norm_max scaling:
 
+  integer :: i_ind_plasma_internal_norm
+  !! Switch for ind_plasma_internal_norm scaling:
+
   integer :: i_rad_loss
   !! switch for radiation loss term usage in power balance (see User Guide):
   !!

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -424,6 +424,9 @@ module physics_variables
   !! - =5 use input value for alphaj.  Set ind_plasma_internal_norm and beta_norm_max from Menard scaling
   !! - =6 use input values for alphaj, c_beta.  Set ind_plasma_internal_norm from Menard and beta_norm_max from Tholerus
 
+  integer :: i_beta_norm_max
+  !! Switch for beta_norm_max scaling:
+
   integer :: i_rad_loss
   !! switch for radiation loss term usage in power balance (see User Guide):
   !!

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -801,7 +801,13 @@ module physics_variables
   !! Seeded f_nd_protium_electrons density / electron density.
 
   real(dp) :: ind_plasma_internal_norm
-  !! Plasma normalised internal inductance (calculated from alphaj if `iprofile=1`)
+  !! Plasma normalised internal inductance
+
+  real(dp) :: ind_plasma_internal_norm_wesson
+  !! Wesson-like plasma normalised internal inductance
+
+  real(dp) :: ind_plasma_internal_menard
+  !! Menard-like plasma normalised internal inductance
 
   real(dp) :: ind_plasma
   !! plasma inductance (H)

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -174,6 +174,18 @@ module physics_variables
   real(dp) :: beta_norm_max
   !! Troyon-like coefficient for beta scaling
 
+  real(dp) :: beta_norm_max_wesson
+  !! Wesson-like coefficient for beta scaling
+
+  real(dp) :: beta_norm_max_menard
+  !! Menard-like coefficient for beta scaling
+
+  real(dp) :: beta_norm_max_original_scaling
+  !! Original scaling coefficient for beta scaling
+
+  real(dp) :: beta_norm_max_tholerus
+  !! Tholerus-like coefficient for beta scaling
+
   real(dp) :: dnelimt
   !! density limit (/m3)
 

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -42,7 +42,10 @@ module physics_variables
   !! Total mass of the plasma (kg)
 
   real(dp) :: alphaj
-  !! current profile index (calculated from q_0 and q if `iprofile=1`)
+  !! current profile index
+
+  real(dp) :: alphaj_wesson
+  !! Wesson-like current profile index
 
   real(dp) :: alphan
   !! density profile index

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -425,10 +425,13 @@ module physics_variables
   !! - =6 use input values for alphaj, c_beta.  Set ind_plasma_internal_norm from Menard and beta_norm_max from Tholerus
 
   integer :: i_beta_norm_max
-  !! Switch for beta_norm_max scaling:
+  !! Switch for maximum normalised beta scaling:
 
   integer :: i_ind_plasma_internal_norm
-  !! Switch for ind_plasma_internal_norm scaling:
+  !! Switch for plasma normalised internal inductance scaling:
+
+  integer :: i_alphaj
+  !! Switch for current profile index scaling:
 
   integer :: i_rad_loss
   !! switch for radiation loss term usage in power balance (see User Guide):

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -138,7 +138,7 @@ module physics_variables
   !! vertical field at plasma (T)
 
   real(dp) :: c_beta
-  !! Destabalisation parameter for iprofile=6 beta limit
+  !! Destabalisation parameter for i_beta_norm_max=4 beta limit
 
   real(dp) :: csawth
   !! coeff. for sawteeth effects on burn V-s requirement
@@ -427,17 +427,6 @@ module physics_variables
   real(dp) :: tesep
   !! electron temperature at separatrix (keV) (`ipedestal==1`) calculated if reinke
   !! criterion is used (`icc=78`)
-
-  integer :: iprofile
-  !! switch for current profile consistency:
-  !!
-  !! - =0 use input values for alphaj, ind_plasma_internal_norm, beta_norm_max
-  !! - =1 make these consistent with input q95, q_0 values (recommend `i_plasma_current=4` with this option)
-  !! - =2 use input values for alphaj, ind_plasma_internal_norm. Scale beta_norm_max with aspect ratio (original scaling)
-  !! - =3 use input values for alphaj, ind_plasma_internal_norm. Scale beta_norm_max with aspect ratio (Menard scaling)
-  !! - =4 use input values for alphaj, beta_norm_max. Set ind_plasma_internal_norm from elongation (Menard scaling)
-  !! - =5 use input value for alphaj.  Set ind_plasma_internal_norm and beta_norm_max from Menard scaling
-  !! - =6 use input values for alphaj, c_beta.  Set ind_plasma_internal_norm from Menard and beta_norm_max from Tholerus
 
   integer :: i_beta_norm_max
   !! Switch for maximum normalised beta scaling:

--- a/tests/integration/data/large_tokamak_1_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_1_MFILE.DAT
@@ -1602,9 +1602,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/integration/data/large_tokamak_2_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_2_MFILE.DAT
@@ -1603,9 +1603,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/integration/data/large_tokamak_3_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_3_MFILE.DAT
@@ -1603,9 +1603,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/integration/data/large_tokamak_4_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_4_MFILE.DAT
@@ -1603,9 +1603,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/integration/data/large_tokamak_IN.DAT
+++ b/tests/integration/data/large_tokamak_IN.DAT
@@ -413,9 +413,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/integration/data/large_tokamak_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_MFILE.DAT
@@ -1604,9 +1604,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/integration/data/large_tokamak_once_through.IN.DAT
+++ b/tests/integration/data/large_tokamak_once_through.IN.DAT
@@ -338,7 +338,6 @@ rhopedt  = 0.94 * r/a of temperature pedestal (`ipedestal==1`)
 tbeta    = 2.0 * temperature profile index beta  (`ipedestal==1)
 teped    = 5.5 * electron temperature of pedestal (keV) (`ipedestal==1')
 tesep    = 0.1 * electron temperature at separatrix (keV) (`ipedestal==1`) calculated if reinke
-iprofile = 1 * switch for current profile consistency;
 i_confinement_time      = 34 * switch for energy confinement time scaling law (see description in `labels_confinement_scalings`)
 i_plasma_geometry   = 0 * switch for plasma cross-sectional shape calculation;
 kappa    = 1.85 * plasma separatrix elongation (calculated if `i_plasma_geometry = 1-5; 7 or 9-10`)

--- a/tests/integration/data/ref_IN.DAT
+++ b/tests/integration/data/ref_IN.DAT
@@ -274,7 +274,6 @@ rhopedt  = 0.94 * R/a of temperature pedestal (ipedestal=1)
 tbeta    = 2.0 * Temperature profile index beta  (ipedestal=1)
 teped    = 5.5 * Electron temperature of pedestal (kev) (ipedestal=1)
 tesep    = 0.1 * Electron temperature at separatrix (kev) (ipedestal=1)
-iprofile = 1 * Switch for current profile consistency;
 i_confinement_time      = 34 * Switch for energy confinement time scaling law
 i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: use input kappa & triang
 *kappa = 1.7808

--- a/tests/integration/data/scan_2D_MFILE.DAT
+++ b/tests/integration/data/scan_2D_MFILE.DAT
@@ -17890,9 +17890,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/integration/data/scan_MFILE.DAT
+++ b/tests/integration/data/scan_MFILE.DAT
@@ -9253,7 +9253,6 @@ rhopedt  = 0.94 * R/a of temperature pedestal (ipedestal=1)
 tbeta    = 2.0 * Temperature profile index beta  (ipedestal=1)
 teped    = 5.5 * Electron temperature of pedestal (kev) (ipedestal=1)
 tesep    = 0.1 * Electron temperature at separatrix (kev) (ipedestal=1)
-iprofile = 1 * Switch for current profile consistency;
 i_confinement_time      = 34 * Switch for energy confinement time scaling law
 i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: use input kappa & triang
 *kappa = 1.7808

--- a/tests/integration/data/uncertainties_nonopt_ref_IN.DAT
+++ b/tests/integration/data/uncertainties_nonopt_ref_IN.DAT
@@ -274,7 +274,6 @@ rhopedt  = 0.94 * R/a of temperature pedestal (ipedestal=1)
 tbeta    = 2.0 * Temperature profile index beta  (ipedestal=1)
 teped    = 5.5 * Electron temperature of pedestal (kev) (ipedestal=1)
 tesep    = 0.1 * Electron temperature at separatrix (kev) (ipedestal=1)
-iprofile = 1 * Switch for current profile consistency;
 i_confinement_time      = 34 * Switch for energy confinement time scaling law
 i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: use input kappa & triang
 *kappa = 1.7808

--- a/tests/integration/data/uncertainties_ref_IN.DAT
+++ b/tests/integration/data/uncertainties_ref_IN.DAT
@@ -274,7 +274,6 @@ rhopedt  = 0.94 * R/a of temperature pedestal (ipedestal=1)
 tbeta    = 2.0 * Temperature profile index beta  (ipedestal=1)
 teped    = 5.5 * Electron temperature of pedestal (kev) (ipedestal=1)
 tesep    = 0.1 * Electron temperature at separatrix (kev) (ipedestal=1)
-iprofile = 1 * Switch for current profile consistency;
 i_confinement_time      = 34 * Switch for energy confinement time scaling law
 i_plasma_geometry   = 0 * Switch for plasma cross-sectional shape calculation: use input kappa & triang
 *kappa = 1.7808

--- a/tests/regression/input_files/large_tokamak.IN.DAT
+++ b/tests/regression/input_files/large_tokamak.IN.DAT
@@ -365,6 +365,9 @@ alphan = 1.00
 * Temperature profile index
 alphat = 1.45 
 
+* Current profile index model switch
+i_alphaj = 1
+
 * (troyon-like) coefficient for beta scaling
 beta_norm_max = 3.0
 
@@ -416,9 +419,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 
@@ -433,6 +433,9 @@ f_sync_reflect = 0.6
 
 * plasma resistivity pre-factor
 plasma_res_factor = 0.7
+
+* Switch for plasma normalised internal inductance model
+i_ind_plasma_internal_norm = 1
 
 * Timings *
 ***********

--- a/tests/regression/input_files/large_tokamak_nof.IN.DAT
+++ b/tests/regression/input_files/large_tokamak_nof.IN.DAT
@@ -398,9 +398,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/regression/input_files/large_tokamak_once_through.IN.DAT
+++ b/tests/regression/input_files/large_tokamak_once_through.IN.DAT
@@ -317,6 +317,7 @@ zref(10) = 1.0
 
 alphan   = 1.00 * density profile index
 alphat   = 1.45 * temperature profile index
+i_alphaj = 1 * Current profile index selection (0 = user input)
 aspect   = 3.0 * aspect ratio (`iteration variable 1`)
 beta     = 0.03230408815355488 * total plasma beta (`iteration variable 5`) (calculated if stellarator)
 bt       = 5.318322174644904 * toroidal field on axis (T) (`iteration variable 2`)
@@ -341,7 +342,6 @@ rhopedt  = 0.94 * r/a of temperature pedestal (`ipedestal==1`)
 tbeta    = 2.0 * temperature profile index beta  (`ipedestal==1)
 teped    = 5.5 * electron temperature of pedestal (keV) (`ipedestal==1')
 tesep    = 0.1 * electron temperature at separatrix (keV) (`ipedestal==1`) calculated if reinke
-iprofile = 1 * switch for current profile consistency;
 i_confinement_time      = 34 * switch for energy confinement time scaling law (see description in `labels_confinement_scalings`)
 i_plasma_geometry   = 0 * switch for plasma cross-sectional shape calculation;
 kappa    = 1.85 * plasma separatrix elongation (calculated if `i_plasma_geometry = 1-5; 7 or 9-10`)
@@ -353,6 +353,7 @@ i_single_null = 1 * switch for single null / double null plasma;
 f_sync_reflect    = 0.6 * synchrotron wall reflectivity factor
 te       = 12.221383528378944 * volume averaged electron temperature (keV) (`iteration variable 4`)
 triang   = 0.5 * plasma separatrix triangularity (calculated if `i_plasma_geometry = 1; 3-5 or 7`)
+i_ind_plasma_internal_norm = 1 * Normalised plasma intenral induction selection switch (0 = user input) 
 
 *----------------------Power-----------------------*
 

--- a/tests/regression/input_files/spherical_tokamak_once_through.IN.DAT
+++ b/tests/regression/input_files/spherical_tokamak_once_through.IN.DAT
@@ -325,7 +325,8 @@ zref(10) = 1.0
 
 *----------------Physics Variables-----------------*
 
-alphaj   = 0.1 * current profile index (calculated from q_0 and q if `iprofile=1`)
+alphaj   = 0.1 * current profile index
+i_alphaj = 0 * Current profile index selection (0 = user input)
 alphan   = 0.9 * density profile index
 alphat   = 1.4 * temperature profile index
 aspect   = 1.8 * aspect ratio (`iteration variable 1`)
@@ -333,6 +334,7 @@ beta     = 0.13134204235647895 * total plasma beta (`iteration variable 5`) (cal
 bt       = 3.0 * toroidal field on axis (T) (`iteration variable 2`)
 dene     = 9.69888313737236e+19 * electron density (/m3) (`iteration variable 6`)
 beta_norm_max = 5.0 * Troyon-like coefficient for beta scaling
+i_beta_norm_max = 0 * Normalised beta max selection (0 = user input)
 f_p_div_lower     = 0.5 * fraction of power to the lower divertor in double null configuration
 fgwped   = 0.1 * fraction of Greenwald density to set as pedestal-top density; If `<0`; pedestal-top
 fgwsep   = 0.1 * fraction of Greenwald density to set as separatrix density; If `<0`; separatrix
@@ -350,7 +352,6 @@ rhopedt  = 0.925 * r/a of temperature pedestal (`ipedestal==1`)
 tbeta    = 2.0 * temperature profile index beta  (`ipedestal==1)
 teped    = 4.5 * electron temperature of pedestal (keV) (`ipedestal==1`)
 tesep    = 0.125 * electron temperature at separatrix (keV) (`ipedestal==1`) calculated if reinke
-iprofile = 0 * switch for current profile consistency;
 i_plasma_geometry = 0 * switch for plasma elongation and triangularity calculations;
 itart    = 1 * switch for spherical tokamak (ST) models;
 itartpf  = 1 * switch for Spherical Tokamak PF models;
@@ -358,7 +359,8 @@ kappa    = 2.8 * plasma separatrix elongation (calculated if `i_plasma_geometry 
 q95        = 5.835830999686161 * Safety factor 'near' plasma edge (`iteration variable 18`) equal to q95
 q0       = 2.0 * safety factor on axis
 f_nd_alpha_electron = 0.08870796537675113 * thermal alpha density/electron density (`iteration variable 109`)
-ind_plasma_internal_norm      = 0.3 * plasma normalised internal inductance (calculated from alphaj if `iprofile=1`)
+ind_plasma_internal_norm      = 0.3 * plasma normalised internal inductance
+i_ind_plasma_internal_norm = 0 * Normalised plasma intenral induction selection switch (0 = user input) 
 rmajor   = 4.5 * plasma major radius (m) (`iteration variable 3`)
 i_single_null = 0 * switch for single null / double null plasma;
 f_sync_reflect = 0.6 * synchrotron wall reflectivity factor

--- a/tests/regression/input_files/st_regression.IN.DAT
+++ b/tests/regression/input_files/st_regression.IN.DAT
@@ -338,14 +338,11 @@ beta_norm_max = 5.0
 * DESCRIPTION:   (Troyon-like) coefficient for beta scaling
 * JUSTIFICATION: 
 * REFERENCE:     Ono & Kaita (2015), Physics of Plasmas, 22, 040501
-*                
+* 
 
-*gtscale = 
-* DESCRIPTION:   Flag to scale beta coefficient with aspect, iprofile=0 only
-* = 0 do not scale beta_norm_max with eps
-* = 1 scale beta_norm_max with aspect, original scaling
-* = 2 scale beta_norm_max with aspect, Menard scaling
-* JUSTIFICATION: Working at fixed normalized beta, default = 0
+i_beta_norm_max = 0
+* DESCRIPTION:   Max normalised beta selection switch (0 = user input)
+
 
 *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -572,6 +569,9 @@ tesep = 0.125
 alphaj = 0.1
 * DESCRIPTION:   Current Profile Index
 * JUSTIFICATION: ST current profile is flattish, value assumed
+
+i_alphaj = 0
+* DESCRIPTION: Current profile selection switch (0 = user input)
 
 
 *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Radiation,Fuelling & Impurities ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2910,16 +2910,13 @@ i_pfirsch_schluter_current = 1
 
 *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-iprofile = 0
-* DESCRIPTION:   Switch for Current Profile Consistency (0: Use Input Values for alphaj ind_plasma_internal_norm beta_norm_max)
-* =0 use input values for alphaj, ind_plasma_internal_norm, beta_norm_max (but see gtscale option)
-* =1 make these consistent with input q, q_0 values (recommend `i_plasma_current=4` with this option)
-* JUSTIFICATION: These consistency equations don't hold for STs
-* REFERENCE:     
 
 ind_plasma_internal_norm = 0.3
 * DESCRIPTION:   Plasma Normalised Internal Inductance
 * JUSTIFICATION: Matched to JETTO li(3).
+
+i_ind_plasma_internal_norm = 0
+* DESCRIPTION:   Normalised plasma intenral induction selection switch (0 = user input)
 
 *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 *csawth

--- a/tests/unit/data/large_tokamak_IN.DAT
+++ b/tests/unit/data/large_tokamak_IN.DAT
@@ -414,9 +414,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/unit/data/large_tokamak_MFILE.DAT
+++ b/tests/unit/data/large_tokamak_MFILE.DAT
@@ -1605,9 +1605,6 @@ teped = 5.5
 * Electron temperature at separatrix (kev) (ipedestal=1)
 tesep = 0.1
 
-* Switch for current profile consistency
-iprofile = 1
-
 * Switch for energy confinement time scaling law
 i_confinement_time = 34
 

--- a/tests/unit/test_physics.py
+++ b/tests/unit/test_physics.py
@@ -1062,11 +1062,7 @@ class PlasmaCurrentParam(NamedTuple):
 
     i_plasma_current: Any = None
 
-    iprofile: Any = None
-
     alphaj: Any = None
-
-    ind_plasma_internal_norm: Any = None
 
     alphap: Any = None
 
@@ -1082,8 +1078,6 @@ class PlasmaCurrentParam(NamedTuple):
 
     len_plasma_poloidal: Any = None
 
-    q0: Any = None
-
     q95: Any = None
 
     rmajor: Any = None
@@ -1095,10 +1089,6 @@ class PlasmaCurrentParam(NamedTuple):
     triang95: Any = None
 
     expected_normalised_total_beta: Any = None
-
-    expected_alphaj: Any = None
-
-    expected_ind_plasma_internal_norm: Any = None
 
     expected_bp: Any = None
 
@@ -1114,9 +1104,7 @@ class PlasmaCurrentParam(NamedTuple):
             beta_norm_total=0,
             beta=0.030000000000000006,
             i_plasma_current=4,
-            iprofile=1,
             alphaj=1,
-            ind_plasma_internal_norm=0.90000000000000002,
             alphap=0,
             bt=5.7000000000000002,
             eps=0.33333333333333331,
@@ -1124,15 +1112,12 @@ class PlasmaCurrentParam(NamedTuple):
             kappa95=1.6517857142857142,
             p0=0,
             len_plasma_poloidal=24.081367139525412,
-            q0=1,
             q95=3.5,
             rmajor=8,
             rminor=2.6666666666666665,
             triang=0.5,
             triang95=0.33333333333333331,
             expected_normalised_total_beta=2.4784688886891844,
-            expected_alphaj=1.9008029008029004,
-            expected_ind_plasma_internal_norm=1.2064840230894305,
             expected_bp=0.96008591022564971,
             expected_qstar=2.900802902105021,
             expected_plasma_current=18398455.678867526,
@@ -1141,9 +1126,7 @@ class PlasmaCurrentParam(NamedTuple):
             beta_norm_total=2.4784688886891844,
             beta=0.030000000000000006,
             i_plasma_current=4,
-            iprofile=1,
             alphaj=1.9008029008029004,
-            ind_plasma_internal_norm=1.2064840230894305,
             alphap=2.4500000000000002,
             bt=5.7000000000000002,
             eps=0.33333333333333331,
@@ -1151,15 +1134,12 @@ class PlasmaCurrentParam(NamedTuple):
             kappa95=1.6517857142857142,
             p0=626431.90482713911,
             len_plasma_poloidal=24.081367139525412,
-            q0=1,
             q95=3.5,
             rmajor=8,
             rminor=2.6666666666666665,
             triang=0.5,
             triang95=0.33333333333333331,
             expected_normalised_total_beta=2.4784688886891844,
-            expected_alphaj=1.9008029008029004,
-            expected_ind_plasma_internal_norm=1.2064840230894305,
             expected_bp=0.96008591022564971,
             expected_qstar=2.900802902105021,
             expected_plasma_current=18398455.678867526,
@@ -1187,11 +1167,9 @@ def test_calculate_plasma_current(plasmacurrentparam, monkeypatch, physics):
 
     monkeypatch.setattr(physics_variables, "beta", plasmacurrentparam.beta)
 
-    _, _, bp, qstar, plasma_current = physics.calculate_plasma_current(
+    bp, qstar, plasma_current = physics.calculate_plasma_current(
         i_plasma_current=plasmacurrentparam.i_plasma_current,
-        iprofile=plasmacurrentparam.iprofile,
         alphaj=plasmacurrentparam.alphaj,
-        ind_plasma_internal_norm=plasmacurrentparam.ind_plasma_internal_norm,
         alphap=plasmacurrentparam.alphap,
         bt=plasmacurrentparam.bt,
         eps=plasmacurrentparam.eps,
@@ -1199,7 +1177,6 @@ def test_calculate_plasma_current(plasmacurrentparam, monkeypatch, physics):
         kappa95=plasmacurrentparam.kappa95,
         p0=plasmacurrentparam.p0,
         len_plasma_poloidal=plasmacurrentparam.len_plasma_poloidal,
-        q0=plasmacurrentparam.q0,
         q95=plasmacurrentparam.q95,
         rmajor=plasmacurrentparam.rmajor,
         rminor=plasmacurrentparam.rminor,


### PR DESCRIPTION
This pull request introduces changes to enhance the flexibility and clarity of the plasma physics model configuration by replacing the `iprofile` switch with three new, more specific switches: `i_beta_norm_max`, `i_ind_plasma_internal_norm`, and `i_alphaj`. Additionally, it updates the documentation to reflect these changes, removes outdated references to `iprofile`, and adds a new section on plasma inductance.

### Key Changes:

#### Switch Replacement and Code Updates:
* Replaced the `iprofile` switch with three new switches: `i_beta_norm_max`, `i_ind_plasma_internal_norm`, and `i_alphaj`, each controlling specific aspects of the plasma physics model. Updated their definitions in `process/input.py` and removed `iprofile` from `process/io/obsolete_vars.py`. 

#### Documentation Updates:
* Updated `plasma_beta.md` to use the new `i_beta_norm_max` switch for beta coefficient configurations, including detailed descriptions of its options and their recommended use cases. 
* Added a new `plasma_inductance.md` file documenting the `i_ind_plasma_internal_norm` switch and its options, including user input, Wesson relation, and Menard inductance relation.
* Updated `plasma_current.md` to describe the `i_alphaj` switch for setting the current profile index and removed legacy references to `iprofile`. 

#### Example Files:

* Removed occurrences of the obsolete `iprofile` switch from multiple example input files such as `large_tokamak_IN.DAT` and others. 

#### Miscellaneous:
* Updated navigation in `mkdocs.yml` to include the new `plasma_inductance.md` file.
* Adjusted the `physics.py` file to remove calculations dependent on the obsolete `iprofile` switch.## Description



------------

### ✨ New variables

#### Switches

`i_beta_norm_max`
`i_ind_plasma_internal_norm`
`i_alphaj`

#### $\beta_N$ scalings

`beta_norm_max_wesson`
`beta_norm_max_menard`
`beta_norm_max_original_scaling`
`beta_norm_max_original_tholerus`

#### $l_i$ scalings

`ind_plasma_internal_norm_wesson`
`ind_plasma_internal_norm_menard`

-----------

### ✍️ Output changes

All of the $\beta_N$ scaling's are now shown 

![image](https://github.com/user-attachments/assets/e77b0b65-006e-4f34-95ae-e1f247bf20cd)

All of the $l_i$ scalings are now shown

![image](https://github.com/user-attachments/assets/04b8eb1c-ce57-4f38-b0ec-a48c0caf02c4)

All of the $\alpha_j$ scalings are now shown

![image](https://github.com/user-attachments/assets/e1f6acb1-0208-4311-95b9-8b680b591e81)



## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
