### PR TITLE
:art: Show the toroidal blanket segments in `plot_proc`

### DIFF
--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -1549,25 +1549,25 @@ class CCFE_HCPB(BlanketLibrary):
             "(abktflnc)",
             cost_variables.abktflnc,
         )
-        po.ovarin(
+        po.ovarre(
             self.outfile,
             "No of inboard blanket modules poloidally",
             "(n_blkt_inboard_modules_poloidal)",
             fwbs_variables.n_blkt_inboard_modules_poloidal,
         )
-        po.ovarin(
+        po.ovarre(
             self.outfile,
             "No of inboard blanket modules toroidally",
             "(n_blkt_inboard_modules_toroidal)",
             fwbs_variables.n_blkt_inboard_modules_toroidal,
         )
-        po.ovarin(
+        po.ovarre(
             self.outfile,
             "No of outboard blanket modules poloidally",
             "(n_blkt_outboard_modules_poloidal)",
             fwbs_variables.n_blkt_outboard_modules_poloidal,
         )
-        po.ovarin(
+        po.ovarre(
             self.outfile,
             "No of outboard blanket modules toroidally",
             "(n_blkt_outboard_modules_toroidal)",

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -3370,6 +3370,48 @@ def toroidal_cross_section(axis, mfile_data, scan, demo_ranges, colour_scheme):
         y = ycorner + c * np.sin(beta) - dx_beam_shield * np.sin(beta)
         axis.plot([xouter, x], [youter, y], linestyle="dotted", color="black")
 
+    # Draw dividing lines in the blanket (inboard modules, toroidal direction)
+    n_blkt_inboard_modules_toroidal = mfile_data.data[
+        "n_blkt_inboard_modules_toroidal"
+    ].get_scan(scan)
+    if n_blkt_inboard_modules_toroidal > 1:
+        # Calculate the angular spacing for each module
+        spacing = rtangle / (n_blkt_inboard_modules_toroidal / 4)
+        r1, _ = cumulative_radial_build2("dr_shld_inboard", mfile_data, scan)
+        r2, _ = cumulative_radial_build2("dr_blkt_inboard", mfile_data, scan)
+        for i in range(1, int(n_blkt_inboard_modules_toroidal / 4)):
+            ang = i * spacing
+            # Draw a line from r1 to r2 at angle ang
+            axis.plot(
+                [r1 * np.cos(ang), r2 * np.cos(ang)],
+                [r1 * np.sin(ang), r2 * np.sin(ang)],
+                color="black",
+                linestyle="-",
+                linewidth=1.5,
+                zorder=100,
+            )
+
+    # Draw dividing lines in the blanket (outboard modules, toroidal direction)
+    n_blkt_outboard_modules_toroidal = mfile_data.data[
+        "n_blkt_outboard_modules_toroidal"
+    ].get_scan(scan)
+    if n_blkt_outboard_modules_toroidal > 1:
+        # Calculate the angular spacing for each module
+        spacing = rtangle / (n_blkt_outboard_modules_toroidal / 4)
+        r1, _ = cumulative_radial_build2("dr_fw_outboard", mfile_data, scan)
+        r2, _ = cumulative_radial_build2("dr_blkt_outboard", mfile_data, scan)
+        for i in range(1, int(n_blkt_outboard_modules_toroidal / 4)):
+            ang = i * spacing
+            # Draw a line from r1 to r2 at angle ang
+            axis.plot(
+                [r1 * np.cos(ang), r2 * np.cos(ang)],
+                [r1 * np.sin(ang), r2 * np.sin(ang)],
+                color="black",
+                linestyle="-",
+                linewidth=1.5,
+                zorder=100,
+            )
+
     # Ranges
     # ---
     # DEMO : Fixed ranges for comparison


### PR DESCRIPTION
This pull request introduces improvements to how blanket module divisions are represented in both the output data and the toroidal cross-section plots. The main changes include updating the output writing function to use a corrected method and enhancing the visualization by adding dividing lines for blanket modules in the toroidal direction.

**Visualization enhancements:**

* Added dividing lines in the blanket region for both inboard and outboard modules along the toroidal direction in the `toroidal_cross_section` plot, improving clarity of module segmentation.

**Output writing improvements:**

* Updated calls from `po.ovarin` to `po.ovarre` in the `write_output` method of `hcpb.py` for outputting blanket module counts, ensuring the correct function is used for writing these variables.…g lines in plot_proc

<img width="500" height="456" alt="image" src="https://github.com/user-attachments/assets/7ef06dfd-2cfc-48a1-9c0f-37b7657c0a5b" />

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
