### PR TITLE
Investigate fw blkt coverage 2

### DIFF
--- a/documentation/proc-pages/fusion-devices/stellarator.md
+++ b/documentation/proc-pages/fusion-devices/stellarator.md
@@ -263,7 +263,7 @@ fblli2o = 0.07 *Lithium oxide fraction of blanket by volume (only relevant for m
 fbllipb = 0. *Lithium lead fraction of blanket by volume (only relevant for mass calculations)
 fblss = 0.13 *Stainless steel fraction of blanket by volume (only relevant for mass calculations)
 fblvd = 0. *Vanadium fraction of blanket by volume (only relevant for mass calculations)
-fhole = 0. *Area fraction taken up by other holes (in addition to f_ster_div_single and f_a_fw_hcd when ipowerflow=1)
+fhole = 0. *Area fraction taken up by other holes (in addition to f_ster_div_single and f_a_fw_outboard_hcd when ipowerflow=1)
 fwclfr = 0.1 *First wall coolant fraction (only relevant for mass calculations)
 i_coolant_pumping = 1 *Switch for pumping power (0: User sets pump power directly)
 p_blkt_coolant_pump_mw = 120. *Blanket coolant mechanical pumping power (MW)

--- a/examples/data/csv_output_large_tokamak_MFILE.DAT
+++ b/examples/data/csv_output_large_tokamak_MFILE.DAT
@@ -1108,8 +1108,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/examples/data/large_tokamak_1_MFILE.DAT
+++ b/examples/data/large_tokamak_1_MFILE.DAT
@@ -1103,8 +1103,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/examples/data/large_tokamak_2_MFILE.DAT
+++ b/examples/data/large_tokamak_2_MFILE.DAT
@@ -1103,8 +1103,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/examples/data/large_tokamak_3_MFILE.DAT
+++ b/examples/data/large_tokamak_3_MFILE.DAT
@@ -1103,8 +1103,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/examples/data/large_tokamak_4_MFILE.DAT
+++ b/examples/data/large_tokamak_4_MFILE.DAT
@@ -1103,8 +1103,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/examples/data/scan_MFILE.DAT
+++ b/examples/data/scan_MFILE.DAT
@@ -930,8 +930,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -1925,8 +1925,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -2920,8 +2920,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -3915,8 +3915,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -4910,8 +4910,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -5905,8 +5905,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -6900,8 +6900,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -7895,8 +7895,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -8890,8 +8890,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/process/blanket_library.py
+++ b/process/blanket_library.py
@@ -336,7 +336,7 @@ class BlanketLibrary:
                 * (
                     1.0
                     - 2.0 * fwbs_variables.f_ster_div_single
-                    - fwbs_variables.f_a_fw_hcd
+                    - fwbs_variables.f_a_fw_outboard_hcd
                 )
                 - build_variables.a_blkt_inboard_surface
             )
@@ -344,7 +344,11 @@ class BlanketLibrary:
             # single null configuration
             build_variables.a_blkt_outboard_surface = (
                 build_variables.a_blkt_total_surface
-                * (1.0 - fwbs_variables.f_ster_div_single - fwbs_variables.f_a_fw_hcd)
+                * (
+                    1.0
+                    - fwbs_variables.f_ster_div_single
+                    - fwbs_variables.f_a_fw_outboard_hcd
+                )
                 - build_variables.a_blkt_inboard_surface
             )
 
@@ -355,7 +359,11 @@ class BlanketLibrary:
 
         fwbs_variables.vol_blkt_outboard = (
             fwbs_variables.vol_blkt_total
-            * (1.0 - fwbs_variables.f_ster_div_single - fwbs_variables.f_a_fw_hcd)
+            * (
+                1.0
+                - fwbs_variables.f_ster_div_single
+                - fwbs_variables.f_a_fw_outboard_hcd
+            )
             - fwbs_variables.vol_blkt_inboard
         )
         fwbs_variables.vol_blkt_total = (

--- a/process/build.py
+++ b/process/build.py
@@ -2063,11 +2063,7 @@ class Build:
             )
             build_variables.a_fw_inboard = (
                 build_variables.a_fw_inboard_full_coverage
-                * (
-                    1.0e0
-                    - 2.0e0 * fwbs_variables.f_ster_div_single
-                    - fwbs_variables.f_a_fw_outboard_hcd
-                )
+                * (1.0e0 - 2.0e0 * fwbs_variables.f_ster_div_single)
             )
         else:
             # Single null configuration
@@ -2081,11 +2077,7 @@ class Build:
             )
             build_variables.a_fw_inboard = (
                 build_variables.a_fw_inboard_full_coverage
-                * (
-                    1.0e0
-                    - fwbs_variables.f_ster_div_single
-                    - fwbs_variables.f_a_fw_outboard_hcd
-                )
+                * (1.0e0 - fwbs_variables.f_ster_div_single)
             )
 
         build_variables.a_fw_total = (

--- a/process/build.py
+++ b/process/build.py
@@ -2011,9 +2011,9 @@ class Build:
             #  Calculate surface area, assuming 100% coverage
 
             (
-                build_variables.a_fw_inboard,
-                build_variables.a_fw_outboard,
-                build_variables.a_fw_total,
+                build_variables.a_fw_inboard_full_coverage,
+                build_variables.a_fw_outboard_full_coverage,
+                build_variables.a_fw_total_full_coverage,
             ) = dshellarea(r1, r2, hfw)
 
         else:  # Cross-section is assumed to be defined by two ellipses
@@ -2044,31 +2044,31 @@ class Build:
             #  Calculate surface area, assuming 100% coverage
 
             (
-                build_variables.a_fw_inboard,
-                build_variables.a_fw_outboard,
-                build_variables.a_fw_total,
+                build_variables.a_fw_inboard_full_coverage,
+                build_variables.a_fw_outboard_full_coverage,
+                build_variables.a_fw_total_full_coverage,
             ) = eshellarea(r1, r2, r3, hfw)
 
         #  Apply area coverage factor
 
         if physics_variables.n_divertors == 2:
             # Double null configuration
-            build_variables.a_fw_outboard = build_variables.a_fw_outboard * (
+            build_variables.a_fw_outboard = build_variables.a_fw_outboard_full_coverage * (
                 1.0e0
                 - 2.0e0 * fwbs_variables.f_ster_div_single
                 - fwbs_variables.f_a_fw_hcd
             )
-            build_variables.a_fw_inboard = build_variables.a_fw_inboard * (
+            build_variables.a_fw_inboard = build_variables.a_fw_inboard_full_coverage * (
                 1.0e0
                 - 2.0e0 * fwbs_variables.f_ster_div_single
                 - fwbs_variables.f_a_fw_hcd
             )
         else:
             # Single null configuration
-            build_variables.a_fw_outboard = build_variables.a_fw_outboard * (
+            build_variables.a_fw_outboard = build_variables.a_fw_outboard_full_coverage * (
                 1.0e0 - fwbs_variables.f_ster_div_single - fwbs_variables.f_a_fw_hcd
             )
-            build_variables.a_fw_inboard = build_variables.a_fw_inboard * (
+            build_variables.a_fw_inboard = build_variables.a_fw_inboard_full_coverage * (
                 1.0e0 - fwbs_variables.f_ster_div_single - fwbs_variables.f_a_fw_hcd
             )
 

--- a/process/build.py
+++ b/process/build.py
@@ -2053,23 +2053,39 @@ class Build:
 
         if physics_variables.n_divertors == 2:
             # Double null configuration
-            build_variables.a_fw_outboard = build_variables.a_fw_outboard_full_coverage * (
-                1.0e0
-                - 2.0e0 * fwbs_variables.f_ster_div_single
-                - fwbs_variables.f_a_fw_hcd
+            build_variables.a_fw_outboard = (
+                build_variables.a_fw_outboard_full_coverage
+                * (
+                    1.0e0
+                    - 2.0e0 * fwbs_variables.f_ster_div_single
+                    - fwbs_variables.f_a_fw_outboard_hcd
+                )
             )
-            build_variables.a_fw_inboard = build_variables.a_fw_inboard_full_coverage * (
-                1.0e0
-                - 2.0e0 * fwbs_variables.f_ster_div_single
-                - fwbs_variables.f_a_fw_hcd
+            build_variables.a_fw_inboard = (
+                build_variables.a_fw_inboard_full_coverage
+                * (
+                    1.0e0
+                    - 2.0e0 * fwbs_variables.f_ster_div_single
+                    - fwbs_variables.f_a_fw_outboard_hcd
+                )
             )
         else:
             # Single null configuration
-            build_variables.a_fw_outboard = build_variables.a_fw_outboard_full_coverage * (
-                1.0e0 - fwbs_variables.f_ster_div_single - fwbs_variables.f_a_fw_hcd
+            build_variables.a_fw_outboard = (
+                build_variables.a_fw_outboard_full_coverage
+                * (
+                    1.0e0
+                    - fwbs_variables.f_ster_div_single
+                    - fwbs_variables.f_a_fw_outboard_hcd
+                )
             )
-            build_variables.a_fw_inboard = build_variables.a_fw_inboard_full_coverage * (
-                1.0e0 - fwbs_variables.f_ster_div_single - fwbs_variables.f_a_fw_hcd
+            build_variables.a_fw_inboard = (
+                build_variables.a_fw_inboard_full_coverage
+                * (
+                    1.0e0
+                    - fwbs_variables.f_ster_div_single
+                    - fwbs_variables.f_a_fw_outboard_hcd
+                )
             )
 
         build_variables.a_fw_total = (
@@ -2078,9 +2094,9 @@ class Build:
 
         if build_variables.a_fw_outboard <= 0.0e0:
             raise ProcessValueError(
-                "fhole+f_ster_div_single+f_a_fw_hcd is too high for a credible outboard wall area",
+                "fhole+f_ster_div_single+f_a_fw_outboard_hcd is too high for a credible outboard wall area",
                 f_ster_div_single=fwbs_variables.f_ster_div_single,
-                f_a_fw_hcd=fwbs_variables.f_a_fw_hcd,
+                f_a_fw_outboard_hcd=fwbs_variables.f_a_fw_outboard_hcd,
             )
 
         #

--- a/process/data_structure/build_variables.py
+++ b/process/data_structure/build_variables.py
@@ -102,6 +102,17 @@ fseppc: float = None
 """Separation force in CS coil pre-compression structure"""
 
 
+a_fw_total_full_coverage: float = None
+"""First wall total surface area with no holes or ports [m^2]"""
+
+
+a_fw_inboard_full_coverage: float = None
+"""Inboard first wall surface area with no holes or ports [m^2]"""
+
+
+a_fw_outboard_full_coverage: float = None
+"""Outboard first wall surface area with no holes or ports [m^2]"""
+
 a_fw_total: float = None
 """First wall total surface area [m^2]"""
 
@@ -419,6 +430,9 @@ def init_build_variables():
     global f_avspace
     global fcspc
     global fseppc
+    global a_fw_total_full_coverage
+    global a_fw_inboard_full_coverage
+    global a_fw_outboard_full_coverage
     global a_fw_total
     global a_fw_inboard
     global a_fw_outboard
@@ -511,6 +525,9 @@ def init_build_variables():
     f_avspace = 1.0
     fcspc = 0.6
     fseppc = 3.5e8
+    a_fw_total_full_coverage = 0.0
+    a_fw_inboard_full_coverage = 0.0
+    a_fw_outboard_full_coverage = 0.0
     a_fw_total = 0.0
     a_fw_inboard = 0.0
     a_fw_outboard = 0.0

--- a/process/dcll.py
+++ b/process/dcll.py
@@ -225,9 +225,9 @@ class DCLL(BlanketLibrary):
             )
             po.ovarre(
                 self.outfile,
-                "Fraction of first wall area covered by HCD and diagnostics",
-                "(f_a_fw_hcd)",
-                fwbs_variables.f_a_fw_hcd,
+                "Fraction of outboard first wall area covered by HCD and diagnostics",
+                "(v_tf_coil_dump_quench_max_kv)",
+                fwbs_variables.v_tf_coil_dump_quench_max_kv,
             )
             po.ovarre(self.outfile, "Blanket coverage factor", "(covf)", covf)
 

--- a/process/dcll.py
+++ b/process/dcll.py
@@ -226,8 +226,8 @@ class DCLL(BlanketLibrary):
             po.ovarre(
                 self.outfile,
                 "Fraction of outboard first wall area covered by HCD and diagnostics",
-                "(v_tf_coil_dump_quench_max_kv)",
-                fwbs_variables.v_tf_coil_dump_quench_max_kv,
+                "(f_a_fw_outboard_hcd)",
+                fwbs_variables.f_a_fw_outboard_hcd,
             )
             po.ovarre(self.outfile, "Blanket coverage factor", "(covf)", covf)
 

--- a/process/dcll.py
+++ b/process/dcll.py
@@ -119,11 +119,17 @@ class DCLL(BlanketLibrary):
         if physics_variables.n_divertors == 2:
             # Double null configuration
             covf = (
-                1 - (2 * fwbs_variables.f_ster_div_single) - fwbs_variables.f_a_fw_hcd
+                1
+                - (2 * fwbs_variables.f_ster_div_single)
+                - fwbs_variables.f_a_fw_outboard_hcd
             )
         else:
             # Single null configuration
-            covf = 1 - fwbs_variables.f_ster_div_single - fwbs_variables.f_a_fw_hcd
+            covf = (
+                1
+                - fwbs_variables.f_ster_div_single
+                - fwbs_variables.f_a_fw_outboard_hcd
+            )
 
         # Nuclear heating in the first wall (MW)
         fwbs_variables.p_fw_nuclear_heat_total_mw = (
@@ -179,7 +185,7 @@ class DCLL(BlanketLibrary):
         fwbs_variables.p_fw_hcd_nuclear_heat_mw = 0
         # Radiation power incident on HCD apparatus (MW)
         fwbs_variables.p_fw_hcd_rad_total_mw = (
-            physics_variables.p_plasma_rad_mw * fwbs_variables.f_a_fw_hcd
+            physics_variables.p_plasma_rad_mw * fwbs_variables.f_a_fw_outboard_hcd
         )
 
         # FW

--- a/process/fw.py
+++ b/process/fw.py
@@ -636,7 +636,7 @@ def init_fwbs_variables():
     fwbs_variables.p_blkt_multiplication_mw = 0.0
     fwbs_variables.fblss = 0.09705
     fwbs_variables.f_ster_div_single = 0.115
-    fwbs_variables.f_a_fw_hcd = 0.0
+    fwbs_variables.f_a_fw_outboard_hcd = 0.0
     fwbs_variables.fhole = 0.0
     fwbs_variables.i_fw_blkt_vv_shape = 2
     fwbs_variables.life_fw_fpy = 0.0

--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -1483,9 +1483,9 @@ class CCFE_HCPB(BlanketLibrary):
         )
         po.ovarre(
             self.outfile,
-            "Fraction of first wall area covered by HCD and diagnostics",
-            "(f_a_fw_hcd)",
-            fwbs_variables.f_a_fw_hcd,
+            "Fraction of outboard first wall area covered by HCD and diagnostics",
+            "(v_tf_coil_dump_quench_max_kv)",
+            fwbs_variables.v_tf_coil_dump_quench_max_kv,
         )
         po.ovarin(
             self.outfile,
@@ -1581,9 +1581,15 @@ class CCFE_HCPB(BlanketLibrary):
         )
         po.ovarre(
             self.outfile,
-            "First wall area (m2)",
+            "First wall area (m^2)",
             "(a_fw_total)",
             build_variables.a_fw_total,
+        )
+        po.ovarre(
+            self.outfile,
+            "First wall area, no holes (m^2)",
+            "(a_fw_total_full_coverage)",
+            build_variables.a_fw_total_full_coverage,
         )
         po.ovarre(
             self.outfile,

--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -766,7 +766,7 @@ class CCFE_HCPB(BlanketLibrary):
 
         # Radiation power incident on HCD apparatus (MW)
         fwbs_variables.p_fw_hcd_rad_total_mw = (
-            physics_variables.p_plasma_rad_mw * fwbs_variables.f_a_fw_hcd
+            physics_variables.p_plasma_rad_mw * fwbs_variables.f_a_fw_outboard_hcd
         )
 
         # Radiation power incident on first wall (MW)

--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -1484,8 +1484,8 @@ class CCFE_HCPB(BlanketLibrary):
         po.ovarre(
             self.outfile,
             "Fraction of outboard first wall area covered by HCD and diagnostics",
-            "(v_tf_coil_dump_quench_max_kv)",
-            fwbs_variables.v_tf_coil_dump_quench_max_kv,
+            "(f_a_fw_outboard_hcd)",
+            fwbs_variables.f_a_fw_outboard_hcd,
         )
         po.ovarin(
             self.outfile,

--- a/process/input.py
+++ b/process/input.py
@@ -733,7 +733,9 @@ INPUT_VARIABLES = {
     "feta_cd_norm_hcd_primary_max": InputVariable(
         fortran.constraint_variables, float, range=(0.001, 10.0)
     ),
-    "f_a_fw_hcd": InputVariable(fortran.fwbs_variables, float, range=(0.0, 1.0)),
+    "f_a_fw_outboard_hcd": InputVariable(
+        fortran.fwbs_variables, float, range=(0.0, 1.0)
+    ),
     "fpflux_div_heat_load_mw": InputVariable(
         fortran.constraint_variables, float, range=(0.001, 10.0)
     ),

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -256,7 +256,7 @@ OBS_VARS = {
     "coreradius": "radius_plasma_core_norm",
     "maxradwallload": "pflux_fw_rad_max",
     "fdiv": "f_ster_div_single",
-    "fhcd": "f_a_fw_hcd",
+    "fhcd": "f_a_fw_outboard_hcd",
     "nblktmodti": "n_blkt_inboard_modules_toroidal",
     "nblktmodpo": "n_blkt_outboard_modules_poloidal",
     "nblktmodpi": "n_blkt_inboard_modules_poloidal",

--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -393,6 +393,7 @@ OBS_VARS = {
     "vdalw": "v_tf_coil_dump_quench_max_kv",
     "vvhealw": None,
     "zeffmax": "zeff_max",
+    "f_a_fw_hcd": "f_a_fw_outboard_hcd",
 }
 
 OBS_VARS_HELP = {

--- a/process/io/sankey_funcs.py
+++ b/process/io/sankey_funcs.py
@@ -90,9 +90,9 @@ def plot_full_sankey(
     p_div_rad_total_mw = p_plasma_rad_mw * m_file.data["f_ster_div_single"].get_scan(
         -1
     )  # Radiation deposited on the divertor (MW)
-    p_fw_hcd_rad_total_mw = p_plasma_rad_mw * m_file.data["f_a_fw_hcd"].get_scan(
-        -1
-    )  # Radiation deposited on HCD (MW)
+    p_fw_hcd_rad_total_mw = p_plasma_rad_mw * m_file.data[
+        "f_a_fw_outboard_hcd"
+    ].get_scan(-1)  # Radiation deposited on HCD (MW)
     p_fw_rad_total_mw = (
         p_plasma_rad_mw - p_div_rad_total_mw - p_fw_hcd_rad_total_mw
     )  # Radiation deposited in the FW (MW)
@@ -544,11 +544,11 @@ def plot_sankey(mfilename="MFILE.DAT"):  # Plot simplified power flow Sankey Dia
     p_div_rad_total_mw = (
         p_plasma_rad_mw * f_ster_div_single
     )  # Radiation deposited on the divertor (MW)
-    f_a_fw_hcd = m_file.data["f_a_fw_hcd"].get_scan(
+    f_a_fw_outboard_hcd = m_file.data["f_a_fw_outboard_hcd"].get_scan(
         -1
     )  # Area fraction covered by HCD and diagnostics
     p_fw_hcd_rad_total_mw = (
-        p_plasma_rad_mw * f_a_fw_hcd
+        p_plasma_rad_mw * f_a_fw_outboard_hcd
     )  # Radiation deposited on HCD and diagnostics (MW)
     p_fw_rad_total_mw = (
         p_plasma_rad_mw - p_div_rad_total_mw - p_fw_hcd_rad_total_mw

--- a/process/physics.py
+++ b/process/physics.py
@@ -2246,7 +2246,7 @@ class Physics:
                 physics_variables.pflux_fw_neutron_mw = (
                     (
                         1.0e0
-                        - fwbs_variables.f_a_fw_hcd
+                        - fwbs_variables.f_a_fw_outboard_hcd
                         - 2.0e0 * fwbs_variables.f_ster_div_single
                     )
                     * physics_variables.p_neutron_total_mw
@@ -2257,7 +2257,7 @@ class Physics:
                 physics_variables.pflux_fw_neutron_mw = (
                     (
                         1.0e0
-                        - fwbs_variables.f_a_fw_hcd
+                        - fwbs_variables.f_a_fw_outboard_hcd
                         - fwbs_variables.f_ster_div_single
                     )
                     * physics_variables.p_neutron_total_mw
@@ -2606,14 +2606,14 @@ class Physics:
                 physics_variables.pflux_fw_rad_mw = (
                     (
                         1.0e0
-                        - fwbs_variables.f_a_fw_hcd
+                        - fwbs_variables.f_a_fw_outboard_hcd
                         - 2.0e0 * fwbs_variables.f_ster_div_single
                     )
                     * physics_variables.p_plasma_rad_mw
                     / build_variables.a_fw_total
                     + (
                         1.0e0
-                        - fwbs_variables.f_a_fw_hcd
+                        - fwbs_variables.f_a_fw_outboard_hcd
                         - 2.0e0 * fwbs_variables.f_ster_div_single
                     )
                     * physics_variables.rad_fraction_sol
@@ -2625,14 +2625,14 @@ class Physics:
                 physics_variables.pflux_fw_rad_mw = (
                     (
                         1.0e0
-                        - fwbs_variables.f_a_fw_hcd
+                        - fwbs_variables.f_a_fw_outboard_hcd
                         - fwbs_variables.f_ster_div_single
                     )
                     * physics_variables.p_plasma_rad_mw
                     / build_variables.a_fw_total
                     + (
                         1.0e0
-                        - fwbs_variables.f_a_fw_hcd
+                        - fwbs_variables.f_a_fw_outboard_hcd
                         - fwbs_variables.f_ster_div_single
                     )
                     * physics_variables.rad_fraction_sol

--- a/process/stellarator.py
+++ b/process/stellarator.py
@@ -486,7 +486,7 @@ class Stellarator:
                 1.0e0
                 - fwbs_variables.fhole
                 - fwbs_variables.f_ster_div_single
-                - fwbs_variables.f_a_fw_hcd
+                - fwbs_variables.f_a_fw_outboard_hcd
             ) * build_variables.a_fw_total
 
         if output:
@@ -1151,7 +1151,7 @@ class Stellarator:
                     1.0e0
                     - fwbs_variables.fhole
                     - fwbs_variables.f_ster_div_single
-                    - fwbs_variables.f_a_fw_hcd
+                    - fwbs_variables.f_a_fw_outboard_hcd
                 )
             )
 
@@ -1218,7 +1218,8 @@ class Stellarator:
                     * fwbs_variables.f_ster_div_single
                 )
                 fwbs_variables.p_fw_hcd_nuclear_heat_mw = (
-                    physics_variables.p_neutron_total_mw * fwbs_variables.f_a_fw_hcd
+                    physics_variables.p_neutron_total_mw
+                    * fwbs_variables.f_a_fw_outboard_hcd
                 )
                 fwbs_variables.p_fw_nuclear_heat_total_mw = (
                     physics_variables.p_neutron_total_mw
@@ -1234,7 +1235,8 @@ class Stellarator:
                     physics_variables.p_plasma_rad_mw * fwbs_variables.f_ster_div_single
                 )
                 fwbs_variables.p_fw_hcd_rad_total_mw = (
-                    physics_variables.p_plasma_rad_mw * fwbs_variables.f_a_fw_hcd
+                    physics_variables.p_plasma_rad_mw
+                    * fwbs_variables.f_a_fw_outboard_hcd
                 )
                 fwbs_variables.p_fw_rad_total_mw = (
                     physics_variables.p_plasma_rad_mw
@@ -1340,7 +1342,8 @@ class Stellarator:
                 #  Neutron power incident on HCD apparatus (MW)
 
                 fwbs_variables.p_fw_hcd_nuclear_heat_mw = (
-                    physics_variables.p_neutron_total_mw * fwbs_variables.f_a_fw_hcd
+                    physics_variables.p_neutron_total_mw
+                    * fwbs_variables.f_a_fw_outboard_hcd
                 )
 
                 #  Neutron power deposited in first wall, blanket and shield (MW)
@@ -1373,7 +1376,8 @@ class Stellarator:
                 #  Radiation power incident on HCD apparatus (MW)
 
                 fwbs_variables.p_fw_hcd_rad_total_mw = (
-                    physics_variables.p_plasma_rad_mw * fwbs_variables.f_a_fw_hcd
+                    physics_variables.p_plasma_rad_mw
+                    * fwbs_variables.f_a_fw_outboard_hcd
                 )
 
                 #  Radiation power lost through holes (eventually hits shield) (MW)
@@ -4403,7 +4407,7 @@ class Stellarator:
                     (
                         1.0e0
                         - fwbs_variables.fhole
-                        - fwbs_variables.f_a_fw_hcd
+                        - fwbs_variables.f_a_fw_outboard_hcd
                         - fwbs_variables.f_ster_div_single
                     )
                     * physics_variables.p_neutron_total_mw
@@ -4533,7 +4537,7 @@ class Stellarator:
                     (
                         1.0e0
                         - fwbs_variables.fhole
-                        - fwbs_variables.f_a_fw_hcd
+                        - fwbs_variables.f_a_fw_outboard_hcd
                         - fwbs_variables.f_ster_div_single
                     )
                     * physics_variables.p_plasma_rad_mw

--- a/source/fortran/fwbs_variables.f90
+++ b/source/fortran/fwbs_variables.f90
@@ -50,7 +50,7 @@ module fwbs_variables
   real(dp) :: f_ster_div_single
   !! Solid angle fraction taken by one divertor
 
-  real(dp) :: f_a_fw_hcd
+  real(dp) :: f_a_fw_outboard_hcd
   !! area fraction of first wall covered by heating/current drive apparatus plus diagnostics
 
   real(dp) :: fhole

--- a/tests/integration/data/large_tokamak_1_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_1_MFILE.DAT
@@ -1102,8 +1102,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/tests/integration/data/large_tokamak_2_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_2_MFILE.DAT
@@ -1103,8 +1103,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/tests/integration/data/large_tokamak_3_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_3_MFILE.DAT
@@ -1103,8 +1103,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/tests/integration/data/large_tokamak_4_MFILE.DAT
+++ b/tests/integration/data/large_tokamak_4_MFILE.DAT
@@ -1103,8 +1103,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/tests/integration/data/scan_2D_MFILE.DAT
+++ b/tests/integration/data/scan_2D_MFILE.DAT
@@ -1104,8 +1104,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -2267,8 +2267,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -3430,8 +3430,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -4593,8 +4593,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -5756,8 +5756,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -6919,8 +6919,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -8082,8 +8082,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -9245,8 +9245,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -10408,8 +10408,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -11571,8 +11571,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -12734,8 +12734,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -13897,8 +13897,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -15060,8 +15060,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -16223,8 +16223,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -17386,8 +17386,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/tests/integration/data/scan_MFILE.DAT
+++ b/tests/integration/data/scan_MFILE.DAT
@@ -930,8 +930,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -1925,8 +1925,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -2920,8 +2920,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -3915,8 +3915,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -4910,8 +4910,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -5905,8 +5905,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -6900,8 +6900,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -7895,8 +7895,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 
@@ -8890,8 +8890,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/tests/regression/input_files/st_regression.IN.DAT
+++ b/tests/regression/input_files/st_regression.IN.DAT
@@ -2306,7 +2306,7 @@ i_fw_coolant_type = helium
 * DESCRIPTION:   First wall coolant fraction (calculated if `i_pulsed_plant=1` or `ipowerflow=1`)
 * JUSTIFICATION: Not using ipowerflow = 1
 
-*f_a_fw_hcd = 
+*f_a_fw_outboard_hcd = 
 * DESCRIPTION:   Area fraction covered by heating/current drive apparatus plus diagnostics
 * JUSTIFICATION: Not yet set
 

--- a/tests/unit/data/large_tokamak_MFILE.DAT
+++ b/tests/unit/data/large_tokamak_MFILE.DAT
@@ -1106,8 +1106,8 @@
  # Plant Power / Heat Transport Balance #
  Neutron_power_multiplication_in_blanket_________________________________ (f_p_blkt_multiplication)_______________________      1.2690E+00    
  Divertor_area_fraction_of_whole_toroid_surface__________________________ (f_ster_div_single)________________________      1.1500E-01    
- H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_hcd)________________________      0.0000E+00    
- First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_hcd)_________________      8.8500E-01    
+ H/CD_apparatus_+_diagnostics_area_fraction______________________________ (f_a_fw_outboard_hcd)________________________      0.0000E+00    
+ First_wall_area_fraction________________________________________________ (1-f_ster_div_single-f_a_fw_outboard_hcd)_________________      8.8500E-01    
  Switch_for_pumping_of_primary_coolant___________________________________ (i_coolant_pumping)_____________              3    
  Mechanical_pumping_power_for_FW_cooling_loop_including_heat_exchanger_(M (p_fw_coolant_pump_mw)____________________      0.0000E+00 OP 
  Mechanical_pumping_power_for_blanket_cooling_loop_including_heat_exchang (p_blkt_coolant_pump_mw)__________________      0.0000E+00 OP 

--- a/tests/unit/test_blanket_library.py
+++ b/tests/unit/test_blanket_library.py
@@ -1246,7 +1246,7 @@ class ApplyCoverageFactorsParam(NamedTuple):
     a_shld_outboard_surface: Any = None
     a_shld_total_surface: Any = None
     f_ster_div_single: Any = None
-    f_a_fw_hcd: Any = None
+    f_a_fw_outboard_hcd: Any = None
     vol_blkt_outboard: Any = None
     vol_blkt_inboard: Any = None
     vol_blkt_total: Any = None
@@ -1280,7 +1280,7 @@ class ApplyCoverageFactorsParam(NamedTuple):
             a_shld_outboard_surface=1344.1106481995357,
             a_shld_total_surface=2044.1779608740142,
             f_ster_div_single=0.115,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             vol_blkt_outboard=1020.3677420460117,
             vol_blkt_inboard=315.83946385183026,
             vol_blkt_total=1336.207205897842,
@@ -1352,7 +1352,9 @@ def test_apply_coverage_factors(
         fwbs_variables, "f_ster_div_single", applycoveragefactorsparam.f_ster_div_single
     )
     monkeypatch.setattr(
-        fwbs_variables, "f_a_fw_hcd", applycoveragefactorsparam.f_a_fw_hcd
+        fwbs_variables,
+        "f_a_fw_outboard_hcd",
+        applycoveragefactorsparam.f_a_fw_outboard_hcd,
     )
     monkeypatch.setattr(
         fwbs_variables, "vol_blkt_outboard", applycoveragefactorsparam.vol_blkt_outboard

--- a/tests/unit/test_ccfe_hcpb.py
+++ b/tests/unit/test_ccfe_hcpb.py
@@ -720,7 +720,7 @@ class PowerflowCalcParam(NamedTuple):
 
     p_fw_hcd_rad_total_mw: Any = None
 
-    f_a_fw_hcd: Any = None
+    f_a_fw_outboard_hcd: Any = None
 
     p_fw_rad_total_mw: Any = None
 
@@ -809,7 +809,7 @@ class PowerflowCalcParam(NamedTuple):
             f_ster_div_single=0.115,
             p_div_rad_total_mw=0,
             p_fw_hcd_rad_total_mw=0,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             p_fw_rad_total_mw=0,
             i_blkt_coolant_type=1,
             temp_blkt_coolant_out=823,
@@ -856,7 +856,7 @@ class PowerflowCalcParam(NamedTuple):
             f_ster_div_single=0.115,
             p_div_rad_total_mw=33.056596978820579,
             p_fw_hcd_rad_total_mw=0,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             p_fw_rad_total_mw=254.39207240222791,
             i_blkt_coolant_type=1,
             temp_blkt_coolant_out=823,
@@ -937,7 +937,9 @@ def test_powerflow_calc(powerflowcalcparam, monkeypatch, ccfe_hcpb):
         powerflowcalcparam.p_fw_hcd_rad_total_mw,
     )
 
-    monkeypatch.setattr(fwbs_variables, "f_a_fw_hcd", powerflowcalcparam.f_a_fw_hcd)
+    monkeypatch.setattr(
+        fwbs_variables, "f_a_fw_outboard_hcd", powerflowcalcparam.f_a_fw_outboard_hcd
+    )
 
     monkeypatch.setattr(
         fwbs_variables, "p_fw_rad_total_mw", powerflowcalcparam.p_fw_rad_total_mw

--- a/tests/unit/test_dcll.py
+++ b/tests/unit/test_dcll.py
@@ -35,7 +35,7 @@ class DcllNeutronicsAndPowerParam(NamedTuple):
 
     p_div_nuclear_heat_total_mw: Any = None
 
-    f_a_fw_hcd: Any = None
+    f_a_fw_outboard_hcd: Any = None
 
     p_fw_hcd_rad_total_mw: Any = None
 
@@ -94,7 +94,7 @@ class DcllNeutronicsAndPowerParam(NamedTuple):
             f_ster_div_single=0.115,
             p_div_rad_total_mw=0,
             p_div_nuclear_heat_total_mw=0,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             p_fw_hcd_rad_total_mw=0,
             p_fw_hcd_nuclear_heat_mw=0,
             p_shld_nuclear_heat_mw=0,
@@ -126,7 +126,7 @@ class DcllNeutronicsAndPowerParam(NamedTuple):
             f_ster_div_single=0.115,
             p_div_rad_total_mw=33.056596978820579,
             p_div_nuclear_heat_total_mw=182.58994516305046,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             p_fw_hcd_rad_total_mw=0,
             p_fw_hcd_nuclear_heat_mw=0,
             p_shld_nuclear_heat_mw=0,
@@ -199,7 +199,9 @@ def test_dcll_neutronics_and_power(dcllneutronicsandpowerparam, monkeypatch, dcl
     )
 
     monkeypatch.setattr(
-        fwbs_variables, "f_a_fw_hcd", dcllneutronicsandpowerparam.f_a_fw_hcd
+        fwbs_variables,
+        "f_a_fw_outboard_hcd",
+        dcllneutronicsandpowerparam.f_a_fw_outboard_hcd,
     )
 
     monkeypatch.setattr(

--- a/tests/unit/test_power.py
+++ b/tests/unit/test_power.py
@@ -2106,7 +2106,7 @@ class Power2Param(NamedTuple):
 
     f_ster_div_single: Any = None
 
-    f_a_fw_hcd: Any = None
+    f_a_fw_outboard_hcd: Any = None
 
     i_thermal_electric_conversion: Any = None
 
@@ -2298,7 +2298,7 @@ class Power2Param(NamedTuple):
             f_p_blkt_multiplication=1.2690000534057617,
             p_div_rad_total_mw=33.119482558354782,
             f_ster_div_single=0.115,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             i_thermal_electric_conversion=2,
             pnuc_cp=0,
             p_div_nuclear_heat_total_mw=182.69222981118057,
@@ -2400,7 +2400,7 @@ class Power2Param(NamedTuple):
             f_p_blkt_multiplication=1.2690000534057617,
             p_div_rad_total_mw=33.119482558354782,
             f_ster_div_single=0.115,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             i_thermal_electric_conversion=2,
             pnuc_cp=0,
             p_div_nuclear_heat_total_mw=182.6352084763719,
@@ -2555,7 +2555,9 @@ def test_power2(power2param, monkeypatch, power):
         fwbs_variables, "f_ster_div_single", power2param.f_ster_div_single
     )
 
-    monkeypatch.setattr(fwbs_variables, "f_a_fw_hcd", power2param.f_a_fw_hcd)
+    monkeypatch.setattr(
+        fwbs_variables, "f_a_fw_outboard_hcd", power2param.f_a_fw_outboard_hcd
+    )
 
     monkeypatch.setattr(
         fwbs_variables,

--- a/tests/unit/test_stellarator.py
+++ b/tests/unit/test_stellarator.py
@@ -298,7 +298,7 @@ class StbildParam(NamedTuple):
 
     f_ster_div_single: Any = None
 
-    f_a_fw_hcd: Any = None
+    f_a_fw_outboard_hcd: Any = None
 
     fhole: Any = None
 
@@ -400,7 +400,7 @@ class StbildParam(NamedTuple):
             radius_fw_channel=0.0060000000000000001,
             blktmodel=0,
             f_ster_div_single=0.115,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             fhole=0,
             dr_fw_wall=0.0030000000000000001,
             ipowerflow=1,
@@ -470,7 +470,7 @@ class StbildParam(NamedTuple):
             radius_fw_channel=0.0060000000000000001,
             blktmodel=0,
             f_ster_div_single=0.021924555536480182,
-            f_a_fw_hcd=0,
+            f_a_fw_outboard_hcd=0,
             fhole=0,
             dr_fw_wall=0.0030000000000000001,
             ipowerflow=1,
@@ -621,7 +621,9 @@ def test_stbild(stbildparam, monkeypatch, stellarator):
         fwbs_variables, "f_ster_div_single", stbildparam.f_ster_div_single
     )
 
-    monkeypatch.setattr(fwbs_variables, "f_a_fw_hcd", stbildparam.f_a_fw_hcd)
+    monkeypatch.setattr(
+        fwbs_variables, "f_a_fw_outboard_hcd", stbildparam.f_a_fw_outboard_hcd
+    )
 
     monkeypatch.setattr(fwbs_variables, "fhole", stbildparam.fhole)
 


### PR DESCRIPTION
This pull request updates the naming of a key variable related to the area fraction for H/CD apparatus and diagnostics in both the codebase and associated data files, improving clarity and consistency. The changes ensure that the variable now specifically refers to the outboard side, which should help avoid confusion in future development and data analysis.

✨ New variables 

`a_fw_inboard_full_coverage`
`a_fw_outboard_full_coverage`
`a_fw_total_full_coverage`

🔄 Renames

`f_a_fw_hcd` -> `f_a_fw_outboard_hcd`


Variable renaming and consistency:

* Renamed the variable `f_a_fw_hcd` to `f_a_fw_outboard_hcd` throughout the code in `process/blanket_library.py`, ensuring all calculations for area and volume fractions consistently use the new name.
* Updated all example data files (`examples/data/*.DAT`) to use `f_a_fw_outboard_hcd` instead of `f_a_fw_hcd` for the H/CD apparatus and diagnostics area fraction, and adjusted the corresponding first wall area fraction calculation to reference the new variable. 

Documentation update:

* Updated the description for `fhole` in `documentation/proc-pages/fusion-devices/stellarator.md` to reference `f_a_fw_outboard_hcd` instead of the old variable name, ensuring documentation matches the code and data files.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
