### PR TITLE
Update portsz 1

### DIFF
--- a/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
+++ b/documentation/proc-pages/eng-models/heating_and_current_drive/NBI/nbi_overview.md
@@ -55,7 +55,7 @@ $$
 g = \sqrt{e^2+f^2-2ef\cos{\phi}}
 $$
 
-If the value of $g$ is geater than $c$, then:
+If the value of $g$ is greater than $c$, then:
 
 $$
 h = \sqrt{g^2-c^2}


### PR DESCRIPTION
This pull request primarily focuses on improving the clarity and consistency of variable naming in documentation and example data files related to neutral beam injection (NBI) models. It also introduces a detailed explanation of the beam tangency radius calculation and updates associated constraints.

### Documentation updates:

* **Variable renaming for clarity**:
  - Renamed `frbeam` to `f_radius_beam_tangency_rmajor` in `culham_nb.md` to better describe its purpose as the ratio of beam tangency radius to plasma major radius. This change is consistently applied across equations and descriptions. [[1]](diffhunk://#diff-e6390dd2a4be327bc3f6df6e1455ec02649d0fb6a3ababec6e862dcbcd2f249fL19-R32) [[2]](diffhunk://#diff-e6390dd2a4be327bc3f6df6e1455ec02649d0fb6a3ababec6e862dcbcd2f249fL76-R76) [[3]](diffhunk://#diff-e6390dd2a4be327bc3f6df6e1455ec02649d0fb6a3ababec6e862dcbcd2f249fL172-R172) [[4]](diffhunk://#diff-e6390dd2a4be327bc3f6df6e1455ec02649d0fb6a3ababec6e862dcbcd2f249fL181-R181) [[5]](diffhunk://#diff-e6390dd2a4be327bc3f6df6e1455ec02649d0fb6a3ababec6e862dcbcd2f249fL216-R216)

* **Beam tangency radius explanation**:
  - Added a detailed explanation of the calculation for the maximum possible tangency radius (`radius_beam_tangency_max`) in `nbi_overview.md`. This includes geometric considerations and constraints based on TF coil dimensions.

### Example data files updates:

* **Variable renaming in example files**:
  - Updated variable name `beamwd` to `dx_beam_duct` in multiple example data files to align with the updated naming convention for the width of the neutral beam duct. 

These changes improve the readability and consistency of the documentation and example data files, making it easier for users to understand and work with the NBI models.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
