### PR TITLE
Update `portsz()`

### DIFF
--- a/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/culham_nb.md
+++ b/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/culham_nb.md
@@ -16,20 +16,20 @@ from that of ITER (approx. 2.8).
 | $\mathtt{fshine}$   | Shine-through fraction of the beam |
 
 $$
-\mathtt{frbeam} = \frac{R_{\text{tan}}}{R_0}
+\mathtt{f_radius_beam_tangency_rmajor} = \frac{R_{\text{tan}}}{R_0}
 $$
 
 Where $R_{\text{tan}}$ is major radius at which the centre-line of the beam is tangential to the toroidal direction. This can be user defined
 
 $$
-\left(1+ \frac{1}{A}\right) < \mathtt{frbeam}
+\left(1+ \frac{1}{A}\right) < \mathtt{f_radius_beam_tangency_rmajor}
 $$
 
 A quick sanity check is done to make sure no negative roots are formed when calculating $\mathtt{dpath}$ this prevents setups where the NBI beam would miss the plasma
 
 
 $$
-\mathtt{dpath} = R_0 \sqrt{\left(1+\frac{1}{A}\right)^2-\mathtt{frbeam}^2}
+\mathtt{dpath} = R_0 \sqrt{\left(1+\frac{1}{A}\right)^2-\mathtt{f_radius_beam_tangency_rmajor}^2}
 $$
 
 Beams topping cross section is calculated via $\mathtt{sigbeam}$ found [here](../NBI/nbi_overview.md/#beam-stopping-cross-section-sigbeam). This produces $\mathtt{sigstop}$
@@ -73,7 +73,7 @@ plus correction terms outlined in Culham Report AEA FUS 172.
 |  $\mathtt{dene}$, $n_{\text{e}}$     |    volume averaged electron density $(\text{m}^{-3})$                           |
 |  $\mathtt{dnla}$, $n_{\text{e,0}}$      |    line averaged electron density $(\text{m}^{-3})$                           |
 |  $\mathtt{e_beam_kev}$      |  neutral beam energy $(\text{keV})$                             |
-|  $\mathtt{frbeam}$      |   R_tangent / R_major for neutral beam injection                            |
+|  $\mathtt{f_radius_beam_tangency_rmajor}$      |   R_tangent / R_major for neutral beam injection                            |
 |  $\mathtt{fshine}$      |  shine-through fraction of beam                             |
 |  $\mathtt{rmajor}$, $R$      |  plasma major radius $(\text{m})$                              |
 |  $\mathtt{rminor}$, $a$      |  plasma minor radius $(\text{m})$                             |
@@ -169,7 +169,7 @@ $$
 Distance along beam to plasma centre
 
 $$
-\mathtt{r} = \text{max}(R, R \times \mathtt{frbeam})
+\mathtt{r} = \text{max}(R, R \times \mathtt{f_radius_beam_tangency_rmajor})
 $$
 
 $$
@@ -178,7 +178,7 @@ $$
 
 
 $$
-\mathtt{d} = R \times \sqrt{((1.0 + \mathtt{eps1})^2 - \mathtt{frbeam}^2)}
+\mathtt{d} = R \times \sqrt{((1.0 + \mathtt{eps1})^2 - \mathtt{f_radius_beam_tangency_rmajor}^2)}
 $$
 
 Distance along beam to plasma centre for ITER
@@ -213,7 +213,7 @@ $$
 Normalised current drive efficiency ($\text{A/W} \text{m}^{2}$) (IPDG89)
 
 $$
-\mathtt{gamnb} = 5.0 \times \mathtt{abd} \times 0.1 \times \mathtt{ten} \times (1.0 - \mathtt{fshine}) \times \mathtt{frbeam} \times \frac{\mathtt{j0}}{0.2} \times \mathtt{ffac}
+\mathtt{gamnb} = 5.0 \times \mathtt{abd} \times 0.1 \times \mathtt{ten} \times (1.0 - \mathtt{fshine}) \times \mathtt{f_radius_beam_tangency_rmajor} \times \frac{\mathtt{j0}}{0.2} \times \mathtt{ffac}
 $$
 
 Current drive efficiency (A/W)

--- a/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/iter_nb.md
+++ b/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/iter_nb.md
@@ -19,7 +19,7 @@ $$
 The beam path length to centre is calculated:
 
 $$
-\underbrace{\mathtt{dpath}}_{\text{Path length to centre}} = R_0 \sqrt{\left(\left(1+\frac{1}{A}\right)^2-\mathtt{frbeam}^2\right)}
+\underbrace{\mathtt{dpath}}_{\text{Path length to centre}} = R_0 \sqrt{\left(\left(1+\frac{1}{A}\right)^2-\mathtt{f_radius_beam_tangency_rmajor}^2\right)}
 $$
 
 

--- a/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
+++ b/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
@@ -3,14 +3,75 @@
 !!! Warning "NBI Models" 
     At present, the neutral beam models do not include the effect of an edge transport barrier (pedestal) in the plasma profile.
 
-## Neutral beam access
+## Neutral beam access | `calculate_beam_port_size()`
 
-If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `radius_beam_tangency` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `f_radius_beam_tangency_rmajor`, which is the ratio of `radius_beam_tangency` to the plasma major radius `rmajor`. The maximum possible tangency radius `radius_beam_tangency_max` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using constraint equation no. 20 with iteration variable no. 33 (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
+If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `radius_beam_tangency` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `f_radius_beam_tangency_rmajor`, which is the ratio of `radius_beam_tangency` to the plasma major radius `rmajor`.
+
+The maximum possible tangency radius `radius_beam_tangency_max` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using `icc = 20` with `ixc = 33` (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
+
 
 <figure markdown>
 ![NBI Port Size](../images/portsize.png){ width = "300"}
 <figcaption>Figure 1: Top-down schematic of the neutral beam access geometry. The beam with the maximum possible tangency radius is shown here.</figcaption>
 </figure>
+
+$$
+\Omega = \frac{2\pi}{\underbrace{N_{\text{TF,coils}}}_{\texttt{n_tf_coils}}}
+$$
+
+$$
+a = 0.5 \times \overbrace{\mathrm{d}x_{\text{TF,inboard-out}}}^{\texttt{dx_tf_inboard_out_toroidal}}
+$$
+
+$$
+b = \overbrace{\mathrm{d}R_{\text{TF,outboard}}}^{\texttt{dr_tf_outboard}}
+$$
+
+$$
+c = \overbrace{\mathrm{d}x_{\text{beam,duct}}}^{\texttt{dx_beam_duct}} + \left(2 \times \overbrace{\mathrm{d}x_{\text{beam,shield}}}^{\texttt{dx_beam_shield}}\right)
+$$
+
+$$
+d = \overbrace{R_{\text{TF,outboard,mid}}}^{\texttt{r_tf_outboard_mid}} - \left(0.5 \times b\right)
+$$
+
+$$
+e = \sqrt{a^2+\left(d+b\right)^2}
+$$
+
+$$
+f = \sqrt{a^2 + d^2}
+$$
+
+$$
+\theta = \Omega - \arctan{\left(\frac{a}{d}\right)}
+$$
+
+$$
+\phi = \theta - \arcsin{\left(\frac{a}{e}\right)}
+$$
+
+$$
+g = \sqrt{e^2+f^2-2ef\cos{\phi}}
+$$
+
+If the value of $g$ is geater than $c$, then:
+
+$$
+h = \sqrt{g^2-c^2}
+$$
+
+$$
+\epsilon = \arcsin{\left(\frac{e\sin{\left(\phi\right)}}{g}\right)} - \arctan{\left(\frac{h}{c}\right)}
+$$
+
+The maximum possible tangency radius, which can be applied as a constraint, is:
+
+$$
+\overbrace{R_{\text{tangency,max}}}^{\texttt{radius_beam_tangency_max}} = f \cos{\left(\epsilon\right)}- \frac{c}{2}
+$$
+
+--------------
 
 ## Neutral beam losses
 
@@ -23,6 +84,8 @@ The power in the beam atoms that are not ionised as they pass through the plasma
 
 It is recommended that <b>only one</b> of these two constraint equations is used during a run.
 
+
+------------
 
 ## Beam stopping cross-section | `sigbeam()`
 
@@ -70,6 +133,7 @@ $$
 (\times 10^{-16} \mathrm{~cm}^2)
 $$
 
+---------------
 
 ## Ion coupled power | `cfnbi()`
 Both the [ITER](./iter_nb.md) and [Culham](culham_nb.md) NBI models both use the `cfnbi` method to calculate the fraction of the fast particle energy coupled to the ions.

--- a/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
+++ b/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
@@ -5,7 +5,7 @@
 
 ## Neutral beam access
 
-If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `radius_beam_tangency` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `frbeam`, which is the ratio of `radius_beam_tangency` to the plasma major radius `rmajor`. The maximum possible tangency radius `radius_beam_tangency_max` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using constraint equation no. 20 with iteration variable no. 33 (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
+If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `radius_beam_tangency` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `f_radius_beam_tangency_rmajor`, which is the ratio of `radius_beam_tangency` to the plasma major radius `rmajor`. The maximum possible tangency radius `radius_beam_tangency_max` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using constraint equation no. 20 with iteration variable no. 33 (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
 
 <figure markdown>
 ![NBI Port Size](../images/portsize.png){ width = "300"}

--- a/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
+++ b/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
@@ -5,7 +5,7 @@
 
 ## Neutral beam access
 
-If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `rtanbeam` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `frbeam`, which is the ratio of `rtanbeam` to the plasma major radius `rmajor`. The maximum possible tangency radius `rtanmax` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using constraint equation no. 20 with iteration variable no. 33 (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
+If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `radius_beam_tangency` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `frbeam`, which is the ratio of `radius_beam_tangency` to the plasma major radius `rmajor`. The maximum possible tangency radius `rtanmax` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using constraint equation no. 20 with iteration variable no. 33 (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
 
 <figure markdown>
 ![NBI Port Size](../images/portsize.png){ width = "300"}

--- a/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
+++ b/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
@@ -5,7 +5,7 @@
 
 ## Neutral beam access
 
-If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `radius_beam_tangency` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `frbeam`, which is the ratio of `radius_beam_tangency` to the plasma major radius `rmajor`. The maximum possible tangency radius `rtanmax` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using constraint equation no. 20 with iteration variable no. 33 (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
+If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `radius_beam_tangency` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `frbeam`, which is the ratio of `radius_beam_tangency` to the plasma major radius `rmajor`. The maximum possible tangency radius `radius_beam_tangency_max` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using constraint equation no. 20 with iteration variable no. 33 (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
 
 <figure markdown>
 ![NBI Port Size](../images/portsize.png){ width = "300"}

--- a/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
+++ b/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
@@ -7,7 +7,7 @@
 
 If present, a neutral beam injection system needs sufficient space between the TF coils to be able to intercept the plasma tangentially. The major radius `radius_beam_tangency` at which the centre-line of the beam is tangential to the toroidal direction is user-defined using input parameter `f_radius_beam_tangency_rmajor`, which is the ratio of `radius_beam_tangency` to the plasma major radius `rmajor`.
 
-The maximum possible tangency radius `radius_beam_tangency_max` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using `icc = 20` with `ixc = 33` (`fportsz`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
+The maximum possible tangency radius `radius_beam_tangency_max` is determined by the geometry of the TF coils - see Figure 1, and this can be enforced using `icc = 20` with `ixc = 33` (`fradius_beam_tangency`). The thickness of the beam duct walls may be set using input parameter `dx_beam_shield`.
 
 
 <figure markdown>

--- a/examples/data/csv_output_large_tokamak_MFILE.DAT
+++ b/examples/data/csv_output_large_tokamak_MFILE.DAT
@@ -606,7 +606,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/examples/data/large_tokamak_1_MFILE.DAT
+++ b/examples/data/large_tokamak_1_MFILE.DAT
@@ -603,7 +603,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/examples/data/large_tokamak_2_MFILE.DAT
+++ b/examples/data/large_tokamak_2_MFILE.DAT
@@ -603,7 +603,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/examples/data/large_tokamak_3_MFILE.DAT
+++ b/examples/data/large_tokamak_3_MFILE.DAT
@@ -603,7 +603,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/examples/data/large_tokamak_4_MFILE.DAT
+++ b/examples/data/large_tokamak_4_MFILE.DAT
@@ -603,7 +603,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/examples/data/scan_MFILE.DAT
+++ b/examples/data/scan_MFILE.DAT
@@ -456,7 +456,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -1451,7 +1451,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -2446,7 +2446,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -3441,7 +3441,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -4436,7 +4436,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -5431,7 +5431,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -6426,7 +6426,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -7421,7 +7421,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -8416,7 +8416,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    

--- a/process/build.py
+++ b/process/build.py
@@ -37,7 +37,7 @@ class Build:
         for adequate beam access.
         <P>The outputs from the routine are
         <UL> <P><LI>radius_beam_tangency : Beam tangency radius (m)
-        <P><LI>rtanmax : Maximum possible tangency radius (m) </UL>
+        <P><LI>radius_beam_tangency_max : Maximum possible tangency radius (m) </UL>
         A User's Guide to the PROCESS Systems Code
         """
         current_drive_variables.radius_beam_tangency = (
@@ -97,14 +97,16 @@ class Build:
 
             #  Maximum tangency radius for centreline of beam (m)
 
-            current_drive_variables.rtanmax = f * np.cos(eps) - 0.5e0 * c
+            current_drive_variables.radius_beam_tangency_max = (
+                f * np.cos(eps) - 0.5e0 * c
+            )
 
         else:  # coil separation is too narrow for beam...
             error_handling.fdiags[0] = g
             error_handling.fdiags[1] = c
             error_handling.report_error(63)
 
-            current_drive_variables.rtanmax = 0.0e0
+            current_drive_variables.radius_beam_tangency_max = 0.0e0
 
     def calculate_vertical_build(self, output: bool) -> None:
         """

--- a/process/build.py
+++ b/process/build.py
@@ -68,7 +68,7 @@ class Build:
 
         #  Width of beam duct, including shielding on both sides (m)
         c = (
-            current_drive_variables.beamwd
+            current_drive_variables.dx_beam_duct
             + 2.0e0 * current_drive_variables.dx_beam_shield
         )
 
@@ -2433,8 +2433,8 @@ class Build:
                 po.ovarre(
                     self.mfile,
                     "Width of neutral beam duct where it passes between the TF coils (m)",
-                    "(beamwd)",
-                    current_drive_variables.beamwd,
+                    "(dx_beam_duct)",
+                    current_drive_variables.dx_beam_duct,
                 )
 
 

--- a/process/build.py
+++ b/process/build.py
@@ -41,7 +41,8 @@ class Build:
         A User's Guide to the PROCESS Systems Code
         """
         current_drive_variables.radius_beam_tangency = (
-            current_drive_variables.frbeam * physics_variables.rmajor
+            current_drive_variables.f_radius_beam_tangency_rmajor
+            * physics_variables.rmajor
         )
 
         #  Toroidal angle between adjacent TF coils

--- a/process/build.py
+++ b/process/build.py
@@ -36,11 +36,11 @@ class Build:
         This subroutine finds the maximum possible tangency radius
         for adequate beam access.
         <P>The outputs from the routine are
-        <UL> <P><LI>rtanbeam : Beam tangency radius (m)
+        <UL> <P><LI>radius_beam_tangency : Beam tangency radius (m)
         <P><LI>rtanmax : Maximum possible tangency radius (m) </UL>
         A User's Guide to the PROCESS Systems Code
         """
-        current_drive_variables.rtanbeam = (
+        current_drive_variables.radius_beam_tangency = (
             current_drive_variables.frbeam * physics_variables.rmajor
         )
 

--- a/process/build.py
+++ b/process/build.py
@@ -28,7 +28,7 @@ class Build:
         self.outfile = constants.nout
         self.mfile = constants.mfile
 
-    def portsz(self):
+    def calculate_beam_port_size(self):
         """Port size calculation
         author: P J Knight, CCFE, Culham Science Centre
         author: M D Kovari, CCFE, Culham Science Centre

--- a/process/caller.py
+++ b/process/caller.py
@@ -270,7 +270,7 @@ class Caller:
         if ft.tfcoil_variables.i_tf_sup == 1:
             self.models.sctfcoil.run(output=False)
 
-        self.models.build.portsz()
+        self.models.build.calculate_beam_port_size()
 
         # Poloidal field and central solenoid model
         self.models.pfcoil.run()

--- a/process/caller.py
+++ b/process/caller.py
@@ -253,10 +253,8 @@ class Caller:
         # Radial build
         if ft.build_variables.i_tf_inside_cs == 1:
             self.models.build.tf_in_cs_bore_calc()
-        self.models.build.calculate_radial_build(output=False)
 
-        # Vertical build
-        self.models.build.calculate_vertical_build(output=False)
+        self.models.build.run()
 
         self.models.physics.physics()
 
@@ -269,8 +267,6 @@ class Caller:
         # Toroidal field coil superconductor model
         if ft.tfcoil_variables.i_tf_sup == 1:
             self.models.sctfcoil.run(output=False)
-
-        self.models.build.calculate_beam_port_size()
 
         # Poloidal field and central solenoid model
         self.models.pfcoil.run()

--- a/process/constraints.py
+++ b/process/constraints.py
@@ -682,17 +682,17 @@ def constraint_equation_20():
     author: P B Lloyd, CCFE, Culham Science Centre
 
     fportsz: f-value for neutral beam tangency radius limit
-    rtanmax: maximum tangency radius for centreline of beam (m)
+    radius_beam_tangency_max: maximum tangency radius for centreline of beam (m)
     radius_beam_tangency: neutral beam centreline tangency radius (m)
     """
     cc = (
         fortran.current_drive_variables.radius_beam_tangency
-        / fortran.current_drive_variables.rtanmax
+        / fortran.current_drive_variables.radius_beam_tangency_max
         - 1.0 * fortran.constraint_variables.fportsz
     )
     return ConstraintResult(
         cc,
-        fortran.current_drive_variables.rtanmax * (1.0 - cc),
+        fortran.current_drive_variables.radius_beam_tangency_max * (1.0 - cc),
         fortran.current_drive_variables.radius_beam_tangency * cc,
     )
 

--- a/process/constraints.py
+++ b/process/constraints.py
@@ -681,14 +681,14 @@ def constraint_equation_20():
     """Equation for neutral beam tangency radius upper limit
     author: P B Lloyd, CCFE, Culham Science Centre
 
-    fportsz: f-value for neutral beam tangency radius limit
+    fradius_beam_tangency: f-value for neutral beam tangency radius limit
     radius_beam_tangency_max: maximum tangency radius for centreline of beam (m)
     radius_beam_tangency: neutral beam centreline tangency radius (m)
     """
     cc = (
         fortran.current_drive_variables.radius_beam_tangency
         / fortran.current_drive_variables.radius_beam_tangency_max
-        - 1.0 * fortran.constraint_variables.fportsz
+        - 1.0 * fortran.constraint_variables.fradius_beam_tangency
     )
     return ConstraintResult(
         cc,
@@ -2367,7 +2367,7 @@ def init_constraint_variables():
     fortran.constraint_variables.fpeakb = 1.0
     fortran.constraint_variables.fpinj = 1.0
     fortran.constraint_variables.fpnetel = 1.0
-    fortran.constraint_variables.fportsz = 1.0
+    fortran.constraint_variables.fradius_beam_tangency = 1.0
     fortran.constraint_variables.fpsepbqar = 1.0
     fortran.constraint_variables.fpsepr = 1.0
     fortran.constraint_variables.fptemp = 1.0

--- a/process/constraints.py
+++ b/process/constraints.py
@@ -683,17 +683,17 @@ def constraint_equation_20():
 
     fportsz: f-value for neutral beam tangency radius limit
     rtanmax: maximum tangency radius for centreline of beam (m)
-    rtanbeam: neutral beam centreline tangency radius (m)
+    radius_beam_tangency: neutral beam centreline tangency radius (m)
     """
     cc = (
-        fortran.current_drive_variables.rtanbeam
+        fortran.current_drive_variables.radius_beam_tangency
         / fortran.current_drive_variables.rtanmax
         - 1.0 * fortran.constraint_variables.fportsz
     )
     return ConstraintResult(
         cc,
         fortran.current_drive_variables.rtanmax * (1.0 - cc),
-        fortran.current_drive_variables.rtanbeam * cc,
+        fortran.current_drive_variables.radius_beam_tangency * cc,
     )
 
 

--- a/process/current_drive.py
+++ b/process/current_drive.py
@@ -2438,7 +2438,7 @@ class CurrentDrive:
 
 def init_current_drive_variables():
     """Initialise current drive variables"""
-    current_drive_variables.beamwd = 0.58
+    current_drive_variables.dx_beam_duct = 0.58
     current_drive_variables.bigq = 0.0
     current_drive_variables.f_c_plasma_bootstrap = 0.0
     current_drive_variables.f_c_plasma_bootstrap_max = 0.9

--- a/process/current_drive.py
+++ b/process/current_drive.py
@@ -2089,8 +2089,8 @@ class CurrentDrive:
                 po.ovarre(
                     self.outfile,
                     "Maximum possible tangency radius (m)",
-                    "(rtanmax)",
-                    current_drive_variables.rtanmax,
+                    "(radius_beam_tangency_max)",
+                    current_drive_variables.radius_beam_tangency_max,
                     "OP ",
                 )
 
@@ -2295,8 +2295,8 @@ class CurrentDrive:
                 po.ovarre(
                     self.outfile,
                     "Maximum possible tangency radius (m)",
-                    "(rtanmax)",
-                    current_drive_variables.rtanmax,
+                    "(radius_beam_tangency_max)",
+                    current_drive_variables.radius_beam_tangency_max,
                     "OP ",
                 )
 
@@ -2503,7 +2503,7 @@ def init_current_drive_variables():
     current_drive_variables.pwplh = 0.0
     current_drive_variables.pwpnb = 0.0
     current_drive_variables.radius_beam_tangency = 0.0
-    current_drive_variables.rtanmax = 0.0
+    current_drive_variables.radius_beam_tangency_max = 0.0
     current_drive_variables.n_beam_decay_lengths_core = 0.0
     current_drive_variables.tbeamin = 3.0
     current_drive_variables.eta_cd_norm_hcd_secondary = 0.0

--- a/process/current_drive.py
+++ b/process/current_drive.py
@@ -33,16 +33,19 @@ class NeutralBeam:
         ITER Documentation Series No.10, IAEA/ITER/DS/10, IAEA, Vienna, 1990
         """
         # Check argument sanity
-        if (1 + physics_variables.eps) < current_drive_variables.frbeam:
+        if (
+            1 + physics_variables.eps
+        ) < current_drive_variables.f_radius_beam_tangency_rmajor:
             raise ProcessValueError(
                 "Imminent negative square root argument; NBI will miss plasma completely",
                 eps=physics_variables.eps,
-                frbeam=current_drive_variables.frbeam,
+                f_radius_beam_tangency_rmajor=current_drive_variables.f_radius_beam_tangency_rmajor,
             )
 
         # Calculate beam path length to centre
         dpath = physics_variables.rmajor * np.sqrt(
-            (1.0 + physics_variables.eps) ** 2 - current_drive_variables.frbeam**2
+            (1.0 + physics_variables.eps) ** 2
+            - current_drive_variables.f_radius_beam_tangency_rmajor**2
         )
 
         # Calculate beam stopping cross-section
@@ -84,7 +87,7 @@ class NeutralBeam:
         )
 
         # Current drive efficiency
-        effnbss = current_drive_variables.frbeam * self.etanb(
+        effnbss = current_drive_variables.f_radius_beam_tangency_rmajor * self.etanb(
             physics_variables.m_beam_amu,
             physics_variables.alphan,
             physics_variables.alphat,
@@ -110,17 +113,20 @@ class NeutralBeam:
         from that of ITER (approx. 2.8).
         AEA FUS 172: Physics Assessment for the European Reactor Study
         """
-        if (1.0e0 + physics_variables.eps) < current_drive_variables.frbeam:
+        if (
+            1.0e0 + physics_variables.eps
+        ) < current_drive_variables.f_radius_beam_tangency_rmajor:
             raise ProcessValueError(
                 "Imminent negative square root argument; NBI will miss plasma completely",
                 eps=physics_variables.eps,
-                frbeam=current_drive_variables.frbeam,
+                f_radius_beam_tangency_rmajor=current_drive_variables.f_radius_beam_tangency_rmajor,
             )
 
         #  Calculate beam path length to centre
 
         dpath = physics_variables.rmajor * np.sqrt(
-            (1.0e0 + physics_variables.eps) ** 2 - current_drive_variables.frbeam**2
+            (1.0e0 + physics_variables.eps) ** 2
+            - current_drive_variables.f_radius_beam_tangency_rmajor**2
         )
 
         #  Calculate beam stopping cross-section
@@ -176,7 +182,7 @@ class NeutralBeam:
             physics_variables.dene,
             physics_variables.dnla,
             current_drive_variables.e_beam_kev,
-            current_drive_variables.frbeam,
+            current_drive_variables.f_radius_beam_tangency_rmajor,
             fshine,
             physics_variables.rmajor,
             physics_variables.rminor,
@@ -195,7 +201,7 @@ class NeutralBeam:
         dene,
         dnla,
         e_beam_kev,
-        frbeam,
+        f_radius_beam_tangency_rmajor,
         fshine,
         rmajor,
         rminor,
@@ -213,7 +219,7 @@ class NeutralBeam:
         dene    : input real : volume averaged electron density (m**-3)
         dnla    : input real : line averaged electron density (m**-3)
         e_beam_kev  : input real : neutral beam energy (keV)
-        frbeam  : input real : R_tangent / R_major for neutral beam injection
+        f_radius_beam_tangency_rmajor  : input real : R_tangent / R_major for neutral beam injection
         fshine  : input real : shine-through fraction of beam
         rmajor  : input real : plasma major radius (m)
         rminor  : input real : plasma minor radius (m)
@@ -273,17 +279,17 @@ class NeutralBeam:
         nnorm = 1.0
 
         #  Distance along beam to plasma centre
-        r = max(rmajor, rmajor * frbeam)
+        r = max(rmajor, rmajor * f_radius_beam_tangency_rmajor)
         eps1 = rminor / r
 
-        if (1.0 + eps1) < frbeam:
+        if (1.0 + eps1) < f_radius_beam_tangency_rmajor:
             raise ProcessValueError(
                 "Imminent negative square root argument; NBI will miss plasma completely",
                 eps=eps1,
-                frbeam=frbeam,
+                f_radius_beam_tangency_rmajor=f_radius_beam_tangency_rmajor,
             )
 
-        d = rmajor * np.sqrt((1.0 + eps1) ** 2 - frbeam**2)
+        d = rmajor * np.sqrt((1.0 + eps1) ** 2 - f_radius_beam_tangency_rmajor**2)
 
         # Distance along beam to plasma centre for ITER
         # assuming a tangency radius equal to the major radius
@@ -303,7 +309,17 @@ class NeutralBeam:
         )
 
         #  Normalised current drive efficiency (A/W m**-2) (IPDG89)
-        gamnb = 5.0 * abd * 0.1 * ten * (1.0 - fshine) * frbeam * j0 / 0.2 * ffac
+        gamnb = (
+            5.0
+            * abd
+            * 0.1
+            * ten
+            * (1.0 - fshine)
+            * f_radius_beam_tangency_rmajor
+            * j0
+            / 0.2
+            * ffac
+        )
 
         #  Current drive efficiency (A/W)
         return gamnb / (dene20 * rmajor)
@@ -2076,8 +2092,8 @@ class CurrentDrive:
                 po.ovarre(
                     self.outfile,
                     "Beam tangency radius / Plasma major radius",
-                    "(frbeam)",
-                    current_drive_variables.frbeam,
+                    "(f_radius_beam_tangency_rmajor)",
+                    current_drive_variables.f_radius_beam_tangency_rmajor,
                 )
                 po.ovarre(
                     self.outfile,
@@ -2282,8 +2298,8 @@ class CurrentDrive:
                 po.ovarre(
                     self.outfile,
                     "Beam tangency radius / Plasma major radius",
-                    "(frbeam)",
-                    current_drive_variables.frbeam,
+                    "(f_radius_beam_tangency_rmajor)",
+                    current_drive_variables.f_radius_beam_tangency_rmajor,
                 )
                 po.ovarre(
                     self.outfile,
@@ -2477,7 +2493,7 @@ def init_current_drive_variables():
     current_drive_variables.p_beam_shine_through_mw = 0.0
     current_drive_variables.feffcd = 1.0
     current_drive_variables.f_p_beam_orbit_loss = 0.0
-    current_drive_variables.frbeam = 1.05
+    current_drive_variables.f_radius_beam_tangency_rmajor = 1.05
     current_drive_variables.f_beam_tritium = 1e-6
     current_drive_variables.eta_cd_norm_hcd_primary = 0.0
     current_drive_variables.eta_cd_norm_ecrh = 0.35

--- a/process/current_drive.py
+++ b/process/current_drive.py
@@ -2082,8 +2082,8 @@ class CurrentDrive:
                 po.ovarre(
                     self.outfile,
                     "Beam centreline tangency radius (m)",
-                    "(rtanbeam)",
-                    current_drive_variables.rtanbeam,
+                    "(radius_beam_tangency)",
+                    current_drive_variables.radius_beam_tangency,
                     "OP ",
                 )
                 po.ovarre(
@@ -2288,8 +2288,8 @@ class CurrentDrive:
                 po.ovarre(
                     self.outfile,
                     "Beam centreline tangency radius (m)",
-                    "(rtanbeam)",
-                    current_drive_variables.rtanbeam,
+                    "(radius_beam_tangency)",
+                    current_drive_variables.radius_beam_tangency,
                     "OP ",
                 )
                 po.ovarre(
@@ -2502,7 +2502,7 @@ def init_current_drive_variables():
     current_drive_variables.f_c_plasma_pfirsch_schluter = 0.0
     current_drive_variables.pwplh = 0.0
     current_drive_variables.pwpnb = 0.0
-    current_drive_variables.rtanbeam = 0.0
+    current_drive_variables.radius_beam_tangency = 0.0
     current_drive_variables.rtanmax = 0.0
     current_drive_variables.n_beam_decay_lengths_core = 0.0
     current_drive_variables.tbeamin = 3.0

--- a/process/input.py
+++ b/process/input.py
@@ -710,7 +710,9 @@ INPUT_VARIABLES = {
     ),
     "fradpwr": InputVariable(fortran.constraint_variables, float, range=(0.0, 1.0)),
     "fradwall": InputVariable(fortran.constraint_variables, float, range=(0.001, 1.0)),
-    "frbeam": InputVariable(fortran.current_drive_variables, float, range=(0.5, 2.0)),
+    "f_radius_beam_tangency_rmajor": InputVariable(
+        fortran.current_drive_variables, float, range=(0.5, 2.0)
+    ),
     "freinke": InputVariable(fortran.constraint_variables, float, range=(0.001, 1.0)),
     "frhocp": InputVariable(fortran.tfcoil_variables, float, range=(0.01, 5.0)),
     "frholeg": InputVariable(fortran.tfcoil_variables, float, range=(0.01, 5.0)),

--- a/process/input.py
+++ b/process/input.py
@@ -193,7 +193,9 @@ INPUT_VARIABLES = {
     "e_beam_kev": InputVariable(
         fortran.current_drive_variables, float, range=(1.0, 1000000.0)
     ),
-    "beamwd": InputVariable(fortran.current_drive_variables, float, range=(0.001, 5.0)),
+    "dx_beam_duct": InputVariable(
+        fortran.current_drive_variables, float, range=(0.001, 5.0)
+    ),
     "deg_div_field_plate": InputVariable(
         fortran.divertor_variables, float, range=(0.0, 360.0)
     ),

--- a/process/input.py
+++ b/process/input.py
@@ -684,7 +684,9 @@ INPUT_VARIABLES = {
     "fpoloidalpower": InputVariable(
         fortran.constraint_variables, float, range=(0.001, 1.0)
     ),
-    "fportsz": InputVariable(fortran.constraint_variables, float, range=(0.001, 10.0)),
+    "fradius_beam_tangency": InputVariable(
+        fortran.constraint_variables, float, range=(0.001, 10.0)
+    ),
     "fpsep": InputVariable(fortran.constraint_variables, float, range=(0.001, 1.0)),
     "fpsepbqar": InputVariable(fortran.constraint_variables, float, range=(0.001, 1.0)),
     "fpsepr": InputVariable(fortran.constraint_variables, float, range=(0.001, 10.0)),

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -360,6 +360,7 @@ OBS_VARS = {
     "vftf": "f_a_tf_turn_cable_space_extra_void",
     "beamwd": "dx_beam_duct",
     "frbeam": "f_radius_beam_tangency_rmajor",
+    "fportsz": "fradius_beam_tangency",
 }
 
 OBS_VARS_HELP = {

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -358,6 +358,8 @@ OBS_VARS = {
     "tfinsgap": "dx_tf_wp_insertion_gap",
     "tinstf": "dx_tf_wp_insulation",
     "vftf": "f_a_tf_turn_cable_space_extra_void",
+    "beamwd": "dx_beam_duct",
+    "frbeam": "f_radius_beam_tangency_rmajor",
 }
 
 OBS_VARS_HELP = {

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -1410,8 +1410,8 @@ def toroidal_cross_section(axis, mfile_data, scan, demo_ranges, colour_scheme):
         d = r3
         e = np.sqrt(a**2 + (d + b) ** 2)
         # Coordinates of the inner and outer edges of the beam at its tangency point
-        rinner = rtanbeam - beamwd
-        router = rtanbeam + beamwd
+        rinner = radius_beam_tangency - beamwd
+        router = radius_beam_tangency + beamwd
         beta = np.arccos(rinner / e)
         xinner = rinner * np.cos(beta)
         yinner = rinner * np.sin(beta)
@@ -5571,7 +5571,7 @@ def main(args=None):
         dr_tf_plasma_case = m_file.data["dr_tf_plasma_case"].get_scan(scan)
 
     global dx_beam_shield
-    global rtanbeam
+    global radius_beam_tangency
     global rtanmax
     global beamwd
 
@@ -5580,11 +5580,11 @@ def main(args=None):
 
     if (i_hcd_primary in [5, 8]) or (i_hcd_secondary in [5, 8]):
         dx_beam_shield = m_file.data["dx_beam_shield"].get_scan(scan)
-        rtanbeam = m_file.data["rtanbeam"].get_scan(scan)
+        radius_beam_tangency = m_file.data["radius_beam_tangency"].get_scan(scan)
         rtanmax = m_file.data["rtanmax"].get_scan(scan)
         beamwd = m_file.data["beamwd"].get_scan(scan)
     else:
-        dx_beam_shield = rtanbeam = rtanmax = beamwd = 0.0
+        dx_beam_shield = radius_beam_tangency = rtanmax = beamwd = 0.0
 
     # Pedestal profile parameters
     global ipedestal

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -1406,12 +1406,12 @@ def toroidal_cross_section(axis, mfile_data, scan, demo_ranges, colour_scheme):
         # Neutral beam geometry
         a = w
         b = dr_tf_outboard
-        c = beamwd + 2 * dx_beam_shield
+        c = dx_beam_duct + 2 * dx_beam_shield
         d = r3
         e = np.sqrt(a**2 + (d + b) ** 2)
         # Coordinates of the inner and outer edges of the beam at its tangency point
-        rinner = radius_beam_tangency - beamwd
-        router = radius_beam_tangency + beamwd
+        rinner = radius_beam_tangency - dx_beam_duct
+        router = radius_beam_tangency + dx_beam_duct
         beta = np.arccos(rinner / e)
         xinner = rinner * np.cos(beta)
         yinner = rinner * np.sin(beta)
@@ -5573,7 +5573,7 @@ def main(args=None):
     global dx_beam_shield
     global radius_beam_tangency
     global rtanmax
-    global beamwd
+    global dx_beam_duct
 
     i_hcd_primary = int(m_file.data["i_hcd_primary"].get_scan(scan))
     i_hcd_secondary = int(m_file.data["i_hcd_secondary"].get_scan(scan))
@@ -5582,9 +5582,9 @@ def main(args=None):
         dx_beam_shield = m_file.data["dx_beam_shield"].get_scan(scan)
         radius_beam_tangency = m_file.data["radius_beam_tangency"].get_scan(scan)
         rtanmax = m_file.data["rtanmax"].get_scan(scan)
-        beamwd = m_file.data["beamwd"].get_scan(scan)
+        dx_beam_duct = m_file.data["dx_beam_duct"].get_scan(scan)
     else:
-        dx_beam_shield = radius_beam_tangency = rtanmax = beamwd = 0.0
+        dx_beam_shield = radius_beam_tangency = rtanmax = dx_beam_duct = 0.0
 
     # Pedestal profile parameters
     global ipedestal

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -5572,7 +5572,7 @@ def main(args=None):
 
     global dx_beam_shield
     global radius_beam_tangency
-    global rtanmax
+    global radius_beam_tangency_max
     global dx_beam_duct
 
     i_hcd_primary = int(m_file.data["i_hcd_primary"].get_scan(scan))
@@ -5581,10 +5581,14 @@ def main(args=None):
     if (i_hcd_primary in [5, 8]) or (i_hcd_secondary in [5, 8]):
         dx_beam_shield = m_file.data["dx_beam_shield"].get_scan(scan)
         radius_beam_tangency = m_file.data["radius_beam_tangency"].get_scan(scan)
-        rtanmax = m_file.data["rtanmax"].get_scan(scan)
+        radius_beam_tangency_max = m_file.data["radius_beam_tangency_max"].get_scan(
+            scan
+        )
         dx_beam_duct = m_file.data["dx_beam_duct"].get_scan(scan)
     else:
-        dx_beam_shield = radius_beam_tangency = rtanmax = dx_beam_duct = 0.0
+        dx_beam_shield = radius_beam_tangency = radius_beam_tangency_max = (
+            dx_beam_duct
+        ) = 0.0
 
     # Pedestal profile parameters
     global ipedestal

--- a/process/iteration_variables.py
+++ b/process/iteration_variables.py
@@ -74,7 +74,9 @@ ITERATION_VARIABLES = {
     30: IterationVariable("fmva", fortran.constraint_variables, 0.010, 1.0),
     31: IterationVariable("gapomin", fortran.build_variables, 0.001, 1.0e1),
     32: IterationVariable("frminor", fortran.constraint_variables, 0.001, 1.0),
-    33: IterationVariable("fportsz", fortran.constraint_variables, 0.001, 1.0),
+    33: IterationVariable(
+        "fradius_beam_tangency", fortran.constraint_variables, 0.001, 1.0
+    ),
     35: IterationVariable("fpeakb", fortran.constraint_variables, 0.001, 1.0),
     36: IterationVariable("fbeta_max", fortran.constraint_variables, 0.001, 1.0),
     37: IterationVariable("j_cs_flat_top_end", fortran.pfcoil_variables, 1.0e5, 1.0e8),

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -5170,8 +5170,8 @@ class Stellarator:
                 po.ovarre(
                     self.outfile,
                     "Maximum possible tangency radius (m)",
-                    "(rtanmax)",
-                    current_drive_variables.rtanmax,
+                    "(radius_beam_tangency_max)",
+                    current_drive_variables.radius_beam_tangency_max,
                 )
                 po.ovarre(
                     self.outfile,

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -5164,8 +5164,8 @@ class Stellarator:
                 po.ovarre(
                     self.outfile,
                     "Beam centreline tangency radius (m)",
-                    "(rtanbeam)",
-                    current_drive_variables.rtanbeam,
+                    "(radius_beam_tangency)",
+                    current_drive_variables.radius_beam_tangency,
                 )
                 po.ovarre(
                     self.outfile,

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -5158,8 +5158,8 @@ class Stellarator:
                 po.ovarre(
                     self.outfile,
                     "R injection tangent / R-major",
-                    "(frbeam)",
-                    current_drive_variables.frbeam,
+                    "(f_radius_beam_tangency_rmajor)",
+                    current_drive_variables.f_radius_beam_tangency_rmajor,
                 )
                 po.ovarre(
                     self.outfile,

--- a/process/utilities/errorlist.json
+++ b/process/utilities/errorlist.json
@@ -323,7 +323,7 @@
     {
       "no": 63,
       "level": 2,
-      "message": "PORTSZ: Max beam tangency radius set =0 temporarily; change beamwd"
+      "message": "PORTSZ: Max beam tangency radius set =0 temporarily; change dx_beam_duct"
     },
     {
       "no": 64,

--- a/source/fortran/constraint_variables.f90
+++ b/source/fortran/constraint_variables.f90
@@ -130,7 +130,7 @@ module constraint_variables
   real(dp) :: fpnetel
   !! f-value for net electric power (`constraint equation 16`, `iteration variable 25`)
 
-  real(dp) :: fportsz
+  real(dp) :: fradius_beam_tangency
   !! f-value for neutral beam tangency radius limit
   !! (`constraint equation 20`, `iteration variable 33`)
 

--- a/source/fortran/current_drive_variables.f90
+++ b/source/fortran/current_drive_variables.f90
@@ -289,7 +289,7 @@ module current_drive_variables
   real(dp) :: radius_beam_tangency
   !! neutral beam centreline tangency radius (m)
 
-  real(dp) :: rtanmax
+  real(dp) :: radius_beam_tangency_max
   !! maximum tangency radius for centreline of beam (m)
 
   real(dp) :: n_beam_decay_lengths_core

--- a/source/fortran/current_drive_variables.f90
+++ b/source/fortran/current_drive_variables.f90
@@ -14,7 +14,7 @@ module current_drive_variables
 
   public
 
-  real(dp) :: beamwd
+  real(dp) :: dx_beam_duct
   !! width of neutral beam duct where it passes between the TF coils (m)
   !! T Inoue et al, Design of neutral beam system for ITER-FEAT,
   !! <A HREF=http://dx.doi.org/10.1016/S0920-3796(01)00339-8>

--- a/source/fortran/current_drive_variables.f90
+++ b/source/fortran/current_drive_variables.f90
@@ -166,7 +166,7 @@ module current_drive_variables
   !! fraction of neutral beam power lost after ionisation but before
   !! thermalisation (orbit loss fraction)
 
-  real(dp) :: frbeam
+  real(dp) :: f_radius_beam_tangency_rmajor
   !! R_tangential / R_major for neutral beam injection
 
   real(dp) :: f_beam_tritium

--- a/source/fortran/current_drive_variables.f90
+++ b/source/fortran/current_drive_variables.f90
@@ -286,7 +286,7 @@ module current_drive_variables
   real(dp) :: pwpnb
   !! neutral beam wall plug power (MW)
 
-  real(dp) :: rtanbeam
+  real(dp) :: radius_beam_tangency
   !! neutral beam centreline tangency radius (m)
 
   real(dp) :: rtanmax

--- a/source/fortran/numerics.f90
+++ b/source/fortran/numerics.f90
@@ -238,7 +238,7 @@ module numerics
   !! <LI> (30) fmva (f-value for equation 19)
   !! <LI> (31) gapomin
   !! <LI> (32) frminor (f-value for equation 21)
-  !! <LI> (33) fportsz (f-value for equation 20)
+  !! <LI> (33) fradius_beam_tangency (f-value for equation 20)
   !! <LI> (34) NOT USED
   !! <LI> (35) fpeakb (f-value for equation 25)
   !! <LI> (36) fbeta_max (f-value for equation 24)

--- a/tests/integration/data/large_tokamak_1_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_1_MFILE.DAT
@@ -602,7 +602,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/tests/integration/data/large_tokamak_2_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_2_MFILE.DAT
@@ -603,7 +603,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/tests/integration/data/large_tokamak_3_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_3_MFILE.DAT
@@ -603,7 +603,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/tests/integration/data/large_tokamak_4_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_4_MFILE.DAT
@@ -603,7 +603,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/tests/integration/data/large_tokamak_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_MFILE.DAT
@@ -601,7 +601,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(excludes_structure)_(m)____________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_Solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/tests/integration/data/scan_2D_MFILE.DAT
+++ b/tests/integration/data/scan_2D_MFILE.DAT
@@ -604,7 +604,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -1767,7 +1767,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -2930,7 +2930,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -4093,7 +4093,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -5256,7 +5256,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -6419,7 +6419,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -7582,7 +7582,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -8745,7 +8745,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -9908,7 +9908,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -11071,7 +11071,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -12234,7 +12234,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -13397,7 +13397,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -14560,7 +14560,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -15723,7 +15723,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    
@@ -16886,7 +16886,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/tests/integration/data/scan_MFILE.DAT
+++ b/tests/integration/data/scan_MFILE.DAT
@@ -456,7 +456,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -1451,7 +1451,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -2446,7 +2446,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -3441,7 +3441,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -4436,7 +4436,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -5431,7 +5431,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -6426,7 +6426,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -7421,7 +7421,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    
@@ -8416,7 +8416,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(m)_________________________________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      7.6976E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      5.4712E+00    

--- a/tests/regression/input_files/st_regression.IN.DAT
+++ b/tests/regression/input_files/st_regression.IN.DAT
@@ -2756,7 +2756,7 @@ feffcd = 1.0
 * DESCRIPTION:   NBI power orbit loss fraction
 * JUSTIFICATION: Not used as no NBI used
 
-*frbeam
+*f_radius_beam_tangency_rmajor
 * DESCRIPTION:   R_tan / R_major for NBI
 * JUSTIFICATION: Not used as no NBI used
 

--- a/tests/regression/input_files/st_regression.IN.DAT
+++ b/tests/regression/input_files/st_regression.IN.DAT
@@ -2748,7 +2748,7 @@ feffcd = 1.0
 * DESCRIPTION:   NBI wall plug to injector efficiency
 * JUSTIFICATION: Not used as no NBI used
 
-*beamwd = 
+*dx_beam_duct = 
 * DESCRIPTION:   Width of neutral beam duct where it passes between the TF coils
 * JUSTIFICATION: Not used as no NBI used
 

--- a/tests/unit/data/large_tokamak_MFILE.DAT
+++ b/tests/unit/data/large_tokamak_MFILE.DAT
@@ -601,7 +601,7 @@
  Underside_vacuum_vessel_radial_thickness_(m)____________________________ (dz_vv_lower)____________________      3.0000E-01    
  External_cryostat_thickness_(excludes_structure)_(m)____________________ (dr_cryostat)_______________________      1.5000E-01    
  Ratio_of_Central_Solenoid_height_to_TF_coil_internal_height_____________ (f_z_cs_tf_internal)______________________      9.0000E-01    
- Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (beamwd)______________________      5.8000E-01    
+ Width_of_neutral_beam_duct_where_it_passes_between_the_TF_coils_(m)_____ (dx_beam_duct)______________________      5.8000E-01    
  # Divertor build and plasma position #
  Plasma_top_position,_radial_(m)_________________________________________ (ptop_radial)_________________      6.6667E+00    
  Plasma_top_position,_vertical_(m)_______________________________________ (ptop_vertical)_______________      4.9333E+00    

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -5,7 +5,6 @@ import pytest
 from process.build import Build
 from process.fortran import (
     build_variables,
-    current_drive_variables,
     divertor_variables,
     physics_variables,
     tfcoil_variables,
@@ -384,70 +383,34 @@ class PortszParam(NamedTuple):
         ),
     ),
 )
-def test_calculate_beam_port_size(portszparam, monkeypatch, build):
+def test_calculate_beam_port_size(portszparam, build):
     """
-    Automatically generated Regression Unit Test for portsz.
+    Regression Unit Test for calculate_beam_port_size with explicit inputs.
 
     This test was generated using data from tracking/baseline_2018/baseline_2018_IN.DAT.
 
     :param portszparam: the data used to mock and assert in this test.
     :type portszparam: portszparam
 
-    :param monkeypatch: pytest fixture used to mock module/class variables
-    :type monkeypatch: _pytest.monkeypatch.monkeypatch
-
     :param build: fixture containing an initialised `Build` object
     :type build: tests.unit.test_build.build (functional fixture)
     """
 
-    monkeypatch.setattr(
-        build_variables, "r_tf_outboard_mid", portszparam.r_tf_outboard_mid
+    radius_beam_tangency, radius_beam_tangency_max = build.calculate_beam_port_size(
+        r_tf_outboard_mid=portszparam.r_tf_outboard_mid,
+        dr_tf_outboard=portszparam.dr_tf_outboard,
+        dx_beam_shield=portszparam.dx_beam_shield,
+        dx_beam_duct=portszparam.dx_beam_duct,
+        f_radius_beam_tangency_rmajor=portszparam.f_radius_beam_tangency_rmajor,
+        rmajor=portszparam.rmajor,
+        dx_tf_inboard_out_toroidal=portszparam.dx_tf_inboard_out_toroidal,
+        n_tf_coils=portszparam.n_tf_coils,
     )
 
-    monkeypatch.setattr(build_variables, "dr_tf_outboard", portszparam.dr_tf_outboard)
-
-    monkeypatch.setattr(
-        current_drive_variables,
-        "radius_beam_tangency",
-        portszparam.radius_beam_tangency,
-    )
-
-    monkeypatch.setattr(
-        current_drive_variables,
-        "radius_beam_tangency_max",
-        portszparam.radius_beam_tangency_max,
-    )
-
-    monkeypatch.setattr(
-        current_drive_variables, "dx_beam_shield", portszparam.dx_beam_shield
-    )
-
-    monkeypatch.setattr(
-        current_drive_variables, "dx_beam_duct", portszparam.dx_beam_duct
-    )
-
-    monkeypatch.setattr(
-        current_drive_variables,
-        "f_radius_beam_tangency_rmajor",
-        portszparam.f_radius_beam_tangency_rmajor,
-    )
-
-    monkeypatch.setattr(physics_variables, "rmajor", portszparam.rmajor)
-
-    monkeypatch.setattr(
-        tfcoil_variables,
-        "dx_tf_inboard_out_toroidal",
-        portszparam.dx_tf_inboard_out_toroidal,
-    )
-
-    monkeypatch.setattr(tfcoil_variables, "n_tf_coils", portszparam.n_tf_coils)
-
-    build.calculate_beam_port_size()
-
-    assert current_drive_variables.radius_beam_tangency == pytest.approx(
+    assert radius_beam_tangency == pytest.approx(
         portszparam.expected_radius_beam_tangency
     )
 
-    assert current_drive_variables.radius_beam_tangency_max == pytest.approx(
+    assert radius_beam_tangency_max == pytest.approx(
         portszparam.expected_radius_beam_tangency_max
     )

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -332,7 +332,7 @@ class PortszParam(NamedTuple):
 
     radius_beam_tangency: Any = None
 
-    rtanmax: Any = None
+    radius_beam_tangency_max: Any = None
 
     dx_beam_shield: Any = None
 
@@ -348,7 +348,7 @@ class PortszParam(NamedTuple):
 
     expected_radius_beam_tangency: Any = None
 
-    expected_rtanmax: Any = None
+    expected_radius_beam_tangency_max: Any = None
 
 
 @pytest.mark.parametrize(
@@ -358,7 +358,7 @@ class PortszParam(NamedTuple):
             r_tf_outboard_mid=16.519405859443332,
             dr_tf_outboard=1.208,
             radius_beam_tangency=0,
-            rtanmax=0,
+            radius_beam_tangency_max=0,
             dx_beam_shield=0.5,
             dx_beam_duct=0.57999999999999996,
             frbeam=1.05,
@@ -366,13 +366,13 @@ class PortszParam(NamedTuple):
             dx_tf_inboard_out_toroidal=1.6395161177915356,
             n_tf_coils=16,
             expected_radius_beam_tangency=9.3346050000000016,
-            expected_rtanmax=14.735821603386416,
+            expected_radius_beam_tangency_max=14.735821603386416,
         ),
         PortszParam(
             r_tf_outboard_mid=16.519405859443332,
             dr_tf_outboard=1.208,
             radius_beam_tangency=9.3346050000000016,
-            rtanmax=14.735821603386416,
+            radius_beam_tangency_max=14.735821603386416,
             dx_beam_shield=0.5,
             dx_beam_duct=0.57999999999999996,
             frbeam=1.05,
@@ -380,7 +380,7 @@ class PortszParam(NamedTuple):
             dx_tf_inboard_out_toroidal=1.6395161177915356,
             n_tf_coils=16,
             expected_radius_beam_tangency=9.3346050000000016,
-            expected_rtanmax=14.735821603386416,
+            expected_radius_beam_tangency_max=14.735821603386416,
         ),
     ),
 )
@@ -412,7 +412,11 @@ def test_portsz(portszparam, monkeypatch, build):
         portszparam.radius_beam_tangency,
     )
 
-    monkeypatch.setattr(current_drive_variables, "rtanmax", portszparam.rtanmax)
+    monkeypatch.setattr(
+        current_drive_variables,
+        "radius_beam_tangency_max",
+        portszparam.radius_beam_tangency_max,
+    )
 
     monkeypatch.setattr(
         current_drive_variables, "dx_beam_shield", portszparam.dx_beam_shield
@@ -440,6 +444,6 @@ def test_portsz(portszparam, monkeypatch, build):
         portszparam.expected_radius_beam_tangency
     )
 
-    assert current_drive_variables.rtanmax == pytest.approx(
-        portszparam.expected_rtanmax
+    assert current_drive_variables.radius_beam_tangency_max == pytest.approx(
+        portszparam.expected_radius_beam_tangency_max
     )

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -330,7 +330,7 @@ class PortszParam(NamedTuple):
 
     dr_tf_outboard: Any = None
 
-    rtanbeam: Any = None
+    radius_beam_tangency: Any = None
 
     rtanmax: Any = None
 
@@ -346,7 +346,7 @@ class PortszParam(NamedTuple):
 
     n_tf_coils: Any = None
 
-    expected_rtanbeam: Any = None
+    expected_radius_beam_tangency: Any = None
 
     expected_rtanmax: Any = None
 
@@ -357,7 +357,7 @@ class PortszParam(NamedTuple):
         PortszParam(
             r_tf_outboard_mid=16.519405859443332,
             dr_tf_outboard=1.208,
-            rtanbeam=0,
+            radius_beam_tangency=0,
             rtanmax=0,
             dx_beam_shield=0.5,
             beamwd=0.57999999999999996,
@@ -365,13 +365,13 @@ class PortszParam(NamedTuple):
             rmajor=8.8901000000000003,
             dx_tf_inboard_out_toroidal=1.6395161177915356,
             n_tf_coils=16,
-            expected_rtanbeam=9.3346050000000016,
+            expected_radius_beam_tangency=9.3346050000000016,
             expected_rtanmax=14.735821603386416,
         ),
         PortszParam(
             r_tf_outboard_mid=16.519405859443332,
             dr_tf_outboard=1.208,
-            rtanbeam=9.3346050000000016,
+            radius_beam_tangency=9.3346050000000016,
             rtanmax=14.735821603386416,
             dx_beam_shield=0.5,
             beamwd=0.57999999999999996,
@@ -379,7 +379,7 @@ class PortszParam(NamedTuple):
             rmajor=8.8901000000000003,
             dx_tf_inboard_out_toroidal=1.6395161177915356,
             n_tf_coils=16,
-            expected_rtanbeam=9.3346050000000016,
+            expected_radius_beam_tangency=9.3346050000000016,
             expected_rtanmax=14.735821603386416,
         ),
     ),
@@ -406,7 +406,11 @@ def test_portsz(portszparam, monkeypatch, build):
 
     monkeypatch.setattr(build_variables, "dr_tf_outboard", portszparam.dr_tf_outboard)
 
-    monkeypatch.setattr(current_drive_variables, "rtanbeam", portszparam.rtanbeam)
+    monkeypatch.setattr(
+        current_drive_variables,
+        "radius_beam_tangency",
+        portszparam.radius_beam_tangency,
+    )
 
     monkeypatch.setattr(current_drive_variables, "rtanmax", portszparam.rtanmax)
 
@@ -430,8 +434,8 @@ def test_portsz(portszparam, monkeypatch, build):
 
     build.portsz()
 
-    assert current_drive_variables.rtanbeam == pytest.approx(
-        portszparam.expected_rtanbeam
+    assert current_drive_variables.radius_beam_tangency == pytest.approx(
+        portszparam.expected_radius_beam_tangency
     )
 
     assert current_drive_variables.rtanmax == pytest.approx(

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -384,7 +384,7 @@ class PortszParam(NamedTuple):
         ),
     ),
 )
-def test_portsz(portszparam, monkeypatch, build):
+def test_calculate_beam_port_size(portszparam, monkeypatch, build):
     """
     Automatically generated Regression Unit Test for portsz.
 
@@ -438,7 +438,7 @@ def test_portsz(portszparam, monkeypatch, build):
 
     monkeypatch.setattr(tfcoil_variables, "n_tf_coils", portszparam.n_tf_coils)
 
-    build.portsz()
+    build.calculate_beam_port_size()
 
     assert current_drive_variables.radius_beam_tangency == pytest.approx(
         portszparam.expected_radius_beam_tangency

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -338,7 +338,7 @@ class PortszParam(NamedTuple):
 
     dx_beam_duct: Any = None
 
-    frbeam: Any = None
+    f_radius_beam_tangency_rmajor: Any = None
 
     rmajor: Any = None
 
@@ -361,7 +361,7 @@ class PortszParam(NamedTuple):
             radius_beam_tangency_max=0,
             dx_beam_shield=0.5,
             dx_beam_duct=0.57999999999999996,
-            frbeam=1.05,
+            f_radius_beam_tangency_rmajor=1.05,
             rmajor=8.8901000000000003,
             dx_tf_inboard_out_toroidal=1.6395161177915356,
             n_tf_coils=16,
@@ -375,7 +375,7 @@ class PortszParam(NamedTuple):
             radius_beam_tangency_max=14.735821603386416,
             dx_beam_shield=0.5,
             dx_beam_duct=0.57999999999999996,
-            frbeam=1.05,
+            f_radius_beam_tangency_rmajor=1.05,
             rmajor=8.8901000000000003,
             dx_tf_inboard_out_toroidal=1.6395161177915356,
             n_tf_coils=16,
@@ -426,7 +426,11 @@ def test_calculate_beam_port_size(portszparam, monkeypatch, build):
         current_drive_variables, "dx_beam_duct", portszparam.dx_beam_duct
     )
 
-    monkeypatch.setattr(current_drive_variables, "frbeam", portszparam.frbeam)
+    monkeypatch.setattr(
+        current_drive_variables,
+        "f_radius_beam_tangency_rmajor",
+        portszparam.f_radius_beam_tangency_rmajor,
+    )
 
     monkeypatch.setattr(physics_variables, "rmajor", portszparam.rmajor)
 

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -336,7 +336,7 @@ class PortszParam(NamedTuple):
 
     dx_beam_shield: Any = None
 
-    beamwd: Any = None
+    dx_beam_duct: Any = None
 
     frbeam: Any = None
 
@@ -360,7 +360,7 @@ class PortszParam(NamedTuple):
             radius_beam_tangency=0,
             rtanmax=0,
             dx_beam_shield=0.5,
-            beamwd=0.57999999999999996,
+            dx_beam_duct=0.57999999999999996,
             frbeam=1.05,
             rmajor=8.8901000000000003,
             dx_tf_inboard_out_toroidal=1.6395161177915356,
@@ -374,7 +374,7 @@ class PortszParam(NamedTuple):
             radius_beam_tangency=9.3346050000000016,
             rtanmax=14.735821603386416,
             dx_beam_shield=0.5,
-            beamwd=0.57999999999999996,
+            dx_beam_duct=0.57999999999999996,
             frbeam=1.05,
             rmajor=8.8901000000000003,
             dx_tf_inboard_out_toroidal=1.6395161177915356,
@@ -418,7 +418,9 @@ def test_portsz(portszparam, monkeypatch, build):
         current_drive_variables, "dx_beam_shield", portszparam.dx_beam_shield
     )
 
-    monkeypatch.setattr(current_drive_variables, "beamwd", portszparam.beamwd)
+    monkeypatch.setattr(
+        current_drive_variables, "dx_beam_duct", portszparam.dx_beam_duct
+    )
 
     monkeypatch.setattr(current_drive_variables, "frbeam", portszparam.frbeam)
 


### PR DESCRIPTION
* Documentation for the derivation of the beam access has been added to 
`nbi_overview.md`

* Function has been refactorized to take inputs instead of changing globals

### 🔄  Renames

`portsx()` -> `calculate_beam_port_size()`

`rtanbeam` -> `radius_beam_tangency`
`beamwd` -> `dx_beam_duct`
`rtanmax` -> `radius_beam_tangency_max`
`frbeam` -> `f_radius_beam_tangency_rmajor`
`fportsz` -> `fradius_beam_tangency`

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
