### PR TITLE
✨ Add full output plotting option to `PROCESS` class

### DIFF
--- a/documentation/proc-pages/installation/vs-code.md
+++ b/documentation/proc-pages/installation/vs-code.md
@@ -7,14 +7,18 @@ vast extension package allowing ease of use with a range of languages. Visual St
 available for install [here](https://code.visualstudio.com/) and more information can be found on
 the [docs pages](https://code.visualstudio.com/docs).
 
-<h2>WSL with VS Code</h2>
+-------------
+
+## WSL with VS Code
 
 To connect WSL to VS Code, the following extension should be installed in VS Code upon
 opening: `Remote - WSL`. This allows for opening of any folder in the Windows Subsystem for
 Linux. This is performed by using `Ctrl+Shift+X` on VS Code, searching for `Remote - WSL` and
 then installing.
 
-<h2>Automatically activating virtual environment on VS Code Open</h2>
+--------------
+
+## Automatically activating virtual environment on VS Code Open
 
 When VS Code is first opened, you are able to set it such that the command:
 

--- a/documentation/proc-pages/usage/plotting.md
+++ b/documentation/proc-pages/usage/plotting.md
@@ -4,7 +4,7 @@
 
 !!! note 
 
-    The majority of the output plots can be automaticall generated at the end of the `PROCESS` run by using the `--full-output` flag.
+    The majority of the output plots can be automatically generated at the end of the `PROCESS` run by using the `--full-output` flag.
     See the [running process section](./running-process.md) section for more info.
 
 ### Summary document

--- a/documentation/proc-pages/usage/plotting.md
+++ b/documentation/proc-pages/usage/plotting.md
@@ -5,7 +5,7 @@
 !!! note 
 
     The majority of the output plots can be automatically generated at the end of the `PROCESS` run by using the `--full-output` flag.
-    See the [running process section](./running-process.md) section for more info.
+    See the [running process](./running-process.md) section for more info.
 
 ### Summary document
 

--- a/documentation/proc-pages/usage/plotting.md
+++ b/documentation/proc-pages/usage/plotting.md
@@ -1,8 +1,14 @@
 # Utilities
 
-<h2>Plotting an MFILE</h2>
+## Plotting an MFILE
 
-<h3>Summary document</h3>
+!!! note 
+
+    The majority of the output plots can be automaticall generated at the end of the `PROCESS` run by using the `--full-output` flag.
+    See the [running process section](./running-process.md) section for more info.
+
+### Summary document
+
 `plot_proc` is used for plotting an overview of the results from an MFILE. It can be run using its own CLI:
 
 ```bash
@@ -59,7 +65,9 @@ process -i path/to/IN.DAT --plot --mfile path/to/MFILE.DAT
 <figcaption>Figure 9: plot_proc first wall comparison page  </figcaption>
 </figure>
 
-<h3>Scan files</h3>
+----------------
+
+### Scan files
 
 `plot_scans` is a tool to show the change in variables as a scan variable is varied.
 Scans can be done in one or two dimensions.
@@ -77,9 +85,9 @@ python process/io/plot_scans.py -f path/to/MFILE.DAT
 <figcaption>Figure 11: 1D scan plot </figcaption>
 </figure>
 
+----------------
 
-
-<h3>Radial build</h3>
+### Radial build
 
 `plot_radial_build` is to plot the radial build of the machine in terms of bar segments. It can be run as follows:
 

--- a/documentation/proc-pages/usage/running-process.md
+++ b/documentation/proc-pages/usage/running-process.md
@@ -2,15 +2,18 @@
 
 There are a number of ways to run PROCESS.  The first two are determined by the value of the switch `ioptimz` in the input file:
 
-`ioptimz` = -2 for evaluation. The physics and engineering models are evaluated and the equality (e.g. model consistency) constraints will be solved using `scipy`'s `fsolve`. The input file and default values together define the input values of all variables. The values of the parameters used to solve the equalities (solution parameters) will be different in the solution, however. This is used when evaluating a set of input parameters (e.g. a "point") whilst ensuring that the models are self-consistent.
+`ioptimz = -2` for evaluation. The physics and engineering models are evaluated and the equality (e.g. model consistency) constraints will be solved using `scipy`'s `fsolve`. The input file and default values together define the input values of all variables. The values of the parameters used to solve the equalities (solution parameters) will be different in the solution, however. This is used when evaluating a set of input parameters (e.g. a "point") whilst ensuring that the models are self-consistent.
 
-`ioptimz` = 1 for optimisation.  Those variables specified as iteration variables (specified by equations such as `ixc = 1` in the input file) are automatically varied during the iteration process, between the bounds given by the arrays `boundl` (lower bounds) and `boundu` (upper bounds).  The input file contains the *initial* values of the iteration variables, but the final values will not be same.  The iteration process continues until convergence, or until the maximum number of iterations (`maxcal`) is reached.  If the code converges, the constraints will be satisfied and the Figure of Merit will be maximised or minimised. 
+`ioptimz = 1` for optimisation.  Those variables specified as iteration variables (specified by equations such as `ixc = 1` in the input file) are automatically varied during the iteration process, between the bounds given by the arrays `boundl` (lower bounds) and `boundu` (upper bounds).  The input file contains the *initial* values of the iteration variables, but the final values will not be same.  The iteration process continues until convergence, or until the maximum number of iterations (`maxcal`) is reached.  If the code converges, the constraints will be satisfied and the Figure of Merit will be maximised or minimised. 
 
 If the optimisation fails to converge, a third option is available by using the command line option `-v` (VaryRun), together with a configuration file.  PROCESS is run repeatedly in optimisation mode (`ioptimz` = 1 must be set), but a new input file is written each time, with different, randomly selected *initial* values of the iteration variables.  The factor within which the initial values of the iteration variables are changed is `FACTOR` (in the configuration file).  For example, `FACTOR = 1.1` will vary the initial values randomly by up to 10%.  This is repeated until PROCESS converges, or until the maximum number of PROCESS runs (`NITER`) is reached.  Sometimes this procedure will generate a converged solution when a single optimisation run does not.
 
 A SCAN is available in any of these modes.  One input variable can be scanned (`scan_dim = 1`) or two input variables (`scan_dim = 2`).  A scan variable must not be an iteration variable.  For details, see [scan_module](https://ukaea.github.io/PROCESS/io/vardes/?h=scan#scan_module).
 
+--------------
+
 ## To run PROCESS
+
 The default PROCESS input file name is IN.DAT. If no input file name is given as an argument in the command line, it assumes an IN.DAT file is present in the current directory:
 ```bash
 # Use an IN.DAT file in the current directory
@@ -28,8 +31,27 @@ will produce the following output files in the same directory as the input file:
     my_file_name_MFILE.DAT
 ```
 
+It may be convenient to automatically generate the summary plots after the `PROCESS` run has finished.
+Setting the `--full-output` flag:
 
-__VaryRun__  
+```bash
+process -i path/to/my_file_name_IN.DAT --full-output
+```
+
+will produce the following output files in the same directory as the input file:
+
+```
+    my_file_name_OUT.DAT
+    my_file_name_MFILE.DAT
+    SankeyPowerFlow.pdf
+    my_file_name.MFILE.DATSUMMARY.pdf
+    my_file_name.MFILE_radial_build.pdf
+```
+
+---------------
+
+### VaryRun 
+
 The default VaryRun configuration filename is `run_process.conf`. If no configuration filename is given as an argument in the command line, `run_process.conf` is assumed to be present in the current directory:
 ```bash
 # Use a configuration file called run_process.conf in the current directory
@@ -41,19 +63,17 @@ process -v -c path/to/my_conf_file.conf
 ```
 When using VaryRun, the input filename is defined inside the configuration file.  The `-i` argument should not be used.
 
+-----------------
 
-__Comand line arguments__  
-The full set of command line arguments is:
+### Command line arguments
 
-```bash
-process [--input, -i input_file_path] [--varyiterparams, -v] [--varyiterparamsconfig, -c config_file_path] [--help, -h]
-```
-
-Help is available with:
+The full set of command line arguments is available with:
 
 ```bash
 process --help
 ```
+
+------------
 
 ## Configuration file for VaryRun
 

--- a/documentation/proc-pages/usage/troubleshooting.md
+++ b/documentation/proc-pages/usage/troubleshooting.md
@@ -5,7 +5,7 @@ produce infeasible results; that is, the code will not find a consistent set of 
 The highly non-linear nature of the numerics of PROCESS is the reason for this difficulty, and 
 it often requires a great deal of painstaking adjustment of the input file to overcome.
 
-<h2>Error handling</h2>
+## Error handling
 
 In general, errors detected during a run are handled in a consistent manner, with the code 
 producing useful diagnostic messages to help the user understand what has happened.

--- a/process/io/plot_radial_build.py
+++ b/process/io/plot_radial_build.py
@@ -42,13 +42,6 @@ def parse_args(args):
     )
 
     parser.add_argument(
-        "-op",
-        "--outputdir",
-        default=Path.cwd(),
-        help="Output directory for plot, defaults to current working directory.",
-    )
-
-    parser.add_argument(
         "-sf",
         "--save_format",
         nargs="?",
@@ -370,10 +363,10 @@ def main(args=None):
     )
     plt.xlabel("Radius [m]")
     plt.tight_layout()
-    plt.savefig(
-        f"{args.outputdir}/{Path(args.input).stem}_radial_build.{save_format}",
-        bbox_inches="tight",
+    output_path = (
+        Path(args.input).parent / f"{Path(args.input).stem}_radial_build.{save_format}"
     )
+    plt.savefig(output_path, bbox_inches="tight")
 
     # Display plot (used in Jupyter notebooks)
     plt.show()

--- a/process/io/plot_sankey.py
+++ b/process/io/plot_sankey.py
@@ -10,6 +10,7 @@ MFILE.DAT
 """
 
 import argparse
+import pathlib
 
 import matplotlib as mpl
 from pylab import savefig, show
@@ -40,7 +41,12 @@ def main(args=None):
     # main program
 
     plot_sankey(args.mfile)
-    savefig("SankeyPowerFlow." + args.end)
+
+    # Get directory of mfile
+    mfile_path = pathlib.Path(args.mfile).resolve()
+    mfile_dir = mfile_path.parent
+    output_path = mfile_dir / f"SankeyPowerFlow.{args.end}"
+    savefig(str(output_path))
 
     show()
 

--- a/tests/integration/test_main_int.py
+++ b/tests/integration/test_main_int.py
@@ -73,11 +73,9 @@ def test_plot_proc(temp_data, mfile_name):
     # Specify input and mfiles
     input_file = temp_data / "large_tokamak_IN.DAT"
     input_file_str = str(input_file.resolve())
-    mfile = temp_data / mfile_name
-    mfile_str = str(mfile)
 
     # Run on input, then plot custom mfile name
-    main.main(args=["-i", input_file_str, "--plot", "--mfile", mfile_str])
+    main.main(args=["-i", input_file_str, "--full-output"])
 
     # Assert a pdf has been created
     assert len(list(temp_data.glob("*.pdf")))

--- a/tests/integration/test_plot_radial_build.py
+++ b/tests/integration/test_plot_radial_build.py
@@ -13,6 +13,6 @@ def test_plot_radial_build(temp_data, mfile_name):
     """
     mfile = temp_data / mfile_name
 
-    plot_radial_build.main(args=["-f", str(mfile), "--outputdir", str(temp_data)])
+    plot_radial_build.main(args=["-f", str(mfile)])
 
     assert len(list(temp_data.glob("*.pdf")))


### PR DESCRIPTION
This pull request focuses on improving documentation and enhancing the functionality of the `PROCESS` tool by introducing a new `--full-output` flag for automated summary plotting. Key changes include updates to documentation, the addition of the new flag, and the removal of outdated functionality.

### Documentation Improvements:
* Standardized headings in multiple documentation files, replacing `<h2>` and `<h3>` tags with Markdown-style headers for consistency (`##` and `###`). 
* Added details about the `--full-output` flag to the "Running PROCESS" documentation, including examples of its usage and the output it generates.
* Enhanced the "Plotting" documentation with a note on automatic plot generation using the `--full-output` flag.

### Code Enhancements:
* Introduced a new `--full-output` flag in `process/main.py` to automate the generation of summary plots (e.g., radial build, Sankey diagrams) after a `PROCESS` run. 
* Updated the `post_process` method to handle the new `--full-output` flag, running all relevant plotting scripts (`plot_proc`, `plot_radial_build`, `plot_sankey`).

### Code Cleanup:
* Removed the deprecated `--plot` argument and its associated logic from `process/main.py` to streamline the codebase. 
* Updated integration tests to reflect the removal of the `--plot` argument and to test the `--full-output` flag instead.

These changes improve both the usability of the `PROCESS` tool and the clarity of its documentation.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
