### PR TITLE
🎨 Add plotting for resistive TF in `plot_proc`

### DIFF
--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -5576,13 +5576,19 @@ def plot_resistive_tf_wp(axis, mfile_data, scan: int, fig) -> None:
     axis.plot(x13, y13, color="black")
     axis.plot(x14, y14, color="black")
 
+    # Choose color based on i_tf_sup: copper for resistive, aluminium for cryo
+    if mfile_data.data["i_tf_sup"].get_scan(scan) == 2:
+        wp_color = "#b0c4de"  # light steel blue (cryo aluminium)
+    else:
+        wp_color = "#b87333"  # copper color
+
     axis.fill_between(
         [
             (r_tf_wp_inboard_inner + dx_tf_wp_insulation) * np.cos(theta_vals[0]),
             (r_tf_wp_inboard_outer - dx_tf_wp_insulation) * np.cos(theta_vals[0]),
         ],
         y13,
-        color="#b87333",  # copper color
+        color=wp_color,
     )
     # Lower main
     axis.fill_between(
@@ -5591,12 +5597,12 @@ def plot_resistive_tf_wp(axis, mfile_data, scan: int, fig) -> None:
             (r_tf_wp_inboard_outer - dx_tf_wp_insulation) * np.cos(theta_vals[-1]),
         ],
         y14,
-        color="#b87333",  # copper color
+        color=wp_color,
     )
     axis.fill_between(
         x12,
         y12,
-        color="#b87333",  # copper color
+        color=wp_color,
     )
 
     # ================================================================
@@ -5710,11 +5716,13 @@ def plot_resistive_tf_wp(axis, mfile_data, scan: int, fig) -> None:
     textstr_wp_insulation = (
         f"$\\mathbf{{Insulation:}}$\n \n"
         f"Area of insulation around WP: {mfile_data.data['a_tf_wp_ground_insulation'].get_scan(scan):.3f} $\\mathrm{{m}}^2$\n"
-        f"$\\Delta r$: {mfile_data.data['dx_tf_wp_insulation'].get_scan(scan):.4f} m"
+        f"$\\Delta r$: {mfile_data.data['dx_tf_wp_insulation'].get_scan(scan):.4f} m\n\n"
+        f"$\\text{{Turn Insulation:}}$\n"
+        f"$\\Delta r$: {mfile_data.data['dx_tf_turn_insulation'].get_scan(scan):.4f} m"
     )
     axis.text(
         0.775,
-        0.6,
+        0.62,
         textstr_wp_insulation,
         fontsize=9,
         verticalalignment="top",
@@ -5736,11 +5744,14 @@ def plot_resistive_tf_wp(axis, mfile_data, scan: int, fig) -> None:
         f"$r_{{start}} \\rightarrow r_{{end}}$: {mfile_data.data['r_tf_wp_inboard_inner'].get_scan(scan):.3f} $\\rightarrow$ {mfile_data.data['r_tf_wp_inboard_outer'].get_scan(scan):.3f} m\n"
         f"$\\Delta r$: {mfile_data.data['dr_tf_wp_with_insulation'].get_scan(scan):.3f} m\n"
         f"$A$, with insulation: {mfile_data.data['a_tf_wp_with_insulation'].get_scan(scan):.3f} $\\mathrm{{m}}^2$\n"
-        f"$A$, no insulation: {mfile_data.data['a_tf_wp_no_insulation'].get_scan(scan):.3f} $\\mathrm{{m}}^2$"
+        f"$A$, no insulation: {mfile_data.data['a_tf_wp_no_insulation'].get_scan(scan):.3f} $\\mathrm{{m}}^2$\n\n"
+        f"Current per turn: {mfile_data.data['c_tf_turn'].get_scan(scan) / 1e3:.3f} $\\mathrm{{kA}}$\n"
+        f"Resistive conductor per coil: {mfile_data.data['a_res_tf_coil_conductor'].get_scan(scan):.3f} $\\mathrm{{m}}^2$\n"
+        f"Coolant area void fraction per turn: {mfile_data.data['fcoolcp'].get_scan(scan):.3f}"
     )
     axis.text(
-        0.775,
-        0.5,
+        0.77,
+        0.475,
         textstr_wp,
         fontsize=9,
         verticalalignment="top",
@@ -5763,7 +5774,7 @@ def plot_resistive_tf_wp(axis, mfile_data, scan: int, fig) -> None:
     )
     axis.text(
         0.55,
-        0.5,
+        0.475,
         textstr_general_info,
         fontsize=9,
         verticalalignment="top",
@@ -5785,6 +5796,17 @@ def plot_resistive_tf_wp(axis, mfile_data, scan: int, fig) -> None:
     axis.set_xlabel("Radial distance [m]")
     axis.set_ylabel("Toroidal distance [m]")
     axis.legend(loc="upper left")
+
+    axis.text(
+        0.05,
+        0.975,
+        "*Turn insulation and cooling pipes not shown",
+        fontsize=9,
+        verticalalignment="top",
+        horizontalalignment="left",
+        color="black",
+        transform=fig.transFigure,
+    )
 
 
 def plot_tf_turn(axis, mfile_data, scan: int) -> None:

--- a/process/resistive_tf_coil.py
+++ b/process/resistive_tf_coil.py
@@ -388,7 +388,7 @@ class ResistiveTFCoil(TFCoil):
         )
 
         # Exact mid-plane cross-section area of the conductor per TF coil [m2]
-        a_tf_cond = np.pi * (
+        tfcoil_variables.a_res_tf_coil_conductor = np.pi * (
             (
                 sctfcoil_module.r_tf_wp_inboard_outer
                 - tfcoil_variables.dx_tf_wp_insulation
@@ -412,12 +412,16 @@ class ResistiveTFCoil(TFCoil):
             tfcoil_variables.dx_tf_wp_insulation
             + tfcoil_variables.dx_tf_turn_insulation * tfcoil_variables.n_tf_coil_turns
         )
-        a_tf_cond = a_tf_cond * (1.0e0 - tfcoil_variables.fcoolcp)
+        tfcoil_variables.a_res_tf_coil_conductor = (
+            tfcoil_variables.a_res_tf_coil_conductor
+            * (1.0e0 - tfcoil_variables.fcoolcp)
+        )
 
         # Inter turn insulation area per coil [m2]
         tfcoil_variables.a_tf_coil_wp_turn_insulation = (
             sctfcoil_module.a_tf_wp_no_insulation
-            - a_tf_cond / (1.0e0 - tfcoil_variables.fcoolcp)
+            - tfcoil_variables.a_res_tf_coil_conductor
+            / (1.0e0 - tfcoil_variables.fcoolcp)
         )
 
         # Total insulation cross-section per coil [m2]

--- a/process/tf_coil.py
+++ b/process/tf_coil.py
@@ -1441,9 +1441,21 @@ class TFCoil:
             )
             po.ovarre(
                 self.outfile,
+                "Inboard leg plasma case area (m^2)",
+                "(a_tf_plasma_case)",
+                sctfcoil_module.a_tf_plasma_case,
+            )
+            po.ovarre(
+                self.outfile,
                 "Inboard leg bucking cylinder thickness (m)",
                 "(dr_tf_nose_case)",
                 tfcoil_variables.dr_tf_nose_case,
+            )
+            po.ovarre(
+                self.outfile,
+                'Inboard leg case inboard "nose" area (m^2)',
+                "(a_tf_coil_nose_case)",
+                sctfcoil_module.a_tf_coil_nose_case,
             )
 
             # Conductor layer geometry
@@ -1459,6 +1471,12 @@ class TFCoil:
                 "Inboard TFC conductor sector area, NO ground & gap (per leg) (m2)",
                 "(a_tf_wp_no_insulation)",
                 sctfcoil_module.a_tf_wp_no_insulation,
+            )
+            po.ovarre(
+                self.outfile,
+                "Ground wall insulation area (m^2)",
+                "(a_tf_wp_ground_insulation)",
+                sctfcoil_module.a_tf_wp_ground_insulation,
             )
             po.ovarre(
                 self.outfile,

--- a/process/tf_coil.py
+++ b/process/tf_coil.py
@@ -5473,6 +5473,7 @@ def init_tfcoil_variables():
     tfv.a_tf_coil_outboard_case = 0.0
     tfv.a_tf_turn_steel = 0.0
     tfv.a_tf_wp_conductor = 0.0
+    tfv.a_res_tf_coil_conductor = 0.0
     tfv.a_tf_turn_cable_space_no_void = 0.0
     tfv.a_tf_turn_insulation = 0.0
     tfv.a_tf_coil_wp_turn_insulation = 0.0

--- a/process/tf_coil.py
+++ b/process/tf_coil.py
@@ -1520,6 +1520,12 @@ class TFCoil:
             )
             po.ovarre(
                 self.outfile,
+                "Area of resistive conductor per coil",
+                "(a_res_tf_coil_conductor)",
+                tfcoil_variables.a_res_tf_coil_conductor,
+            )
+            po.ovarre(
+                self.outfile,
                 "Outboard leg current per turn (A)",
                 "(c_tf_turn)",
                 tfcoil_variables.c_tf_turn,

--- a/source/fortran/tfcoil_variables.f90
+++ b/source/fortran/tfcoil_variables.f90
@@ -28,6 +28,10 @@ module tfcoil_variables
   !! Winding pack conductor area [m2]
   !! Does not include the area of voids and central helium channel
 
+  real(dp) :: a_res_tf_coil_conductor
+  !! Area of resistive conductor in resistive TF coil [m2]
+
+
   real(dp) :: a_tf_turn_cable_space_no_void
   !! Cable space area (per turn)  [m2]
   !! Includes the area of voids and central helium channel


### PR DESCRIPTION
This PR adds the plotting of resistive TF coil structures to `plot_proc.py`. It is not perfect but finally allows coils to be seen

### ✨ New variables

`a_res_tf_coil_conductor`

**Resistive conductor area variable integration:**

* Added `a_res_tf_coil_conductor` to the `tfcoil_variables` Fortran module to store the area of the resistive conductor in the TF coil.
* Initialized `a_res_tf_coil_conductor` in the `init_tfcoil_variables` function in `tf_coil.py`.
* Updated `res_tf_internal_geom` in `resistive_tf_coil.py` to compute and assign the resistive conductor area to `tfcoil_variables.a_res_tf_coil_conductor` instead of a local variable, and updated downstream calculations to use this field. 

**Output and reporting improvements:**

* Added output of `a_res_tf_coil_conductor` and other new geometry variables (such as `a_tf_plasma_case`, `a_tf_coil_nose_case`, and `a_tf_wp_ground_insulation`) in the `outtf` function for better diagnostics. 


<img width="1191" height="654" alt="image" src="https://github.com/user-attachments/assets/b9d2e907-76ac-422a-bc0c-7c91e369b86d" />


<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
