### PR TITLE
add tl;dr about failed quality jobs to pre-commit docs

### DIFF
--- a/documentation/proc-pages/development/pre-commit.md
+++ b/documentation/proc-pages/development/pre-commit.md
@@ -1,7 +1,7 @@
 # Pre-commit
 
 !!! Info "TL;DR: the quality job fails"
-    If the quality job fails, run pre-commit using `pre-commit run --all-files` and commit the file changes to your branch. If this doesn't solve
+    If the quality job fails, run pre-commit using `pre-commit run --all-files` and fix any failures (some issues may be fixed automatically). Add and commit the changes until pre-commit no longer fails. If this doesn't solve
     the problem then see below for more details.
 
 

--- a/documentation/proc-pages/development/pre-commit.md
+++ b/documentation/proc-pages/development/pre-commit.md
@@ -1,5 +1,10 @@
 # Pre-commit
 
+!!! Info "TL;DR: the quality job fails"
+    If the quality job fails, run pre-commit using `pre-commit run --all-files` and commit the file changes to your branch. If this doesn't solve
+    the problem then see below for more details.
+
+
 Pre-commit is PROCESS' way of ensuring all code pushed to our repository is of a certain quality 
 and style. One common style ensures PROCESS can be easily navigated and understood by all users. It 
 also reduces the "diffs" when reviewing code changes as often small style changes (such as the 

--- a/documentation/proc-pages/development/pre-commit.md
+++ b/documentation/proc-pages/development/pre-commit.md
@@ -87,7 +87,7 @@ your commits pass through pre-commit, then these jobs should not fail as your co
 Although not required, the `ruff` VSCode extension will ensure that all the Python files you save 
 will be ruff-compliant and, as such, won't need to modified by pre-commit.
 
-Open or create the file `.vscode/settings.sh` and add/modify the following settings:
+Open or create the file `.vscode/settings.json` and add/modify the following settings:
 ```json
 {
     "[python]": {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
Closes #1637 
Added a tl;dr to the docs to say what to do if the quality job fails. This is how it looks in the docs:

![image](https://github.com/user-attachments/assets/28f2a149-e102-4e3b-9947-367ff47b993e)


## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
