### PR TITLE
Add `casthi` to obsolete

### DIFF
--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -333,6 +333,7 @@ OBS_VARS = {
     "roughness": "roughness_fw_channel",
     "casthi_is_fraction": "i_f_dr_tf_plasma_case",
     "casthi_fraction": "f_dr_tf_plasma_case",
+    "casthi": "dr_tf_plasma_case",
     "htpmw_blkt": "p_blkt_coolant_pump_mw",
     "htpmw_div": "p_div_coolant_pump_mw",
     "htpmw_fw": "p_fw_coolant_pump_mw",


### PR DESCRIPTION
This pull request includes a minor update to the `process/io/obsolete_vars.py` file. The change adds a new mapping for the variable `casthi` to `dr_tf_plasma_case` to align with existing naming conventions.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
