### PR TITLE
Raise exception if GitHub API error occurs

### DIFF
--- a/tests/regression/regression_test_assets.py
+++ b/tests/regression/regression_test_assets.py
@@ -87,10 +87,12 @@ class RegressionTestAssetCollector:
         hashes returned from `_git_commit_hashes`.
         :rtype: list[TrackedMFile]
         """
-        repository_files = requests.get(
+        repository_files_request = requests.get(
             f"https://api.github.com/repos/"
             f"{self.remote_repository_owner}/{self.remote_repository_repo}/git/trees/master"
-        ).json()["tree"]
+        )
+        repository_files_request.raise_for_status()
+        repository_files = repository_files_request.json()["tree"]
 
         # create a list of tracked MFiles from the list of all files
         # in the remote repository.


### PR DESCRIPTION
Makes the error more visible when the GitHub rate limit causes the regression tests to fail

<img width="1046" height="508" alt="image" src="https://github.com/user-attachments/assets/89e6cc6c-1a04-4cbe-98b0-6db1f0f60d04" />
https://github.com/ukaea/PROCESS/actions/runs/16324133834/job/46160359860?pr=3722