### PR TITLE
📝  Add naming convention for stress and strains in style guide

### DIFF
--- a/documentation/development/standards.md
+++ b/documentation/development/standards.md
@@ -406,6 +406,12 @@ The unit declaration `_fpy` can be used to specify that it is the full-power yea
 
 ---------------------
 
+##### Strain
+
+- Strains should start with the `str_` prefix.
+
+---------------------
+
 ##### Forces
 
 - Forces should start with the `forc_` prefix.

--- a/documentation/development/standards.md
+++ b/documentation/development/standards.md
@@ -402,15 +402,30 @@ The unit declaration `_fpy` can be used to specify that it is the full-power yea
 
 ##### Stress
 
-- Stresses should start with the `s_` prefix followed by the type of stress, for example `s_shear_`.
+- Stresses should start with the `stress_` prefix followed by the type of stress, for example `stress_shear_`. Normal stresses are assumed in the `stress_` only case.
+
 
 ---------------------
 
 ##### Strain
 
-- Strains should start with the `str_` prefix.
+- Strains due to normal stresses should start with the `strain_` prefix.
+
+- Strains due to shear stresses should start with the `strain_shear_` prefix.
 
 ---------------------
+
+##### Young's Modulus
+
+- The Young's modulus of materials should start with the `youngmod_` prefix.
+
+---------------------
+
+##### Poisson's ratios
+
+- Poisons ratios for material under stress should start with the `f_poisson_`
+
+--------------------
 
 ##### Forces
 


### PR DESCRIPTION
This pull request updates the coding standards documentation to clarify and expand the naming conventions for mechanical engineering variables. The main changes include new guidelines for strains, Young's modulus, and Poisson's ratios, as well as clarification of existing stress naming conventions.

**Expanded variable naming conventions:**

* Added guidelines for naming strain variables, specifying `strain_` for normal strains and `strain_shear_` for shear strains.
* Introduced the `youngmod_` prefix for Young's modulus variables to standardize material property notation.
* Added the `f_poisson_` prefix for Poisson's ratio variables under stress.
* Renamed the unit for stress `s_` to `stress_`

**Clarifications to existing conventions:**

* Clarified that normal stresses can use the `stress_` prefix alone, while other types should be explicitly named.This pull request updates the documentation standards in `documentation/proc-pages/development/standards.md` to include naming conventions for strains.


<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
