### PR TITLE
:bug: Fix some missed integration due to rebases

### DIFF
--- a/process/input.py
+++ b/process/input.py
@@ -230,6 +230,9 @@ INPUT_VARIABLES = {
     "f_c_plasma_bootstrap_max": InputVariable(
         fortran.current_drive_variables, float, range=(-0.999, 0.999)
     ),
+    "f_c_plasma_bootstrap": InputVariable(
+        fortran.current_drive_variables, float, range=(0.0, 1.0)
+    ),
     "breeder_f": InputVariable(fortran.fwbs_variables, float, range=(0.0, 1.0)),
     "breeder_multiplier": InputVariable(
         fortran.fwbs_variables, float, range=(0.0, 1.0)
@@ -1478,7 +1481,7 @@ INPUT_VARIABLES = {
     "i_cp_lifetime": InputVariable(fortran.cost_variables, int, range=(0, 3)),
     "i_cs_precomp": InputVariable(fortran.build_variables, int, choices=[0, 1]),
     "i_cs_stress": InputVariable(fortran.pfcoil_variables, int, choices=[0, 1]),
-    "i_density_limit": InputVariable(fortran.physics_variables, int, range=(1, 7)),
+    "i_density_limit": InputVariable(fortran.physics_variables, int, range=(1, 8)),
     "i_diamagnetic_current": InputVariable(
         fortran.physics_variables, int, choices=[0, 1, 2]
     ),

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -824,7 +824,7 @@ def plot_main_plasma_information(
         arrowprops={"facecolor": "grey", "edgecolor": "grey", "lw": 1},
     )
 
-    textstr_neutron = f"$P_{{\\text{{n,total}}}}$ {mfile_data.data['neutron_power_total'].get_scan(scan):.2f} MW"
+    textstr_neutron = f"$P_{{\\text{{n,total}}}}$ {mfile_data.data['p_neutron_total_mw'].get_scan(scan):.2f} MW"
 
     axis.text(
         0.75,
@@ -848,11 +848,11 @@ def plot_main_plasma_information(
         f"$\\mathbf{{Fusion \\ Reactions:}}$\n \n"
         f"Fuel mixture: \n"
         f"|  D: {mfile_data.data['f_deuterium'].get_scan(scan):.2f}  |  T: {mfile_data.data['f_tritium'].get_scan(scan):.2f}  |  3He: {mfile_data.data['f_helium3'].get_scan(scan):.2f}  |\n\n"
-        f"Fusion Power, $P_{{\\text{{fus}}}}:$ {mfile_data.data['fusion_power'].get_scan(scan):.2f} MW\n"
-        f"D-T Power, $P_{{\\text{{fus,DT}}}}:$ {mfile_data.data['dt_power_total'].get_scan(scan):.2f} MW\n"
-        f"D-D Power, $P_{{\\text{{fus,DD}}}}:$ {mfile_data.data['dd_power'].get_scan(scan):.2f} MW\n"
-        f"D-3He Power, $P_{{\\text{{fus,D3He}}}}:$ {mfile_data.data['dhe3_power'].get_scan(scan):.2f} MW\n"
-        f"Alpha Power, $P_{{\\alpha}}:$ {mfile_data.data['alpha_power_total'].get_scan(scan):.2f} MW"
+        f"Fusion Power, $P_{{\\text{{fus}}}}:$ {mfile_data.data['p_fusion_total_mw'].get_scan(scan):.2f} MW\n"
+        f"D-T Power, $P_{{\\text{{fus,DT}}}}:$ {mfile_data.data['p_dt_total_mw'].get_scan(scan):.2f} MW\n"
+        f"D-D Power, $P_{{\\text{{fus,DD}}}}:$ {mfile_data.data['p_dd_total_mw'].get_scan(scan):.2f} MW\n"
+        f"D-3He Power, $P_{{\\text{{fus,D3He}}}}:$ {mfile_data.data['p_dhe3_total_mw'].get_scan(scan):.2f} MW\n"
+        f"Alpha Power, $P_{{\\alpha}}:$ {mfile_data.data['p_alpha_total_mw'].get_scan(scan):.2f} MW"
     )
 
     axis.text(


### PR DESCRIPTION
This pull request introduces updates to the `process/input.py` and `process/io/plot_proc.py` files, focusing on extending input variable ranges, adding a new input variable, and updating variable names for consistency in plotting functions.

### Input Variable Updates:
* Added a new input variable, `"f_c_plasma_bootstrap"`, with a range of `(0.0, 1.0)` in `process/input.py`.
* Extended the range of the `"i_density_limit"` variable from `(1, 7)` to `(1, 8)` in `process/input.py`.

### Plotting Function Updates:
* Renamed the `"neutron_power_total"` variable to `"p_neutron_total_mw"` for consistency in `process/io/plot_proc.py`.
* Updated several variable names in the fusion power summary to align with a consistent naming convention (e.g., `"fusion_power"` to `"p_fusion_total_mw"`, `"dt_power_total"` to `"p_dt_total_mw"`, etc.) in `process/io/plot_proc.py`.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
