### PR TITLE
♻️ Refactor toroidal field coil models to support copper and aluminium

### DIFF
--- a/process/caller.py
+++ b/process/caller.py
@@ -261,12 +261,15 @@ class Caller:
         # Toroidal field coil model
 
         # Toroidal field coil resistive model
-        if ft.tfcoil_variables.i_tf_sup != 1:
-            self.models.resistive_tf_coil.run(output=False)
+        if ft.tfcoil_variables.i_tf_sup == 0:
+            self.models.copper_tf_coil.run(output=False)
 
         # Toroidal field coil superconductor model
         if ft.tfcoil_variables.i_tf_sup == 1:
             self.models.sctfcoil.run(output=False)
+
+        if ft.tfcoil_variables.i_tf_sup == 2:
+            self.models.aluminium_tf_coil.run(output=False)
 
         # Poloidal field and central solenoid model
         self.models.pfcoil.run()

--- a/process/main.py
+++ b/process/main.py
@@ -93,7 +93,7 @@ from process.plasma_geometry import PlasmaGeom
 from process.plasma_profiles import PlasmaProfile
 from process.power import Power
 from process.pulse import Pulse
-from process.resistive_tf_coil import ResistiveTFCoil
+from process.resistive_tf_coil import AluminiumTFCoil, CopperTFCoil, ResistiveTFCoil
 from process.scan import Scan
 from process.stellarator import Neoclassics, Stellarator
 from process.structure import Structure
@@ -656,6 +656,8 @@ class Models:
         self.sctfcoil = SuperconductingTFCoil()
         self.tfcoil = TFCoil(build=self.build)
         self.resistive_tf_coil = ResistiveTFCoil()
+        self.copper_tf_coil = CopperTFCoil()
+        self.aluminium_tf_coil = AluminiumTFCoil()
         self.divertor = Divertor()
         self.structure = Structure()
         self.plasma_geom = PlasmaGeom()

--- a/process/output.py
+++ b/process/output.py
@@ -61,13 +61,17 @@ def write(models, _outfile):
     # Cryostat build
     models.cryostat.cryostat_output()
 
-    # Toroidal field coil resistive model
-    if ft.tfcoil_variables.i_tf_sup != 1:
-        models.resistive_tf_coil.run(output=True)
+    # Toroidal field coil copper model
+    if ft.tfcoil_variables.i_tf_sup == 0:
+        models.copper_tf_coil.run(output=True)
 
     # Toroidal field coil superconductor model
     if ft.tfcoil_variables.i_tf_sup == 1:
         models.sctfcoil.run(output=True)
+
+    # Toroidal field coil aluminium model
+    if ft.tfcoil_variables.i_tf_sup == 2:
+        models.aluminium_tf_coil.run(output=True)
 
     # Tight aspect ratio machine model
     if ft.physics_variables.itart == 1 and ft.tfcoil_variables.i_tf_sup != 1:

--- a/process/resistive_tf_coil.py
+++ b/process/resistive_tf_coil.py
@@ -1005,3 +1005,29 @@ class ResistiveTFCoil(TFCoil):
             vol_case_cp,
             vol_gr_ins_cp,
         )
+
+
+class CopperTFCoil(ResistiveTFCoil):
+    """
+    Copper TF coil class for resistive TF coil calculations.
+    Inherits from ResistiveTFCoil and implements specific methods for copper TF coils.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def run(self, output: bool):
+        super().run(output)
+
+
+class AluminiumTFCoil(ResistiveTFCoil):
+    """
+    Aluminium TF coil class for resistive TF coil calculations.
+    Inherits from ResistiveTFCoil and implements specific methods for aluminium TF coils.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def run(self, output: bool):
+        super().run(output)


### PR DESCRIPTION
This pull request introduces support for additional Toroidal Field (TF) coil models, specifically for copper and aluminum TF coils, alongside the existing resistive and superconducting TF coil models. The changes ensure that the appropriate model is invoked based on the `i_tf_sup` variable, enhancing the flexibility of the system.

### Enhancements to TF Coil Models:

* **Conditional logic updates to support new TF coil types**:
  - Updated `_call_models_once` in `process/caller.py` to invoke `CopperTFCoil` when `i_tf_sup == 0` and `AluminiumTFCoil` when `i_tf_sup == 2`.
  - Updated `write` in `process/output.py` to include copper and aluminum TF coil models in the output generation process.

* **New classes for copper and aluminum TF coils**:
  - Added `CopperTFCoil` and `AluminiumTFCoil` classes in `process/resistive_tf_coil.py`, inheriting from `ResistiveTFCoil` and implementing specific methods for these materials.

### Codebase Adjustments for New Models:

* **Initialization of new TF coil models**:
  - Modified `__init__` in `process/main.py` to instantiate `CopperTFCoil` and `AluminiumTFCoil` objects.

* **Import statements updated**:
  - Updated imports in `process/main.py` to include `CopperTFCoil` and `AluminiumTFCoil`.…ypes

## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
