### PR TITLE
Refactor TF `supercon`

### DIFF
--- a/process/superconducting_tf_coil.py
+++ b/process/superconducting_tf_coil.py
@@ -984,6 +984,9 @@ class SuperconductingTFCoil(TFCoil):
 
         # Find critical current density in the superconducter (j_crit_sc)
         # and the superconducting cable (j_crit_cable)
+
+        # =================================================================
+
         if i_tf_superconductor == 1:  # ITER Nb3Sn critical surface parameterization
             bc20m = 32.97e0
             tc0m = 16.06e0
@@ -1013,6 +1016,8 @@ class SuperconductingTFCoil(TFCoil):
                 1.0e0 - f_a_tf_turn_cable_copper
             )
 
+        # =================================================================
+
         elif (
             i_tf_superconductor == 2
         ):  # Bi-2212 high temperature superconductor parameterization
@@ -1040,6 +1045,7 @@ class SuperconductingTFCoil(TFCoil):
             # Strand critical current calulation for costing in $ / kAm
             # Copper in the strand is already accounted for
             tfcoil_variables.j_crit_str_tf = j_crit_sc
+        # =================================================================
 
         elif i_tf_superconductor == 3:  # NbTi data
             bc20m = 15.0e0
@@ -1062,6 +1068,8 @@ class SuperconductingTFCoil(TFCoil):
             tfcoil_variables.j_crit_str_tf = j_crit_sc * (
                 1.0e0 - f_a_tf_turn_cable_copper
             )
+
+        # =================================================================
 
         elif (
             i_tf_superconductor == 4
@@ -1092,6 +1100,8 @@ class SuperconductingTFCoil(TFCoil):
                 1.0e0 - f_a_tf_turn_cable_copper
             )
 
+        # =================================================================
+
         elif i_tf_superconductor == 5:  # WST Nb3Sn parameterisation
             bc20m = 32.97e0
             tc0m = 16.06e0
@@ -1121,6 +1131,8 @@ class SuperconductingTFCoil(TFCoil):
                 1.0e0 - f_a_tf_turn_cable_copper
             )
 
+        # =================================================================
+
         elif (
             i_tf_superconductor == 6
         ):  # "REBCO" 2nd generation HTS superconductor in CrCo strand
@@ -1149,6 +1161,8 @@ class SuperconductingTFCoil(TFCoil):
                 1.0e0 - f_a_tf_turn_cable_copper
             )
 
+        # =================================================================
+
         elif (
             i_tf_superconductor == 8
         ):  # Durham Ginzburg-Landau critical surface model for REBCO
@@ -1176,6 +1190,8 @@ class SuperconductingTFCoil(TFCoil):
             # Strand critical current calulation for costing in $ / kAm
             # Already includes buffer and support layers so no need to include f_a_tf_turn_cable_copper here
             tfcoil_variables.j_crit_str_tf = j_crit_sc
+
+        # =================================================================
 
         elif (
             i_tf_superconductor == 9
@@ -1226,7 +1242,7 @@ class SuperconductingTFCoil(TFCoil):
         #  Ratio of operating / critical current
         iooic = c_tf_turn / icrit
         #  Operating current density
-        jwdgop = c_tf_turn / a_tf_turn
+        j_tf_coil_turn = c_tf_turn / a_tf_turn
         #  Actual current density in superconductor, which should be equal to jcrit(temp_tf_coolant_peak_field+tmarg)
         #  when we have found the desired value of tmarg
         jsc = iooic * j_crit_sc
@@ -1250,14 +1266,14 @@ class SuperconductingTFCoil(TFCoil):
 
         #  Temperature margin (already calculated in superconductors.bi2212 for i_tf_superconductor=2)
 
-        if (
-            (i_tf_superconductor == 1)
-            or (i_tf_superconductor == 3)
-            or (i_tf_superconductor == 4)
-            or (i_tf_superconductor == 5)
-            or (i_tf_superconductor == 7)
-            or (i_tf_superconductor == 8)
-            or (i_tf_superconductor == 9)
+        if i_tf_superconductor in (
+            1,
+            3,
+            4,
+            5,
+            7,
+            8,
+            9,
         ):  # Find temperature at which current density margin = 0
             if i_tf_superconductor == 3:
                 arguments = (
@@ -1532,8 +1548,8 @@ class SuperconductingTFCoil(TFCoil):
             po.ovarre(
                 self.outfile,
                 "Actual current density in winding pack (A/m2)",
-                "(jwdgop)",
-                jwdgop,
+                "(j_tf_coil_turn)",
+                j_tf_coil_turn,
                 "OP ",
             )
 

--- a/process/superconducting_tf_coil.py
+++ b/process/superconducting_tf_coil.py
@@ -874,74 +874,83 @@ class SuperconductingTFCoil(TFCoil):
 
     def supercon(
         self,
-        a_tf_turn_cable_space,
-        a_tf_turn,
-        b_tf_inboard_peak,
-        f_a_tf_turn_cooling_extra,
-        f_a_tf_turn_cable_copper,
-        c_tf_turn,
-        j_tf_wp,
-        i_tf_superconductor,
-        f_strain_scale,
-        t_tf_quench_dump,
-        e_tf_coil_magnetic_stored,
-        thelium,
-        tmax,
-        bcritsc,
-        tcritsc,
+        a_tf_turn_cable_space: float,
+        a_tf_turn: float,
+        b_tf_inboard_peak: float,
+        f_a_tf_turn_cooling_extra: float,
+        f_a_tf_turn_cable_copper: float,
+        c_tf_turn: float,
+        j_tf_wp: float,
+        i_tf_superconductor: int,
+        f_strain_scale: float,
+        t_tf_quench_dump: float,
+        e_tf_coil_magnetic_stored: float,
+        temp_tf_coolant_peak_field: float,
+        temp_tf_conductor_peak_quench: float,
+        bcritsc: float,
+        tcritsc: float,
         output: bool,
-    ):
-        """Routine to calculate the TF superconducting conductor  properties
-        author: P J Knight, CCFE, Culham Science Centre
-        author: J Galambos, ORNL
-        author: R Kemp, CCFE, Culham Science Centre
-        author: M Kovari, CCFE, Culham Science Centre
-        author: J Miller, ORNL
-        a_tf_turn_cable_space : input real : Cable space - inside area (m2)
-        a_tf_turn : input real : Area per turn (i.e. entire jacketed conductor) (m2)
-        b_tf_inboard_peak : input real : Peak field at conductor (T)
-        f_a_tf_turn_cooling_extra : input real : Additional fraction of turn cabe space that is reserved for cooling
-        f_a_tf_turn_cable_copper : input real : Fraction of conductor that is copper
-        c_tf_turn : input real : Operating current per turn (A)
-        j_tf_wp : input real : Actual winding pack current density (A/m2)
-        i_tf_superconductor : input integer : Switch for conductor type:
-        1 = ITER Nb3Sn, standard parameters,
-        2 = Bi-2212 High Temperature Superconductor,
-        3 = NbTi,
-        4 = ITER Nb3Sn, user-defined parameters
-        5 = WST Nb3Sn parameterisation
-        7 = Durham Ginzburg-Landau Nb-Ti parameterisation
-        8 = Durham Ginzburg-Landau critical surface model for REBCO
-        9 = Hazelton experimental data + Zhai conceptual model for REBCO
-        f_strain_scale    : input real : Adjustment factor (<= 1) to account for strain,
-        radiation damage, fatigue or AC losses
-        t_tf_quench_dump : input real : Dump time (sec)
-        e_tf_coil_magnetic_stored : input real : Energy stored in one TF coil (J)
-        thelium : input real : He temperature at peak field point (K)
-        tmax : input real : Max conductor temperature during quench (K)
-        bcritsc : input real : Critical field at zero temperature and strain (T) (i_tf_superconductor=4 only)
-        tcritsc : input real : Critical temperature at zero field and strain (K) (i_tf_superconductor=4 only)
-        iprint : input integer : Switch for printing (1 = yes, 0 = no)
-        outfile : input integer : Fortran output unit identifier
-        jwdgpro : output real : Winding pack current density from temperature
-        rise protection (A/m2)
-        j_tf_wp_critical : output real : Critical winding pack current density (A/m2)
-        vd : output real : Discharge voltage imposed on a TF coil (V)
-        tmarg : output real : Temperature margin (K)
-        This routine calculates the superconductor properties for the TF coils.
-        It was originally programmed by J. Galambos 1991, from algorithms provided
-        by J. Miller.
-        <P>The routine calculates the critical current density (winding pack)
-        and also the protection information (for a quench).
-        NOT used for the Croco conductor
+    ) -> tuple[float, float, float]:
+        """
+        Calculates the properties of the TF superconducting conductor.
 
-        N.B. critical current density for a super conductor (j_crit_sc)
-        is for the superconducting strands/tape, not including copper.
-        Critical current density for a cable (j_crit_cable) acounts for
-        both the fraction of the cable taken up by helium coolant channels,
-        and the cable conductor copper fraction - i.e., the copper in the
-        superconducting strands AND any addtional copper, such as REBCO
-        tape support.
+        :param float a_tf_turn_cable_space:
+            Cable space - inside area (m²).
+        :param float a_tf_turn:
+            Area per turn (i.e. entire jacketed conductor) (m²).
+        :param float b_tf_inboard_peak:
+            Peak field at conductor (T).
+        :param float f_a_tf_turn_cooling_extra:
+            Additional fraction of turn cable space reserved for cooling.
+        :param float f_a_tf_turn_cable_copper:
+            Fraction of conductor that is copper.
+        :param float c_tf_turn:
+            Operating current per turn (A).
+        :param float j_tf_wp:
+            Actual winding pack current density (A/m²).
+        :param int i_tf_superconductor:
+            Switch for conductor type:
+            - 1: ITER Nb3Sn, standard parameters
+            - 2: Bi-2212 High Temperature Superconductor
+            - 3: NbTi
+            - 4: ITER Nb3Sn, user-defined parameters
+            - 5: WST Nb3Sn parameterisation
+            - 7: Durham Ginzburg-Landau Nb-Ti parameterisation
+            - 8: Durham Ginzburg-Landau critical surface model for REBCO
+            - 9: Hazelton experimental data + Zhai conceptual model for REBCO
+        :param float f_strain_scale:
+            Adjustment factor (<= 1) to account for strain, radiation damage, fatigue or AC losses.
+        :param float t_tf_quench_dump:
+            Dump time (s).
+        :param float e_tf_coil_magnetic_stored:
+            Energy stored in one TF coil (J).
+        :param float temp_tf_coolant_peak_field:
+            He temperature at peak field point (K).
+        :param float temp_tf_conductor_peak_quench:
+            Max conductor temperature during quench (K).
+        :param float bcritsc:
+            Critical field at zero temperature and strain (T) (used only if i_tf_superconductor=4).
+        :param float tcritsc:
+            Critical temperature at zero field and strain (K) (used only if i_tf_superconductor=4).
+        :param bool output:
+            Switch for printing output.
+
+        :returns: tuple (j_tf_wp_critical, vd, tmarg)
+            - j_tf_wp_critical (float): Critical winding pack current density (A/m²).
+            - vd (float): Discharge voltage imposed on a TF coil (V).
+            - tmarg (float): Temperature margin (K).
+
+        :notes:
+            This routine calculates the superconductor properties for the TF coils.
+            It was originally programmed by J. Galambos (1991), from algorithms provided by J. Miller.
+            The routine calculates the critical current density (winding pack) and also the protection
+            information (for a quench). Not used for the CroCo conductor.
+
+            The critical current density for a superconductor (``j_crit_sc``) is for the superconducting
+            strands/tape, not including copper. The critical current density for a cable (``j_crit_cable``)
+            accounts for both the fraction of the cable taken up by helium coolant channels, and the cable
+            conductor copper fraction (i.e., the copper in the superconducting strands and any additional
+            copper, such as REBCO tape support).
         """
         tdump = t_tf_quench_dump
 
@@ -987,7 +996,7 @@ class SuperconductingTFCoil(TFCoil):
             #  j_crit_sc returned by superconductors.itersc is the critical current density in the
             #  superconductor - not the whole strand, which contains copper
             j_crit_sc, _, _ = superconductors.itersc(
-                thelium, b_tf_inboard_peak, strain, bc20m, tc0m
+                temp_tf_coolant_peak_field, b_tf_inboard_peak, strain, bc20m, tc0m
             )
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = (
@@ -1020,7 +1029,7 @@ class SuperconductingTFCoil(TFCoil):
             )
 
             j_crit_cable, tmarg = superconductors.bi2212(
-                b_tf_inboard_peak, jstrand, thelium, f_strain_scale
+                b_tf_inboard_peak, jstrand, temp_tf_coolant_peak_field, f_strain_scale
             )
             j_crit_sc = j_crit_cable / (1.0e0 - f_a_tf_turn_cable_copper)
             #  Critical current in cable
@@ -1037,7 +1046,7 @@ class SuperconductingTFCoil(TFCoil):
             tc0m = 9.3e0
             c0 = 1.0e10
             j_crit_sc, _ = superconductors.jcrit_nbti(
-                thelium, b_tf_inboard_peak, c0, bc20m, tc0m
+                temp_tf_coolant_peak_field, b_tf_inboard_peak, c0, bc20m, tc0m
             )
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = (
@@ -1066,7 +1075,7 @@ class SuperconductingTFCoil(TFCoil):
                 strain = np.sign(strain) * 0.5e-2
 
             j_crit_sc, _, _ = superconductors.itersc(
-                thelium, b_tf_inboard_peak, strain, bc20m, tc0m
+                temp_tf_coolant_peak_field, b_tf_inboard_peak, strain, bc20m, tc0m
             )
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = (
@@ -1095,7 +1104,7 @@ class SuperconductingTFCoil(TFCoil):
             #  j_crit_sc returned by superconductors.itersc is the critical current density in the
             #  superconductor - not the whole strand, which contains copper
             j_crit_sc, _, _ = superconductors.western_superconducting_nb3sn(
-                thelium, b_tf_inboard_peak, strain, bc20m, tc0m
+                temp_tf_coolant_peak_field, b_tf_inboard_peak, strain, bc20m, tc0m
             )
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = (
@@ -1123,7 +1132,7 @@ class SuperconductingTFCoil(TFCoil):
             bc20m = tfcoil_variables.b_crit_upper_nbti
             tc0m = tfcoil_variables.t_crit_nbti
             j_crit_sc, _, _ = superconductors.gl_nbti(
-                thelium, b_tf_inboard_peak, strain, bc20m, tc0m
+                temp_tf_coolant_peak_field, b_tf_inboard_peak, strain, bc20m, tc0m
             )
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = (
@@ -1152,7 +1161,7 @@ class SuperconductingTFCoil(TFCoil):
                 strain = np.sign(strain) * 0.7e-2
 
             j_crit_sc, _, _ = superconductors.gl_rebco(
-                thelium, b_tf_inboard_peak, strain, bc20m, tc0m
+                temp_tf_coolant_peak_field, b_tf_inboard_peak, strain, bc20m, tc0m
             )
             # A0 calculated for tape cross section already
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
@@ -1183,7 +1192,7 @@ class SuperconductingTFCoil(TFCoil):
             #  and based on Hazelton experimental data and Zhai conceptual model;
             #  see subroutine for full references
             j_crit_sc, _, _ = superconductors.hijc_rebco(
-                thelium,
+                temp_tf_coolant_peak_field,
                 b_tf_inboard_peak,
                 bc20m,
                 tc0m,
@@ -1218,7 +1227,7 @@ class SuperconductingTFCoil(TFCoil):
         iooic = c_tf_turn / icrit
         #  Operating current density
         jwdgop = c_tf_turn / a_tf_turn
-        #  Actual current density in superconductor, which should be equal to jcrit(thelium+tmarg)
+        #  Actual current density in superconductor, which should be equal to jcrit(temp_tf_coolant_peak_field+tmarg)
         #  when we have found the desired value of tmarg
         jsc = iooic * j_crit_sc
 
@@ -1270,10 +1279,10 @@ class SuperconductingTFCoil(TFCoil):
                     tc0m,
                 )
 
-            another_estimate = 2 * thelium
+            another_estimate = 2 * temp_tf_coolant_peak_field
             t_zero_margin, root_result = optimize.newton(
                 superconductors.current_density_margin,
-                thelium,
+                temp_tf_coolant_peak_field,
                 fprime=None,
                 args=arguments,
                 # args=(i_tf_superconductor, jsc, b_tf_inboard_peak, strain, bc20m, tc0m,),
@@ -1286,7 +1295,7 @@ class SuperconductingTFCoil(TFCoil):
                 disp=True,
             )
             # print(root_result)  # Diagnostic for newton method
-            tmarg = t_zero_margin - thelium
+            tmarg = t_zero_margin - temp_tf_coolant_peak_field
             tfcoil_variables.temp_margin = tmarg
 
         #  Find the current density limited by the protection limit
@@ -1301,8 +1310,8 @@ class SuperconductingTFCoil(TFCoil):
             tdump,
             f_a_tf_turn_cable_space_conductor,
             f_a_tf_turn_cable_copper,
-            thelium,
-            tmax,
+            temp_tf_coolant_peak_field,
+            temp_tf_conductor_peak_quench,
         )
 
         if output:  # Output --------------------------
@@ -1471,8 +1480,8 @@ class SuperconductingTFCoil(TFCoil):
             po.ovarre(
                 self.outfile,
                 "Helium temperature at peak field (= superconductor temperature) (K)",
-                "(thelium)",
-                thelium,
+                "(temp_tf_coolant_peak_field)",
+                temp_tf_coolant_peak_field,
             )
             po.ovarre(
                 self.outfile,

--- a/process/superconducting_tf_coil.py
+++ b/process/superconducting_tf_coil.py
@@ -348,7 +348,7 @@ class SuperconductingTFCoil(TFCoil):
 
         tfes = sctfcoil_module.e_tf_magnetic_stored_total / tfcoil_variables.n_tf_coils
         # Cross-sectional area per turn
-        aturn = tfcoil_variables.c_tf_total / (
+        a_tf_turn = tfcoil_variables.c_tf_total / (
             tfcoil_variables.j_tf_wp
             * tfcoil_variables.n_tf_coils
             * tfcoil_variables.n_tf_coil_turns
@@ -357,7 +357,7 @@ class SuperconductingTFCoil(TFCoil):
         if tfcoil_variables.i_tf_sc_mat == 6:
             (tfcoil_variables.j_tf_wp_critical, tfcoil_variables.tmargtf) = (
                 self.supercon_croco(
-                    aturn,
+                    a_tf_turn,
                     tfcoil_variables.bmaxtfrp,
                     tfcoil_variables.c_tf_turn,
                     tfcoil_variables.tftmp,
@@ -376,7 +376,7 @@ class SuperconductingTFCoil(TFCoil):
                 tfcoil_variables.tmargtf,
             ) = self.supercon(
                 tfcoil_variables.a_tf_turn_cable_space_no_void,
-                aturn,
+                a_tf_turn,
                 tfcoil_variables.bmaxtfrp,
                 tfcoil_variables.f_a_tf_turn_cable_space_extra_void,
                 tfcoil_variables.fcutfsu,
@@ -426,7 +426,7 @@ class SuperconductingTFCoil(TFCoil):
 
         return croco_voltage
 
-    def supercon_croco(self, aturn, bmax, iop, thelium, output: bool):
+    def supercon_croco(self, a_tf_turn, bmax, iop, thelium, output: bool):
         """TF superconducting CroCo conductor using REBCO tape
         author: M Kovari, CCFE, Culham Science Centre
         bmax : input real : Peak field at conductor (T)
@@ -495,12 +495,12 @@ class SuperconductingTFCoil(TFCoil):
         )
 
         # Critical current density in winding pack
-        # aturn : Area per turn (i.e. entire jacketed conductor with insulation) (m2)
-        j_tf_wp_critical = icrit / aturn
+        # a_tf_turn : Area per turn (i.e. entire jacketed conductor with insulation) (m2)
+        j_tf_wp_critical = icrit / a_tf_turn
         #  Ratio of operating / critical current
         iooic = iop / icrit
         #  Operating current density
-        jwdgop = iop / aturn
+        jwdgop = iop / a_tf_turn
         #  Actual current density in superconductor,
         # which should be equal to jcrit(thelium+tmarg)
 
@@ -872,8 +872,8 @@ class SuperconductingTFCoil(TFCoil):
 
     def supercon(
         self,
-        acs,
-        aturn,
+        a_tf_turn_cable_space,
+        a_tf_turn,
         bmax,
         fhe,
         fcu,
@@ -895,8 +895,8 @@ class SuperconductingTFCoil(TFCoil):
         author: R Kemp, CCFE, Culham Science Centre
         author: M Kovari, CCFE, Culham Science Centre
         author: J Miller, ORNL
-        acs : input real : Cable space - inside area (m2)
-        aturn : input real : Area per turn (i.e. entire jacketed conductor) (m2)
+        a_tf_turn_cable_space : input real : Cable space - inside area (m2)
+        a_tf_turn : input real : Area per turn (i.e. entire jacketed conductor) (m2)
         bmax : input real : Peak field at conductor (T)
         fhe : input real : Fraction of cable space that is for He cooling
         fcu : input real : Fraction of conductor that is copper
@@ -949,7 +949,7 @@ class SuperconductingTFCoil(TFCoil):
             + (np.pi / 4.0e0)
             * tfcoil_variables.dia_tf_turn_coolant_channel
             * tfcoil_variables.dia_tf_turn_coolant_channel
-            / acs
+            / a_tf_turn_cable_space
         )
 
         # Guard against negative conductor fraction fcond
@@ -983,7 +983,7 @@ class SuperconductingTFCoil(TFCoil):
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable
-            icrit = j_crit_cable * acs
+            icrit = j_crit_cable * a_tf_turn_cable_space
 
             # Strand critical current calculation for costing in $/kAm
             # = Superconducting filaments jc * (1 - strand copper fraction)
@@ -996,12 +996,12 @@ class SuperconductingTFCoil(TFCoil):
             #  The parameterization for j_crit_cable assumes a particular strand
             #  composition that does not require a user-defined copper fraction,
             #  so this is irrelevant in this model
-            jstrand = jwp * aturn / (acs * fcond)
+            jstrand = jwp * a_tf_turn / (a_tf_turn_cable_space * fcond)
 
             j_crit_cable, tmarg = superconductors.bi2212(bmax, jstrand, thelium, fhts)
             j_crit_sc = j_crit_cable / (1.0e0 - fcu)
             #  Critical current in cable
-            icrit = j_crit_cable * acs * fcond
+            icrit = j_crit_cable * a_tf_turn_cable_space * fcond
 
             # Strand critical current calulation for costing in $ / kAm
             # Copper in the strand is already accounted for
@@ -1015,7 +1015,7 @@ class SuperconductingTFCoil(TFCoil):
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable
-            icrit = j_crit_cable * acs
+            icrit = j_crit_cable * a_tf_turn_cable_space
 
             # Strand critical current calulation for costing in $ / kAm
             # = superconducting filaments jc * (1 -strand copper fraction)
@@ -1034,7 +1034,7 @@ class SuperconductingTFCoil(TFCoil):
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable
-            icrit = j_crit_cable * acs
+            icrit = j_crit_cable * a_tf_turn_cable_space
 
             # Strand critical current calulation for costing in $ / kAm
             # = superconducting filaments jc * (1 -strand copper fraction)
@@ -1057,7 +1057,7 @@ class SuperconductingTFCoil(TFCoil):
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable
-            icrit = j_crit_cable * acs
+            icrit = j_crit_cable * a_tf_turn_cable_space
 
             # Strand critical current calulation for costing in $ / kAm
             # = superconducting filaments jc * (1 -strand copper fraction)
@@ -1077,7 +1077,7 @@ class SuperconductingTFCoil(TFCoil):
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable
-            icrit = j_crit_cable * acs
+            icrit = j_crit_cable * a_tf_turn_cable_space
 
             # Strand critical current calulation for costing in $ / kAm
             # = superconducting filaments jc * (1 -strand copper fraction)
@@ -1099,7 +1099,7 @@ class SuperconductingTFCoil(TFCoil):
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable (copper added at this stage in HTS cables)
-            icrit = j_crit_cable * acs
+            icrit = j_crit_cable * a_tf_turn_cable_space
 
             # Strand critical current calulation for costing in $ / kAm
             # Already includes buffer and support layers so no need to include fcu here
@@ -1131,7 +1131,7 @@ class SuperconductingTFCoil(TFCoil):
             # j_crit_cable = j_crit_sc * non-copper fraction of conductor * conductor fraction of cable
             j_crit_cable = j_crit_sc * (1.0e0 - fcu) * fcond
             #  Critical current in cable (copper added at this stage in HTS cables)
-            icrit = j_crit_cable * acs
+            icrit = j_crit_cable * a_tf_turn_cable_space
 
             # Strand critical current calulation for costing in $ / kAm
             # = superconducting filaments jc * (1 -strand copper fraction)
@@ -1141,12 +1141,12 @@ class SuperconductingTFCoil(TFCoil):
             raise ProcessValueError("Illegal value for i_tf_sc_mat", isumat=isumat)
 
         # Critical current density in winding pack
-        # aturn : Area per turn (i.e. entire jacketed conductor with insulation) (m2)
-        j_tf_wp_critical = icrit / aturn
+        # a_tf_turn : Area per turn (i.e. entire jacketed conductor with insulation) (m2)
+        j_tf_wp_critical = icrit / a_tf_turn
         #  Ratio of operating / critical current
         iooic = iop / icrit
         #  Operating current density
-        jwdgop = iop / aturn
+        jwdgop = iop / a_tf_turn
         #  Actual current density in superconductor, which should be equal to jcrit(thelium+tmarg)
         #  when we have found the desired value of tmarg
         jsc = iooic * j_crit_sc
@@ -1157,7 +1157,7 @@ class SuperconductingTFCoil(TFCoil):
             jsc: {jsc}
             iooic: {iooic}
             j_crit_sc: {j_crit_sc}
-            Check conductor dimensions. Cable space area acs likely gone negative. acs: {acs}
+            Check conductor dimensions. Cable space area a_tf_turn_cable_space likely gone negative. a_tf_turn_cable_space: {a_tf_turn_cable_space}
             This is likely because dr_tf_turn_cable_space or dx_tf_turn_cable_space has gone negative:
             dr_tf_turn_cable_space: {sctfcoil_module.dr_tf_turn_cable_space}
             dx_tf_turn_cable_space: {sctfcoil_module.dx_tf_turn_cable_space}
@@ -1208,7 +1208,7 @@ class SuperconductingTFCoil(TFCoil):
         #  to presence of fcu argument, which is not used for this model above)
 
         tfcoil_variables.jwdgpro, vd = self.protect(
-            iop, tfes, acs, aturn, tdump, fcond, fcu, thelium, tmax
+            iop, tfes, a_tf_turn_cable_space, a_tf_turn, tdump, fcond, fcu, thelium, tmax
         )
 
         if output:  # Output --------------------------

--- a/tests/unit/test_sctfcoil.py
+++ b/tests/unit/test_sctfcoil.py
@@ -146,8 +146,6 @@ class SuperconParam(NamedTuple):
 
     f_strain_scale: Any = None
 
-    c_tf_turn: Any = None
-
     j_tf_wp: Any = None
 
     t_tf_quench_dump: Any = None

--- a/tests/unit/test_sctfcoil.py
+++ b/tests/unit/test_sctfcoil.py
@@ -128,35 +128,35 @@ class SuperconParam(NamedTuple):
 
     run_tests: Any = None
 
-    isumat: Any = None
+    i_tf_superconductor: Any = None
 
     iprint: Any = None
 
     outfile: Any = None
 
-    acs: Any = None
+    a_tf_turn_cable_space: Any = None
 
-    aturn: Any = None
+    a_tf_turn: Any = None
 
-    bmax: Any = None
+    b_tf_inboard_peak: Any = None
 
-    fcu: Any = None
+    f_a_tf_turn_cable_copper: Any = None
 
-    fhe: Any = None
+    f_a_tf_turn_cooling_extra: Any = None
 
-    fhts: Any = None
+    f_strain_scale: Any = None
 
-    iop: Any = None
+    c_tf_turn: Any = None
 
-    jwp: Any = None
+    j_tf_wp: Any = None
 
-    tdmptf: Any = None
+    t_tf_quench_dump: Any = None
 
-    tfes: Any = None
+    e_tf_coil_magnetic_stored: Any = None
 
-    thelium: Any = None
+    temp_tf_coolant_peak_field: Any = None
 
-    tmax: Any = None
+    temp_tf_conductor_peak_quench: Any = None
 
     bcritsc: Any = None
 
@@ -193,21 +193,20 @@ class SuperconParam(NamedTuple):
             tf_fit_z=0.3149613642807837,
             tf_fit_y=1.0658869305062604,
             run_tests=0,
-            isumat=5,
+            i_tf_superconductor=5,
             iprint=0,
             outfile=11,
-            acs=0.001293323051622732,
-            aturn=0.0032012300777680192,
-            bmax=12.48976756562082,
-            fcu=0.80884,
-            fhe=0.30000000000000004,
-            fhts=0.5,
-            iop=74026.751437500003,
-            jwp=23124470.793774806,
-            tdmptf=25.829000000000001,
-            tfes=9548964780.4287167,
-            thelium=4.75,
-            tmax=150,
+            a_tf_turn_cable_space=0.001293323051622732,
+            a_tf_turn=0.0032012300777680192,
+            b_tf_inboard_peak=12.48976756562082,
+            f_a_tf_turn_cable_copper=0.80884,
+            f_a_tf_turn_cooling_extra=0.30000000000000004,
+            f_strain_scale=0.5,
+            j_tf_wp=23124470.793774806,
+            t_tf_quench_dump=25.829000000000001,
+            e_tf_coil_magnetic_stored=9548964780.4287167,
+            temp_tf_coolant_peak_field=4.75,
+            temp_tf_conductor_peak_quench=150,
             bcritsc=24,
             tcritsc=16,
             expected_temp_margin=2.34312129,
@@ -233,21 +232,20 @@ class SuperconParam(NamedTuple):
             tf_fit_z=0.3149613642807837,
             tf_fit_y=1.0658869305062604,
             run_tests=0,
-            isumat=5,
+            i_tf_superconductor=5,
             iprint=0,
             outfile=11,
-            acs=0.001293323051622732,
-            aturn=0.0032012300777680192,
-            bmax=12.48976756562082,
-            fcu=0.80884,
-            fhe=0.30000000000000004,
-            fhts=0.5,
-            iop=74026.751437500003,
-            jwp=23124470.793774806,
-            tdmptf=25.829000000000001,
-            tfes=9561415368.8360519,
-            thelium=4.75,
-            tmax=150,
+            a_tf_turn_cable_space=0.001293323051622732,
+            a_tf_turn=0.0032012300777680192,
+            b_tf_inboard_peak=12.48976756562082,
+            f_a_tf_turn_cable_copper=0.80884,
+            f_a_tf_turn_cooling_extra=0.30000000000000004,
+            f_strain_scale=0.5,
+            j_tf_wp=23124470.793774806,
+            t_tf_quench_dump=25.829000000000001,
+            e_tf_coil_magnetic_stored=9561415368.8360519,
+            temp_tf_coolant_peak_field=4.75,
+            temp_tf_conductor_peak_quench=150,
             bcritsc=24,
             tcritsc=16,
             expected_temp_margin=2.34312129,
@@ -273,21 +271,20 @@ class SuperconParam(NamedTuple):
             tf_fit_z=0.3149613642807837,
             tf_fit_y=1.0658869305062604,
             run_tests=0,
-            isumat=5,
+            i_tf_superconductor=5,
             iprint=0,
             outfile=11,
-            acs=0.001293323051622732,
-            aturn=0.0032012300777680192,
-            bmax=12.48976756562082,
-            fcu=0.80884,
-            fhe=0.30000000000000004,
-            fhts=0.5,
-            iop=74026.751437500003,
-            jwp=23124470.793774806,
-            tdmptf=25.829000000000001,
-            tfes=9561415368.8360519,
-            thelium=4.75,
-            tmax=150,
+            a_tf_turn_cable_space=0.001293323051622732,
+            a_tf_turn=0.0032012300777680192,
+            b_tf_inboard_peak=12.48976756562082,
+            f_a_tf_turn_cable_copper=0.80884,
+            f_a_tf_turn_cooling_extra=0.30000000000000004,
+            f_strain_scale=0.5,
+            j_tf_wp=23124470.793774806,
+            t_tf_quench_dump=25.829000000000001,
+            e_tf_coil_magnetic_stored=9561415368.8360519,
+            temp_tf_coolant_peak_field=4.75,
+            temp_tf_conductor_peak_quench=150,
             bcritsc=24,
             tcritsc=16,
             expected_temp_margin=2.34312129,
@@ -355,19 +352,19 @@ def test_supercon(superconparam, monkeypatch, sctfcoil):
     monkeypatch.setattr(global_variables, "run_tests", superconparam.run_tests)
 
     j_tf_wp_critical, vd, tmarg = sctfcoil.supercon(
-        isumat=superconparam.isumat,
-        acs=superconparam.acs,
-        aturn=superconparam.aturn,
-        bmax=superconparam.bmax,
-        fcu=superconparam.fcu,
-        fhe=superconparam.fhe,
-        fhts=superconparam.fhts,
-        iop=superconparam.iop,
-        jwp=superconparam.jwp,
-        tdmptf=superconparam.tdmptf,
-        tfes=superconparam.tfes,
-        thelium=superconparam.thelium,
-        tmax=superconparam.tmax,
+        i_tf_superconductor=superconparam.i_tf_superconductor,
+        a_tf_turn_cable_space=superconparam.a_tf_turn_cable_space,
+        a_tf_turn=superconparam.a_tf_turn,
+        b_tf_inboard_peak=superconparam.b_tf_inboard_peak,
+        f_a_tf_turn_cable_copper=superconparam.f_a_tf_turn_cable_copper,
+        f_a_tf_turn_cooling_extra=superconparam.f_a_tf_turn_cooling_extra,
+        f_strain_scale=superconparam.f_strain_scale,
+        c_tf_turn=superconparam.c_tf_turn,
+        j_tf_wp=superconparam.j_tf_wp,
+        t_tf_quench_dump=superconparam.t_tf_quench_dump,
+        e_tf_coil_magnetic_stored=superconparam.e_tf_coil_magnetic_stored,
+        temp_tf_coolant_peak_field=superconparam.temp_tf_coolant_peak_field,
+        temp_tf_conductor_peak_quench=superconparam.temp_tf_conductor_peak_quench,
         bcritsc=superconparam.bcritsc,
         tcritsc=superconparam.tcritsc,
         output=False,


### PR DESCRIPTION
This pull request refactors the `SuperconParam` class and updates its usage in test cases within the `tests/unit/test_sctfcoil.py` file. The changes focus on renaming variables to improve clarity and consistency, ensuring the codebase aligns with domain-specific terminology.

### Refactoring for clarity and consistency:

* [`tests/unit/test_sctfcoil.py`](diffhunk://#diff-0889e65586cbf2b32d8ec0779e85743c7d5a987c35a6d2eef703c9b8d2c244c9L131-R157): Renamed multiple attributes in the `SuperconParam` class to use more descriptive and domain-specific names, such as changing `isumat` to `i_tf_superconductor` and `acs` to `a_tf_turn_cable_space`. This improves readability and aligns the code with the terminology used in superconducting coil design.

### Updates to test cases:

* [`tests/unit/test_sctfcoil.py`](diffhunk://#diff-0889e65586cbf2b32d8ec0779e85743c7d5a987c35a6d2eef703c9b8d2c244c9L196-R207): Updated initialization of `SuperconParam` instances in test cases to reflect the new attribute names. For example, `isumat=5` was changed to `i_tf_superconductor=5`. [[1]](diffhunk://#diff-0889e65586cbf2b32d8ec0779e85743c7d5a987c35a6d2eef703c9b8d2c244c9L196-R207) [[2]](diffhunk://#diff-0889e65586cbf2b32d8ec0779e85743c7d5a987c35a6d2eef703c9b8d2c244c9L236-R246) [[3]](diffhunk://#diff-0889e65586cbf2b32d8ec0779e85743c7d5a987c35a6d2eef703c9b8d2c244c9L276-R285)
* [`tests/unit/test_sctfcoil.py`](diffhunk://#diff-0889e65586cbf2b32d8ec0779e85743c7d5a987c35a6d2eef703c9b8d2c244c9L358-R365): Modified the `test_supercon` function to pass renamed attributes from `SuperconParam` to the `sctfcoil.supercon` method, ensuring compatibility with the updated class definition.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
