### PR TITLE
Vague cryogenics efficiencies

### DIFF
--- a/process/power.py
+++ b/process/power.py
@@ -2657,23 +2657,6 @@ class Power:
             "(tcoolin)",
             tfcoil_variables.tcoolin,
         )
-        # TODO: Both of these efficiencies are printed when it should be either 13% (ITER) or 40% (Strawbrige) - subset of TODO on line 1118
-        po.ovarre(
-            self.outfile,
-            "Efficiency (figure of merit) of cryogenic plant is 13% of ideal Carnot value:",
-            "",
-            (tfcoil_variables.eff_tf_cryo * tfcoil_variables.temp_tf_cryo)
-            / (constants.temp_room - tfcoil_variables.temp_tf_cryo),
-            "OP ",
-        )
-        po.ovarre(
-            self.outfile,
-            "Efficiency (figure of merit) of cryogenic aluminium plant is 40% of ideal Carnot value:",
-            "",
-            (tfcoil_variables.eff_tf_cryo * tfcoil_variables.tcoolin)
-            / (constants.temp_room - tfcoil_variables.tcoolin),
-            "OP ",
-        )
         po.ovarre(
             self.outfile,
             "Electric power for cryogenic plant (MW)",


### PR DESCRIPTION
## Description

Two efficiencies are calculated as part of the Cryogenics output but these can have unphysical (negative) values. What they actually are and mean is also unclear. As such, they have been removed.

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
