### PR TITLE
:fire: Remove redundant calculation of thermal poloidal beta for Wils…

### DIFF
--- a/process/physics.py
+++ b/process/physics.py
@@ -1891,18 +1891,13 @@ class Physics:
         )
 
         # Wilson scaling uses thermal poloidal beta, not total
-        betpth = (
-            physics_variables.beta
-            - physics_variables.beta_fast_alpha
-            - physics_variables.beta_beam
-        ) * (physics_variables.btot / physics_variables.bp) ** 2
         current_drive_variables.f_c_plasma_bootstrap_wilson = (
             current_drive_variables.cboot
             * self.bootstrap_fraction_wilson(
                 physics_variables.alphaj,
                 physics_variables.alphap,
                 physics_variables.alphat,
-                betpth,
+                physics_variables.beta_thermal_poloidal,
                 physics_variables.q0,
                 physics_variables.q95,
                 physics_variables.rmajor,


### PR DESCRIPTION
This pull request updates the `physics` method in `process/physics.py` to simplify and improve the calculation of the Wilson scaling bootstrap current drive variable. The most important change is the replacement of a manually calculated `betpth` value with the pre-existing `beta_thermal_toroidal` variable from `physics_variables`.

Improvements to Wilson scaling calculation:

* [`process/physics.py`](diffhunk://#diff-e21acd338af89777d2e84c823a6854ec4e80ca6fcf7ebb8fe062fbfc36d51c9cL1894-R1900): Replaced the manually computed `betpth` value with `physics_variables.beta_thermal_toroidal`, simplifying the code and reducing redundancy. This change ensures the use of a standardized variable for thermal poloidal beta in the Wilson scaling calculation.…on bootstrap scaling

## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
