### PR TITLE
Read image files in plot_proc before loading into array

### DIFF
--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -764,9 +764,11 @@ def plot_main_plasma_information(
     # =========================================
 
     # Load the neutron image
-    alpha_particle = mpimg.imread(
-        resources.path("process.io", "alpha_particle.PNG")
-    )  # Use importlib.resources to locate the image
+    with resources.path(
+        "process.io", "alpha_particle.PNG"
+    ) as alpha_particle_image_path:
+        # Use importlib.resources to locate the image
+        alpha_particle = mpimg.imread(alpha_particle_image_path.open("rb"))
 
     # Display the neutron image over the figure, not the axes
     new_ax = axis.inset_axes(
@@ -806,7 +808,8 @@ def plot_main_plasma_information(
     )
 
     # =========================================
-    neutron = mpimg.imread(resources.path("process.io", "neutron.png"))
+    with resources.path("process.io", "neutron.png") as neutron_image_path:
+        neutron = mpimg.imread(neutron_image_path.open("rb"))
     new_ax = axis.inset_axes(
         [0.975, 0.75, 0.075, 0.075], transform=axis.transAxes, zorder=10
     )


### PR DESCRIPTION
It seems that between Python 3.10 and 3.11 `importlib.resources` changed their API slightly and the underlying context manager no longer provides an interface compatible with Pillow's image reader (I suspect we were somewhat lucky that it worked and were relying on an unstable API). 

`imread` supports `BinaryIO` input and so I have changed the loading of images to first read the contents of the file into binary before attempting to load it into a numpy array representation of the image. 