### PR TITLE
Refactor pulse `burn()`

### DIFF
--- a/documentation/proc-pages/physics-models/plasma_current/inductive_plasma_current.md
+++ b/documentation/proc-pages/physics-models/plasma_current/inductive_plasma_current.md
@@ -1,4 +1,6 @@
-Currently in `PROCESS` the inductive current fraction from the CS is not calculated directly but is just equal to ($1 - \mathtt{f_c_plasma_non_inductive}$). Where $\mathtt{f_c_plasma_non_inductive}$ is the sum of the fractions of current driven by non inductive means.
+# Inductive Current
+
+Currently in `PROCESS` the inductive current fraction from the CS is not calculated directly but is just equal to ($1 - \texttt{f_c_plasma_non_inductive}$). Where $\texttt{f_c_plasma_non_inductive}$ is the sum of the fractions of current driven by non inductive means.
 
 This calculated fraction (`f_c_plasma_inductive`) is then used in the `calculate_volt_second_requirements()` and `burn()` functions to calculate the volt-second requirements and the burn time for a pulsed machine.
 
@@ -40,14 +42,14 @@ In the ramp up phase we need to take the plasma current from 0 Amps to the plasm
 Thankfully a formulation of the resistive flux consumption during ramp phase is given by Ejima et.al [^1].
 
 $$
-\mathtt{vs\_res\_ramp} = \Phi_{\text{res,ramp}} = C_{\text{eji}}\mu_0I_{\text{p}}R
+\overbrace{\Phi_{\text{res,ramp}}}^{\texttt{vs_res_ramp}} = C_{\text{eji}}\mu_0I_{\text{p}}R
 $$
 
 where $C_{\text{ejima}}$ is the empirical Ejima coefficient defined by the user or at its default of 0.4.
 
 This relation is is done by analyzing a wide range of cross-sections,
 ranging from circular to doublet produced in the Doublet III machine. The plasma cross-section is
-slightly elongated, with $\kappa=1.2$. The toroidal field is 2.4 $\text{T}$. The current swing of the Ohmic-heating transformer is nominally from $-25 \text{kA}$ to $+80 \text{kA}$, corresponding to a flux swing of $\approx 2.6 \ \text{Vs}$.
+slightly elongated, with $\kappa=1.2$. The toroidal field is $2.4 \ \text{T}$. The current swing of the Ohmic-heating transformer is nominally from $-25 \  \text{kA}$ to $+80 \ \text{kA}$, corresponding to a flux swing of $\approx 2.6 \ \text{Vs}$.
 
 The initial one-turn loop voltage is around $50 \ \text{V}$, causing the plasma current to rise to $300 \ \text{kA}$ in about $80 \  \text{ms}$. The plasma current is then increased to higher flat-top currents at a steady rate of $2 \text{MA} \text{s}^{-1}$.
 
@@ -64,7 +66,7 @@ The internal inductance is defined as the part of the inductance obtained by int
 The internal component of the plasma self inductance flux consumption during the ramp up phase is given by:
 
 $$
-\mathtt{vs\_plasma\_internal} = \Phi_{\text{ind,internal,ramp}} =  I_{\text{p}} \times \underbrace{\left[\frac{\mu_0 R l_i}{2}\right]}_{\mathtt{ind\_plasma\_internal}}
+\overbrace{\Phi_{\text{ind,internal,ramp}}}^{\texttt{vs_plasma_internal}} =  I_{\text{p}} \times \underbrace{\left[\frac{\mu_0 R l_i}{2}\right]}_{\texttt{ind_plasma_internal}}
 $$
 
 Here $l_i$ is known as the normalized internal inductance defined for circular cross section plasmas with minor radius $a$:
@@ -86,7 +88,7 @@ The external inductance needs to be accounted for also as even though we assume 
 Hirshman et.al[^3] gives a formula for the external plasma inductance in the form:
 
 $$
-\mathtt{ind\_plasma\_external} = L_{\text{ext}} = \mu_0 R\frac{a(\epsilon)(1-\epsilon)}{1-\epsilon + b(\epsilon)\kappa}
+\overbrace{L_{\text{ext}}}^{\texttt{ind_plasma_external}} = \mu_0 R\frac{a(\epsilon)(1-\epsilon)}{1-\epsilon + b(\epsilon)\kappa}
 $$
 
 $$
@@ -104,20 +106,19 @@ where $\epsilon$ is the plasma inverse aspect ratio and $\kappa$ is the separatr
 The total plasma inductance is then calculated as:
 
 $$
-\mathtt{ind\_plasma\_total} = \mathtt{ind\_plasma\_external} + \mathtt{ind\_plasma\_internal}
+\texttt{ind_plasma_total} = \texttt{ind_plasma_external} + \texttt{ind_plasma_internal}
 $$
 
 Therefore the total inductive flux consumption during ramp up is given by:
 
 $$
-\mathtt{vs\_self\_ind\_ramp} = \Phi_{\text{ind,ramp}} =  \mathtt{ind\_plasma\_total} \times I_{\text{p}}
+\overbrace{\Phi_{\text{ind,ramp}}}^{\texttt{vs_self_ind_ramp}} =  \texttt{ind_plasma_total} \times I_{\text{p}}
 $$
 
 So the total resisitive and inductive flux consumption at current ramp up which is the total flux requires is given by:
 
 $$
-\mathtt{vs\_ramp\_required} = \mathtt{vs\_res\_ramp} + \mathtt{vs\_self\_ind\_ramp} \\
-\Phi_{\text{tot,ramp}} =  \Phi_{\text{res,ramp}} + \Phi_{\text{ind,ramp}}
+\overbrace{\Phi_{\text{tot,ramp}}}^{\texttt{vs_ramp_required}} =  \overbrace{\Phi_{\text{res,ramp}}}^{\texttt{vs_res_ramp}} + \overbrace{\Phi_{\text{ind,ramp}}}^{\texttt{vs_self_ind_ramp}}
 $$
 
 ------------------
@@ -134,7 +135,7 @@ At plasma current flat-top there is no self inductance contribution as the plasm
 For the flat top resistive component we can just take the loop voltage value based on the plasmas resistivity and the known fraction of current driven inductively:
 
 $$
-\mathtt{v\_burn\_resistive} = V_{\text{loop}} = I_{\text{p}}  \rho_\text{p} f_{\text{ind}}
+\overbrace{V_{\text{loop}}}^{\texttt{v_burn_resistive}} = I_{\text{p}}  \rho_\text{p} f_{\text{ind}}
 $$
 
 where $\rho_\text{p}$ is the calculated [plasma resistivity](./plasma_resistive_heating.md) and $f_{\text{ind}}$ is the inductive current fraction.
@@ -142,8 +143,7 @@ where $\rho_\text{p}$ is the calculated [plasma resistivity](./plasma_resistive_
 The total flux required is then simply found by multiplying the loop voltage above by the required duration of the burn phase:
 
 $$
-\mathtt{vs\_burn\_required} = \Phi_{\text{res,burn}} = I_{\text{p}}  \rho_\text{p} f_{\text{ind}} \times T_{\text{burn}} \\
-= \mathtt{v\_burn\_resistive} \times \mathtt{t\_burn}
+\overbrace{\Phi_{\text{res,burn}}}^{\texttt{vs_burn_required}} = \overbrace{I_{\text{p}}  \rho_\text{p} f_{\text{ind}}}^{\texttt{v_burn_resistive}} \times \overbrace{T_{\text{burn}}}^{\texttt{t_burn}}
 $$
 
 ----------------
@@ -151,8 +151,7 @@ $$
 Finally we can now find the minimum flux required for the full duration of the pulse:
 
 $$
-\mathtt{vs\_total\_required} = \Phi_{\text{tot}} = \Phi_{\text{tot,ramp}} + \Phi_{\text{res,burn}} \\
-= \mathtt{vs\_ramp\_required} + \mathtt{vs\_burn\_required}
+\overbrace{\Phi_{\text{tot}}}^{\texttt{vs_total_required}} = \overbrace{\Phi_{\text{tot,ramp}}}^{\texttt{vs_ramp_required}} + \overbrace{\Phi_{\text{res,burn}}}^{\texttt{vs_burn_required}}
 $$
 
 

--- a/documentation/proc-pages/physics-models/plasma_current/inductive_plasma_current.md
+++ b/documentation/proc-pages/physics-models/plasma_current/inductive_plasma_current.md
@@ -118,7 +118,7 @@ $$
 So the total resisitive and inductive flux consumption at current ramp up which is the total flux requires is given by:
 
 $$
-\overbrace{\Phi_{\text{tot,ramp}}}^{\texttt{vs_ramp_required}} =  \overbrace{\Phi_{\text{res,ramp}}}^{\texttt{vs_res_ramp}} + \overbrace{\Phi_{\text{ind,ramp}}}^{\texttt{vs_self_ind_ramp}}
+\overbrace{\Phi_{\text{tot,ramp}}}^{\texttt{vs_plasma_ramp_required}} =  \overbrace{\Phi_{\text{res,ramp}}}^{\texttt{vs_res_ramp}} + \overbrace{\Phi_{\text{ind,ramp}}}^{\texttt{vs_self_ind_ramp}}
 $$
 
 ------------------
@@ -151,7 +151,7 @@ $$
 Finally we can now find the minimum flux required for the full duration of the pulse:
 
 $$
-\overbrace{\Phi_{\text{tot}}}^{\texttt{vs_total_required}} = \overbrace{\Phi_{\text{tot,ramp}}}^{\texttt{vs_ramp_required}} + \overbrace{\Phi_{\text{res,burn}}}^{\texttt{vs_burn_required}}
+\overbrace{\Phi_{\text{tot}}}^{\texttt{vs_total_required}} = \overbrace{\Phi_{\text{tot,ramp}}}^{\texttt{vs_plasma_ramp_required}} + \overbrace{\Phi_{\text{res,burn}}}^{\texttt{vs_burn_required}}
 $$
 
 

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -2750,7 +2750,14 @@ class PFCoil:
             self.outfile,
             "Total volt-second consumption by coils (Wb)",
             "(vs_cs_pf_total_pulse)",
-            f"{pfv.vs_cs_pf_total_pulse:.2}",
+            pfv.vs_cs_pf_total_pulse,
+            "OP",
+        )
+        op.ovarre(
+            self.outfile,
+            "Total volt-second available for burn phase (Wb)",
+            "(vs_cs_pf_total_burn)",
+            pfv.vs_cs_pf_total_burn,
             "OP",
         )
 

--- a/process/physics.py
+++ b/process/physics.py
@@ -102,6 +102,7 @@ def calculate_volt_second_requirements(
                 - vs_plasma_internal: Internal plasma volt-seconds (Wb)
                 - ind_plasma_internal: Plasma inductance (H)
                 - vs_plasma_burn_required: Volt-seconds needed during flat-top (heat+burn) (Wb)
+                - vs_plasma_ramp_required: Volt-seconds needed during ramp-up (Wb)
                 - ind_plasma_total,: Internal and external plasma inductance V-s (Wb)
                 - vs_res_ramp: Resistive losses in start-up volt-seconds (Wb)
                 - vs_plasma_total_required: Total volt-seconds needed (Wb)
@@ -178,6 +179,7 @@ def calculate_volt_second_requirements(
         vs_plasma_internal,
         ind_plasma_total,
         vs_plasma_burn_required,
+        vs_ramp_required,
         vs_self_ind_ramp,
         vs_res_ramp,
         vs_plasma_total_required,
@@ -2462,6 +2464,7 @@ class Physics:
             physics_variables.vs_plasma_internal,
             physics_variables.ind_plasma,
             physics_variables.vs_plasma_burn_required,
+            physics_variables.vs_plasma_ramp_required,
             physics_variables.vs_plasma_ind_ramp,
             physics_variables.vs_plasma_res_ramp,
             physics_variables.vs_plasma_total_required,

--- a/process/physics.py
+++ b/process/physics.py
@@ -5937,24 +5937,13 @@ class Physics:
                 physics_variables.vs_plasma_total_required,
                 "OP ",
             )
+            po.oblnkl(self.outfile)
             po.ovarre(
                 self.outfile,
                 "Total plasma inductive flux consumption for plasma current ramp-up (Wb)",
                 "(vs_plasma_ind_ramp)",
                 physics_variables.vs_plasma_ind_ramp,
                 "OP ",
-            )
-            po.ovarrf(
-                self.outfile,
-                "Ejima coefficient",
-                "(ejima_coeff)",
-                physics_variables.ejima_coeff,
-            )
-            po.ovarre(
-                self.outfile,
-                "Internal plasma V-s",
-                "(vs_plasma_internal)",
-                physics_variables.vs_plasma_internal,
             )
             po.ovarre(
                 self.outfile,
@@ -5963,6 +5952,27 @@ class Physics:
                 physics_variables.vs_plasma_res_ramp,
                 "OP ",
             )
+            po.ovarre(
+                self.outfile,
+                "Total flux consumption for plasma current ramp-up (Wb)",
+                "(vs_plasma_ramp_required)",
+                physics_variables.vs_plasma_ramp_required,
+                "OP ",
+            )
+            po.ovarrf(
+                self.outfile,
+                "Ejima coefficient",
+                "(ejima_coeff)",
+                physics_variables.ejima_coeff,
+            )
+            po.oblnkl(self.outfile)
+            po.ovarre(
+                self.outfile,
+                "Internal plasma V-s",
+                "(vs_plasma_internal)",
+                physics_variables.vs_plasma_internal,
+            )
+
             po.ovarre(
                 self.outfile,
                 "Plasma volt-seconds needed for flat-top (heat + burn times) (Wb)",
@@ -5978,6 +5988,13 @@ class Physics:
                 physics_variables.v_plasma_loop_burn,
                 "OP ",
             )
+            po.ovarrf(
+                self.outfile,
+                "Coefficient for sawtooth effects on burn V-s requirement",
+                "(csawth)",
+                physics_variables.csawth,
+            )
+            po.oblnkl(self.outfile)
             po.ovarre(
                 self.outfile,
                 "Plasma resistance (ohm)",
@@ -6006,12 +6023,6 @@ class Physics:
                 "(ind_plasma_internal_norm)",
                 physics_variables.ind_plasma_internal_norm,
                 "OP ",
-            )
-            po.ovarrf(
-                self.outfile,
-                "Coefficient for sawtooth effects on burn V-s requirement",
-                "(csawth)",
-                physics_variables.csawth,
             )
 
             po.oblnkl(self.outfile)

--- a/process/physics.py
+++ b/process/physics.py
@@ -158,7 +158,7 @@ def calculate_volt_second_requirements(
     # Inductive V-s component
 
     vs_self_ind_ramp = ind_plasma_total * plasma_current
-    vs_ramp_required = vs_res_ramp + vs_self_ind_ramp
+    vs_plasma_ramp_required = vs_res_ramp + vs_self_ind_ramp
 
     # Plasma loop voltage during flat-top
     # Include enhancement factor in flattop V-s requirement
@@ -173,13 +173,13 @@ def calculate_volt_second_requirements(
     # will be correct on subsequent calls.
 
     vs_plasma_burn_required = v_burn_resistive * (t_fusion_ramp + t_burn)
-    vs_plasma_total_required = vs_ramp_required + vs_plasma_burn_required
+    vs_plasma_total_required = vs_plasma_ramp_required + vs_plasma_burn_required
 
     return (
         vs_plasma_internal,
         ind_plasma_total,
         vs_plasma_burn_required,
-        vs_ramp_required,
+        vs_plasma_ramp_required,
         vs_self_ind_ramp,
         vs_res_ramp,
         vs_plasma_total_required,

--- a/process/physics.py
+++ b/process/physics.py
@@ -8725,6 +8725,7 @@ def init_physics_variables():
     physics_variables.triang95 = 0.24
     physics_variables.vol_plasma = 0.0
     physics_variables.vs_plasma_burn_required = 0.0
+    physics_variables.vs_plasma_ramp_required = 0.0
     physics_variables.v_plasma_loop_burn = 0.0
     physics_variables.vshift = 0.0
     physics_variables.vs_plasma_ind_ramp = 0.0

--- a/process/pulse.py
+++ b/process/pulse.py
@@ -27,16 +27,16 @@ class Pulse:
         :param output: indicate whether output should be written to the output file, or not
         :type output: boolean
         """
-        self.tohswg(output=output)
+        if pulse_variables.i_pulsed_plant == 1:
+            self.tohswg(output=output)
 
-        #  Burn time calculation
+            #  Burn time calculation
 
-        times_variables.t_burn = self.calculate_burn_time(
-            i_pulsed_plant=pulse_variables.i_pulsed_plant,
-            vs_cs_pf_total_burn=pfcoil_variables.vs_cs_pf_total_burn,
-            v_plasma_loop_burn=physics_variables.v_plasma_loop_burn,
-            t_fusion_ramp=times_variables.t_fusion_ramp,
-        )
+            times_variables.t_burn = self.calculate_burn_time(
+                vs_cs_pf_total_burn=pfcoil_variables.vs_cs_pf_total_burn,
+                v_plasma_loop_burn=physics_variables.v_plasma_loop_burn,
+                t_fusion_ramp=times_variables.t_fusion_ramp,
+            )
 
     def tohswg(self, output: bool) -> None:
         """Routine to calculate the plasma current ramp-up time
@@ -150,7 +150,6 @@ class Pulse:
 
     def calculate_burn_time(
         self,
-        i_pulsed_plant: int,
         vs_cs_pf_total_burn: float,
         v_plasma_loop_burn: float,
         t_fusion_ramp: float,
@@ -163,8 +162,6 @@ class Pulse:
         plasma loop voltage during burn. It also checks for negative burn time
         and reports an error if encountered.
 
-        :param i_pulsed_plant: Indicator for pulsed plant (1 for pulsed, 0 otherwise)
-        :type i_pulsed_plant: int
         :param vs_cs_pf_total_burn: Total volt-seconds in CS and PF coils available for burn (V·s)
         :type vs_cs_pf_total_burn: float
         :param v_plasma_loop_burn: Plasma loop voltage during burn (V)
@@ -177,8 +174,6 @@ class Pulse:
         :raises: Reports error 93 if calculated burn time is negative.
 
         """
-        if i_pulsed_plant != 1:
-            return None
 
         t_burn = (abs(vs_cs_pf_total_burn) / v_plasma_loop_burn) - t_fusion_ramp
 

--- a/source/fortran/physics_variables.f90
+++ b/source/fortran/physics_variables.f90
@@ -912,6 +912,9 @@ module physics_variables
   real(dp) :: vs_plasma_burn_required
   !! V-s needed during flat-top (heat + burn times) (Wb)
 
+  real(dp) :: vs_plasma_ramp_required
+  !! V-s needed during ramp-up (Wb)
+
   real(dp) :: v_plasma_loop_burn
   !! Plasma loop voltage during flat-top (V)
 

--- a/tests/unit/test_physics.py
+++ b/tests/unit/test_physics.py
@@ -1911,6 +1911,8 @@ class VoltSecondReqParam(NamedTuple):
 
     expected_vs_plasma_burn_required: Any = None
 
+    expected_vs_plasma_ramp_required: Any = None
+
     expected_vs_plasma_ind_ramp: Any = None
 
     expected_vs_plasma_res_ramp: Any = None
@@ -1938,6 +1940,7 @@ class VoltSecondReqParam(NamedTuple):
             expected_vs_plasma_internal=111.57651734747576,
             expected_ind_plasma=1.4075705307248088e-05,
             expected_vs_plasma_burn_required=42.109179697761263,
+            expected_vs_plasma_ramp_required=314.4596753393147,
             expected_vs_plasma_ind_ramp=258.97124024420435,
             expected_vs_plasma_res_ramp=55.488435095110333,
             expected_vs_plasma_total_required=356.56885503707593,
@@ -1958,6 +1961,7 @@ class VoltSecondReqParam(NamedTuple):
             expected_vs_plasma_internal=111.57651734747576,
             expected_ind_plasma=1.4075705307248088e-05,
             expected_vs_plasma_burn_required=0.41692257126496302,
+            expected_vs_plasma_ramp_required=314.4596753393147,
             expected_vs_plasma_ind_ramp=258.97124024420435,
             expected_vs_plasma_res_ramp=55.488435095110333,
             expected_vs_plasma_total_required=314.87659791057968,
@@ -1979,6 +1983,7 @@ def test_vscalc(voltsecondreqparam):
         vs_plasma_internal,
         ind_plasma,
         vs_plasma_burn_required,
+        vs_plasma_ramp_required,
         vs_plasma_ind_ramp,
         vs_plasma_res_ramp,
         vs_plasma_total_required,
@@ -2005,6 +2010,10 @@ def test_vscalc(voltsecondreqparam):
 
     assert vs_plasma_burn_required == pytest.approx(
         voltsecondreqparam.expected_vs_plasma_burn_required
+    )
+
+    assert vs_plasma_ramp_required == pytest.approx(
+        voltsecondreqparam.expected_vs_plasma_ramp_required
     )
 
     assert vs_plasma_ind_ramp == pytest.approx(

--- a/tests/unit/test_pulse.py
+++ b/tests/unit/test_pulse.py
@@ -10,7 +10,6 @@ from process.fortran import (
     pfcoil_variables,
     physics_variables,
     pulse_variables,
-    times_variables,
 )
 from process.pulse import Pulse
 
@@ -61,36 +60,6 @@ class TohswgParam(NamedTuple):
     iprint: Any = None
 
     expected_tohsmn: Any = None
-
-
-class BurnParam(NamedTuple):
-    res_plasma: Any = None
-
-    vs_plasma_res_ramp: Any = None
-
-    vs_plasma_ind_ramp: Any = None
-
-    vs_cs_pf_total_burn: Any = None
-
-    vs_cs_pf_total_pulse: Any = None
-
-    plasma_current: Any = None
-
-    f_c_plasma_inductive: Any = None
-
-    csawth: Any = None
-
-    i_pulsed_plant: Any = None
-
-    t_burn: Any = None
-
-    t_fusion_ramp: Any = None
-
-    outfile: Any = None
-
-    iprint: Any = None
-
-    expected_tburn: Any = None
 
 
 @pytest.mark.parametrize(
@@ -1281,89 +1250,25 @@ def test_tohswg(tohswgparam, monkeypatch, pulse):
 
 
 @pytest.mark.parametrize(
-    "burnparam",
-    (
-        BurnParam(
-            res_plasma=3.2347283861249307e-09,
-            vs_plasma_res_ramp=59.392760827339345,
-            vs_plasma_ind_ramp=284.23601098215397,
-            vs_cs_pf_total_burn=0,
-            vs_cs_pf_total_pulse=-718.91787876294552,
-            plasma_current=17721306.969367817,
-            f_c_plasma_inductive=0.60433999999999999,
-            csawth=1,
-            i_pulsed_plant=1,
-            t_burn=0,
-            t_fusion_ramp=10,
-            outfile=11,
-            iprint=0,
-            expected_tburn=0,
-        ),
-        BurnParam(
-            res_plasma=3.2347283861249307e-09,
-            vs_plasma_res_ramp=59.392760827339345,
-            vs_plasma_ind_ramp=284.23601098215397,
-            vs_cs_pf_total_pulse=-718.9849676846776,
-            vs_cs_pf_total_burn=-354.76231817639609,
-            plasma_current=17721306.969367817,
-            f_c_plasma_inductive=0.60433999999999999,
-            csawth=1,
-            i_pulsed_plant=1,
-            t_burn=10234.092022756307,
-            t_fusion_ramp=10,
-            outfile=11,
-            iprint=0,
-            expected_tburn=10230.533336387545,
-        ),
-    ),
+    "i_pulsed_plant, vs_cs_pf_total_burn, v_plasma_loop_burn, t_fusion_ramp, expected",
+    [
+        (1, 100.0, 10.0, 2.0, 8.0),
+        (1, -100.0, 10.0, 2.0, 8.0),  # abs() should be used
+        (1, 50.0, 5.0, 0.0, 10.0),
+    ],
 )
-def test_burn(burnparam, monkeypatch, initialise_error_module, pulse):
-    """
-    Automatically generated Regression Unit Test for burn.
-
-    This test was generated using data from tracking/baseline_2018/baseline_2018_IN.DAT.
-
-    :param burnparam: the data used to mock and assert in this test.
-    :type burnparam: burnparam
-
-    :param monkeypatch: pytest fixture used to mock module/class variables
-    :type monkeypatch: _pytest.monkeypatch.monkeypatch
-    """
-
-    monkeypatch.setattr(physics_variables, "res_plasma", burnparam.res_plasma)
-
-    monkeypatch.setattr(
-        physics_variables, "vs_plasma_res_ramp", burnparam.vs_plasma_res_ramp
+def test_calculate_burn_time_valid(
+    i_pulsed_plant,
+    vs_cs_pf_total_burn,
+    v_plasma_loop_burn,
+    t_fusion_ramp,
+    expected,
+):
+    pulse = Pulse()
+    result = pulse.calculate_burn_time(
+        i_pulsed_plant=i_pulsed_plant,
+        vs_cs_pf_total_burn=vs_cs_pf_total_burn,
+        v_plasma_loop_burn=v_plasma_loop_burn,
+        t_fusion_ramp=t_fusion_ramp,
     )
-
-    monkeypatch.setattr(
-        physics_variables, "vs_plasma_ind_ramp", burnparam.vs_plasma_ind_ramp
-    )
-
-    monkeypatch.setattr(
-        pfcoil_variables, "vs_cs_pf_total_pulse", burnparam.vs_cs_pf_total_pulse
-    )
-
-    monkeypatch.setattr(
-        pfcoil_variables, "vs_cs_pf_total_burn", burnparam.vs_cs_pf_total_burn
-    )
-
-    monkeypatch.setattr(physics_variables, "plasma_current", burnparam.plasma_current)
-
-    monkeypatch.setattr(
-        physics_variables,
-        "f_c_plasma_inductive",
-        burnparam.f_c_plasma_inductive,
-    )
-
-    monkeypatch.setattr(physics_variables, "csawth", burnparam.csawth)
-
-    monkeypatch.setattr(pulse_variables, "i_pulsed_plant", burnparam.i_pulsed_plant)
-
-    monkeypatch.setattr(times_variables, "t_burn", burnparam.t_burn)
-
-    monkeypatch.setattr(times_variables, "t_fusion_ramp", burnparam.t_fusion_ramp)
-
-    pulse.burn(output=True)
-
-    assert times_variables.t_burn == pytest.approx(burnparam.expected_tburn)
+    assert result == expected

--- a/tests/unit/test_pulse.py
+++ b/tests/unit/test_pulse.py
@@ -1250,15 +1250,14 @@ def test_tohswg(tohswgparam, monkeypatch, pulse):
 
 
 @pytest.mark.parametrize(
-    "i_pulsed_plant, vs_cs_pf_total_burn, v_plasma_loop_burn, t_fusion_ramp, expected",
+    "vs_cs_pf_total_burn, v_plasma_loop_burn, t_fusion_ramp, expected",
     [
-        (1, 100.0, 10.0, 2.0, 8.0),
-        (1, -100.0, 10.0, 2.0, 8.0),  # abs() should be used
-        (1, 50.0, 5.0, 0.0, 10.0),
+        (100.0, 10.0, 2.0, 8.0),
+        (-100.0, 10.0, 2.0, 8.0),  # abs() should be used
+        (50.0, 5.0, 0.0, 10.0),
     ],
 )
 def test_calculate_burn_time_valid(
-    i_pulsed_plant,
     vs_cs_pf_total_burn,
     v_plasma_loop_burn,
     t_fusion_ramp,
@@ -1266,7 +1265,6 @@ def test_calculate_burn_time_valid(
 ):
     pulse = Pulse()
     result = pulse.calculate_burn_time(
-        i_pulsed_plant=i_pulsed_plant,
         vs_cs_pf_total_burn=vs_cs_pf_total_burn,
         v_plasma_loop_burn=v_plasma_loop_burn,
         t_fusion_ramp=t_fusion_ramp,


### PR DESCRIPTION
This pull request introduces several updates to the plasma current modeling documentation, Python codebase, and associated unit tests. The changes primarily focus on improving the calculation and representation of volt-second requirements during different phases of plasma operation, such as ramp-up and burn phases. Additionally, the modifications enhance code clarity and expand the test coverage to ensure correctness.

### Documentation Updates:
* [`documentation/proc-pages/physics-models/plasma_current/inductive_plasma_current.md`](diffhunk://#diff-92bb6f1500460098e81ec4869b37ac3d282249ade80c875d3f9ba6375c922e43L1-R3): Improved mathematical notation by replacing `\mathtt` with `\texttt` for better readability and consistency in equations. Added overbrace notation to clarify variable definitions. 

### Code Enhancements:
#### Volt-second Calculations:
* [`process/physics.py`](diffhunk://#diff-e21acd338af89777d2e84c823a6854ec4e80ca6fcf7ebb8fe062fbfc36d51c9cR105): Added `vs_plasma_ramp_required` to track volt-seconds needed during ramp-up. Updated functions (`calculate_volt_second_requirements`, `physics`, and `outplas`) to include this new variable and its corresponding outputs. 
* [`process/pulse.py`](diffhunk://#diff-d4b714cec22b32830e7d785f8dfe9b52fc5ac109ef3b1c8a7730f6196c85bf81L34-R37): Refactored burn time calculation into a new function `calculate_burn_time`, improving modularity and readability. Removed legacy `burn` method.

#### Additional Outputs:
* [`process/pfcoil.py`](diffhunk://#diff-bbe884bb882f206e9a2b76a6fbba4e0fa7ea241cc87524126c546cccfa7003d4L2753-R2760): Added output for total volt-seconds available for the burn phase (`vs_cs_pf_total_burn`).

#### Variable Initialization:
* [`source/fortran/physics_variables.f90`](diffhunk://#diff-29b12d64a7a449d25b857a4f5383b13952c3a6ede5b58dcc10f774645fbc519aR915-R917): Introduced `vs_plasma_ramp_required` to the `physics_variables` module for tracking ramp-up volt-seconds.

### Unit Test Updates:
* [`tests/unit/test_physics.py`](diffhunk://#diff-6a27eccc54b18fc4232f01a54529404a8203d13c1259f5126276ae5f6494c614R1914-R1915): Updated `VoltSecondReqParam` to include `expected_vs_plasma_ramp_required`. Added assertions in `test_vscalc` to verify the correctness of ramp-up volt-second calculations.
---------------

### 🐛 Bugs

The outputting of `vs_cs_pf_total_pulse` was set to only to significant figures of accuracy, this has now been removed.

❌
```python
f"{pfv.vs_cs_pf_total_pulse:.2}
```
✅
```python
f"{pfv.vs_cs_pf_total_pulse}
```

This has caused the regression in large tokamak to change appropriately as per:
`ref=-570.0, new=-569.766570590771`



## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
