### PR TITLE
Add Stambaugh normalised beta limit

### DIFF
--- a/documentation/proc-pages/physics-models/plasma_beta/plasma_beta.md
+++ b/documentation/proc-pages/physics-models/plasma_beta/plasma_beta.md
@@ -324,6 +324,21 @@ where $F_p$ is the pressure peaking, $F_p = p_{\text{ax}} / \langle p \rangle$ a
 
 **This is only recommended for spherical tokamaks**
 
+-------------
+
+#### Stambaugh Relation
+
+This can be activated by stating `i_beta_norm_max = 5` in the input file.
+
+`beta_norm_max` is set to `beta_norm_max_stambaugh` using[^8] [^9]:
+
+
+$$
+g=\frac{f_\beta \times 10 \times\left(-0.7748+1.2869 \kappa-0.2921 \kappa^2+0.0197 \kappa^3\right)}{A^{0.5523} \times \tanh \left[(1.8524+0.2319 \kappa) / A^{0.6163}\right]}
+$$
+
+This fit was done for $A = 1.2 -7.0, \kappa = 1.5-6.0$ with $\delta = 0.5$ for nearly 100% bootstrap current
+
 ---------
 
 ## Key Constraints
@@ -405,4 +420,10 @@ The value of `beta_min` can be set to the desired minimum total beta. The scalin
 [^6]: M. E. Mauel et al., “Operation at the tokamak equilibrium poloidal beta-limit in TFTR,” Nuclear Fusion, vol. 32, no. 8, pp. 1468–1473, Aug. 1992. doi:https://dx.doi.org/10.1088/0029-5515/32/8/I14
 
 [^7]: T. T. S et al., “Profile Optimization and High Beta Discharges and Stability of High Elongation Plasmas in the DIII-D Tokamak,” Osti.gov, Oct. 1990. https://www.osti.gov/biblio/6194284 (accessed Dec. 19, 2024).
+
+[^8]: R. D. Stambaugh et al., “Fusion Nuclear Science Facility Candidates,” Fusion Science and Technology, vol. 59, no. 2, pp. 279–307, Feb. 2011, doi: https://doi.org/10.13182/fst59-279.
+
+[^9]: Y. R. Lin-Liu and R. D. Stambaugh, “Optimum equilibria for high performance, steady state tokamaks,” Nuclear Fusion, vol. 44, no. 4, pp. 548–554, Mar. 2004, doi: https://doi.org/10.1088/0029-5515/44/4/009.
+‌
+‌
 ‌

--- a/process/input.py
+++ b/process/input.py
@@ -1544,7 +1544,7 @@ INPUT_VARIABLES = {
     "ipnet": InputVariable(fortran.cost_variables, int, choices=[0, 1]),
     "ipowerflow": InputVariable(fortran.heat_transport_variables, int, choices=[0, 1]),
     "iprimshld": InputVariable(fortran.heat_transport_variables, int, choices=[0, 1]),
-    "i_beta_norm_max": InputVariable(fortran.physics_variables, int, range=(0, 4)),
+    "i_beta_norm_max": InputVariable(fortran.physics_variables, int, range=(0, 5)),
     "i_ind_plasma_internal_norm": InputVariable(
         fortran.physics_variables, int, range=(0, 2)
     ),

--- a/process/physics.py
+++ b/process/physics.py
@@ -2543,29 +2543,12 @@ class Physics:
             )
         )
 
-        # R. D. Stambaugh et al., “Fusion Nuclear Science Facility Candidates,”
-        # Fusion Science and Technology, vol. 59, no. 2, pp. 279-307, Feb. 2011,
-        # doi: https://doi.org/10.13182/fst59-279.
-
-        # Y. R. Lin-Liu and R. D. Stambaugh, “Optimum equilibria for high performance, steady state tokamaks,”
-        # Nuclear Fusion, vol. 44, no. 4, pp. 548-554, Mar. 2004,
-        # doi: https://doi.org/10.1088/0029-5515/44/4/009.
-
+        # R. D. Stambaugh scaling law
         physics_variables.beta_norm_max_stambaugh = (
-            current_drive_variables.f_c_plasma_bootstrap
-            * 10
-            * (
-                -0.7748
-                + (1.2869 * physics_variables.kappa)
-                - (0.2921 * physics_variables.kappa**2)
-                + (0.0197 * physics_variables.kappa**3)
-            )
-            / (
-                physics_variables.aspect**0.5523
-                * np.tanh(
-                    (1.8524 + (0.2319 * physics_variables.kappa))
-                    / physics_variables.aspect**0.6163
-                )
+            self.calculate_beta_norm_max_stambaugh(
+                f_c_plasma_bootstrap=current_drive_variables.f_c_plasma_bootstrap,
+                kappa=physics_variables.kappa,
+                aspect=physics_variables.aspect,
             )
         )
 
@@ -2912,6 +2895,45 @@ class Physics:
         """
         return 3.7 + (
             (c_beta / (p0 / vol_avg_pressure)) * (12.5 - 3.5 * (p0 / vol_avg_pressure))
+        )
+
+    @staticmethod
+    def calculate_beta_norm_max_stambaugh(
+        f_c_plasma_bootstrap: float,
+        kappa: float,
+        aspect: float,
+    ) -> float:
+        """
+        Calculate the Stambaugh normalized beta upper limit.
+
+        :param f_c_plasma_bootstrap: Bootstrap current fraction.
+        :type f_c_plasma_bootstrap: float
+        :param kappa: Plasma separatrix elongation.
+        :type kappa: float
+        :param aspect: Plasma aspect ratio.
+        :type aspect: float
+
+        :return: The Stambaugh normalized beta upper limit.
+        :rtype: float
+
+        :Notes:
+            - This method calculates the normalized beta upper limit based on the Stambaugh scaling.
+            - The formula is derived from empirical fits to high-performance, steady-state tokamak equilibria.
+
+        :References:
+            - R. D. Stambaugh et al., “Fusion Nuclear Science Facility Candidates,”
+              Fusion Science and Technology, vol. 59, no. 2, pp. 279-307, Feb. 2011,
+              doi: https://doi.org/10.13182/fst59-279.
+
+            - Y. R. Lin-Liu and R. D. Stambaugh, “Optimum equilibria for high performance, steady state tokamaks,”
+              Nuclear Fusion, vol. 44, no. 4, pp. 548-554, Mar. 2004,
+              doi: https://doi.org/10.1088/0029-5515/44/4/009.
+        """
+        return (
+            f_c_plasma_bootstrap
+            * 10
+            * (-0.7748 + (1.2869 * kappa) - (0.2921 * kappa**2) + (0.0197 * kappa**3))
+            / (aspect**0.5523 * np.tanh((1.8524 + (0.2319 * kappa)) / aspect**0.6163))
         )
 
     @staticmethod

--- a/process/physics.py
+++ b/process/physics.py
@@ -2543,19 +2543,27 @@ class Physics:
             )
         )
 
+        # R. D. Stambaugh et al., “Fusion Nuclear Science Facility Candidates,”
+        # Fusion Science and Technology, vol. 59, no. 2, pp. 279-307, Feb. 2011,
+        # doi: https://doi.org/10.13182/fst59-279.
+
+        # Y. R. Lin-Liu and R. D. Stambaugh, “Optimum equilibria for high performance, steady state tokamaks,”
+        # Nuclear Fusion, vol. 44, no. 4, pp. 548-554, Mar. 2004,
+        # doi: https://doi.org/10.1088/0029-5515/44/4/009.
+
         physics_variables.beta_norm_max_stambaugh = (
             current_drive_variables.f_c_plasma_bootstrap
             * 10
             * (
                 -0.7748
-                + 1.2869 * physics_variables.kappa
-                - 0.2921 * physics_variables.kappa**2
-                + 0.0197 * physics_variables.kappa**3
+                + (1.2869 * physics_variables.kappa)
+                - (0.2921 * physics_variables.kappa**2)
+                + (0.0197 * physics_variables.kappa**3)
             )
             / (
-                physics_variables.aspect
+                physics_variables.aspect**0.5523
                 * np.tanh(
-                    (1.8524 + 0.2319 * physics_variables.kappa)
+                    (1.8524 + (0.2319 * physics_variables.kappa))
                     / physics_variables.aspect**0.6163
                 )
             )

--- a/process/physics.py
+++ b/process/physics.py
@@ -2543,6 +2543,24 @@ class Physics:
             )
         )
 
+        physics_variables.beta_norm_max_stambaugh = (
+            current_drive_variables.f_c_plasma_bootstrap
+            * 10
+            * (
+                -0.7748
+                + 1.2869 * physics_variables.kappa
+                - 0.2921 * physics_variables.kappa**2
+                + 0.0197 * physics_variables.kappa**3
+            )
+            / (
+                physics_variables.aspect
+                * np.tanh(
+                    (1.8524 + 0.2319 * physics_variables.kappa)
+                    / physics_variables.aspect**0.6163
+                )
+            )
+        )
+
         # Map calculation methods to a dictionary
         beta_norm_max_calculations = {
             0: physics_variables.beta_norm_max,
@@ -2550,6 +2568,7 @@ class Physics:
             2: physics_variables.beta_norm_max_original_scaling,
             3: physics_variables.beta_norm_max_menard,
             4: physics_variables.beta_norm_max_thloreus,
+            5: physics_variables.beta_norm_max_stambaugh,
         }
 
         # Calculate beta_norm_max based on i_beta_norm_max
@@ -4332,6 +4351,13 @@ class Physics:
                 "E. Thloreus normalised beta upper limit",
                 "(beta_norm_max_thloreus) ",
                 physics_variables.beta_norm_max_thloreus,
+                "OP ",
+            )
+            po.ovarrf(
+                self.outfile,
+                "R. Stambaugh normalised beta upper limit",
+                "(beta_norm_max_stambaugh) ",
+                physics_variables.beta_norm_max_stambaugh,
                 "OP ",
             )
 
@@ -8494,6 +8520,7 @@ def init_physics_variables():
     physics_variables.beta_norm_max_menard = 0.0
     physics_variables.beta_norm_max_original_scaling = 0.0
     physics_variables.beta_norm_max_tholerus = 0.0
+    physics_variables.beta_norm_max_stambaugh = 0.0
     physics_variables.dnelimt = 0.0
     physics_variables.nd_ions_total = 0.0
     physics_variables.dnla = 0.0

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -189,6 +189,9 @@ module physics_variables
   real(dp) :: beta_norm_max_tholerus
   !! Tholerus-like coefficient for beta scaling
 
+  real(dp) :: beta_norm_max_stambaugh
+  !! Stambaugh-like coefficient for beta scaling
+
   real(dp) :: dnelimt
   !! density limit (/m3)
 

--- a/tests/unit/test_physics.py
+++ b/tests/unit/test_physics.py
@@ -3306,3 +3306,14 @@ def test_calculate_beta_norm_max_thloreus():
     vol_avg_pressure = 1.0
     result = Physics.calculate_beta_norm_max_thloreus(c_beta, p0, vol_avg_pressure)
     assert result == pytest.approx(5.075, abs=0.00001)
+
+
+def test_calculate_beta_norm_max_stambaugh():
+    """Test calculate_beta_norm_max_thloreus()"""
+    f_c_plasma_bootstrap = 0.7
+    kappa = 2.0
+    aspect = 2.5
+    result = Physics.calculate_beta_norm_max_stambaugh(
+        f_c_plasma_bootstrap, kappa, aspect
+    )
+    assert result == pytest.approx(3.840954484207041, abs=0.00001)


### PR DESCRIPTION
This pull request introduces the implementation of the Stambaugh relation for normalized beta (`beta_norm_max`) in the plasma physics model. It includes updates to the documentation, Python code, and Fortran code to support this new feature.



$$
g=\frac{f_\beta \times 10 \times\left(-0.7748+1.2869 \kappa-0.2921 \kappa^2+0.0197 \kappa^3\right)}{A^{0.5523} \times \tanh \left[(1.8524+0.2319 \kappa) / A^{0.6163}\right]}
$$

--------------

R. D. Stambaugh et al., “Fusion Nuclear Science Facility Candidates,” Fusion Science and Technology, vol. 59, no. 2, pp. 279–307, Feb. 2011, doi: https://doi.org/10.13182/fst59-279.
### Documentation Updates:
* Added a new section in `plasma_beta.md` explaining the Stambaugh relation, including the formula and applicable parameter ranges. References to relevant research papers were also included. 

### Python Code Updates:
* Implemented the calculation of `beta_norm_max_stambaugh` in the `physics` method of `process/physics.py`, based on the Stambaugh relation formula.
* Integrated `beta_norm_max_stambaugh` into the `beta_norm_max_calculations` dictionary for selection via the `i_beta_norm_max` parameter.
* Added output support for `beta_norm_max_stambaugh` in the `outplas` method for reporting purposes.
* Initialized `beta_norm_max_stambaugh` in the `init_physics_variables` function.

### Fortran Code Updates:
* Added a new variable, `beta_norm_max_stambaugh`, to the `physics_variables` module to store the Stambaugh coefficient for beta scaling.

### Output

![image](https://github.com/user-attachments/assets/115601e0-3205-4ae5-81fc-d47662b74b90)



<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
