### PR TITLE
Fixes to 2d_scan function in scan.py

### DIFF
--- a/process/scan.py
+++ b/process/scan.py
@@ -905,8 +905,8 @@ class Scan:
         process_output.write(
             constants.nout,
             f"***** 2D Scan point {iscan} of {scan_module.isweep * scan_module.isweep_2} : "
-            f"{f2py_compatible_to_string(global_variables.vlabel)} = {scan_module.sweep[iscan - 1]} and"
-            f" {f2py_compatible_to_string(global_variables.vlabel_2)} = {scan_module.sweep_2[iscan_r]} "
+            f"{f2py_compatible_to_string(global_variables.vlabel)} = {scan_module.sweep[iscan_1 - 1]} and"
+            f" {f2py_compatible_to_string(global_variables.vlabel_2)} = {scan_module.sweep_2[iscan_r - 1]} "
             "*****",
         )
         process_output.ostars(constants.nout, 110)
@@ -915,9 +915,9 @@ class Scan:
 
         print(
             f"Starting scan point {iscan}:  {f2py_compatible_to_string(global_variables.xlabel)}, "
-            f"{f2py_compatible_to_string(global_variables.vlabel)} = {scan_module.sweep[iscan - 1]}"
+            f"{f2py_compatible_to_string(global_variables.vlabel)} = {scan_module.sweep[iscan_1 - 1]}"
             f" and {f2py_compatible_to_string(global_variables.xlabel_2)}, "
-            f"{f2py_compatible_to_string(global_variables.vlabel_2)} = {scan_module.sweep_2[iscan_r]} "
+            f"{f2py_compatible_to_string(global_variables.vlabel_2)} = {scan_module.sweep_2[iscan_r - 1]} "
         )
 
         return iscan_r


### PR DESCRIPTION
## Description

Resolved the issue of incorrect sweep values being printed to the terminal in a 2d scan. Issue was that scan indexes were running from 1->n, so added a idx-1 when calling the sweep value. Also for the primary sweeping variable it was using the cumulative scan number not the sweep1 scan number.

## Checklist

I confirm that I have completed the following checks:

- [] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)

