### PR TITLE
Re-enable large tokamak (no f values)

### DIFF
--- a/tests/regression/test_process_input_files.py
+++ b/tests/regression/test_process_input_files.py
@@ -274,11 +274,6 @@ def test_input_file(
     should be compared in the test.
     :type opt_params_only: bool
     """
-    if input_file.name == "large_tokamak_nof.IN.DAT":
-        pytest.skip(
-            "The inequalities large tokamak input file currently doesn't solve."
-        )
-
     new_input_file = tmp_path / input_file.name
     shutil.copy(input_file, new_input_file)
 


### PR DESCRIPTION
Was disabled in #3619. Since then, something in the code has changed to cause the solver to take a different path and solve, although I'm not sure what (which is unsurprising since we don't know what caused it, although #3619 was put in just after #3565).