### PR TITLE
Cache coolprop calculations to avoid calling PropsSI

### DIFF
--- a/process/coolprop_interface.py
+++ b/process/coolprop_interface.py
@@ -1,54 +1,56 @@
+from functools import cache
+
 from CoolProp.CoolProp import PropsSI
 
 
 class FluidProperties:
     def __init__(self, coolprop_inputs: list[str | float]):
-        self._coolprop_inputs = coolprop_inputs
+        self._coolprop_inputs = tuple(coolprop_inputs)
 
     @property
     def temperature(self):
         """fluid temperature [K]"""
-        return PropsSI("T", *self._coolprop_inputs)
+        return _temperature(self._coolprop_inputs)
 
     @property
     def pressure(self):
         """fluid pressure [Pa]"""
-        return PropsSI("P", *self._coolprop_inputs)
+        return _pressure(self._coolprop_inputs)
 
     @property
     def density(self):
         """fluid density [kg/m3]"""
-        return PropsSI("D", *self._coolprop_inputs)
+        return _density(self._coolprop_inputs)
 
     @property
     def enthalpy(self):
         """fluid specific enthalpy [J/kg]"""
-        return PropsSI("H", *self._coolprop_inputs)
+        return _enthalpy(self._coolprop_inputs)
 
     @property
     def entropy(self):
         """fluid entropy [J/kg/K]"""
-        return PropsSI("S", *self._coolprop_inputs)
+        return _entropy(self._coolprop_inputs)
 
     @property
     def specific_heat_const_p(self):
         """fluid specific heat capacity at constant pressure [J/kg/K]"""
-        return PropsSI("C", *self._coolprop_inputs)
+        return _specific_heat_const_p(self._coolprop_inputs)
 
     @property
     def specific_heat_const_v(self):
         """fluid specific heat capacity at constant volume [J/kg/K]"""
-        return PropsSI("CVMASS", *self._coolprop_inputs)
+        return _specific_heat_const_v(self._coolprop_inputs)
 
     @property
     def viscosity(self):
         """fluid viscosity [Pa.s]"""
-        return PropsSI("V", *self._coolprop_inputs)
+        return _viscosity(self._coolprop_inputs)
 
     @property
     def thermal_conductivity(self):
         """fluid thermal conductivity [W/m/K]"""
-        return PropsSI("CONDUCTIVITY", *self._coolprop_inputs)
+        return _thermal_conductivity(self._coolprop_inputs)
 
     @classmethod
     def of(
@@ -86,3 +88,48 @@ class FluidProperties:
         coolprop_inputs.append(fluid_name.title())
 
         return cls(coolprop_inputs)
+
+
+@cache
+def _temperature(coolprop_inputs: tuple[str | float]):
+    return PropsSI("T", *coolprop_inputs)
+
+
+@cache
+def _pressure(coolprop_inputs: tuple[str | float]):
+    return PropsSI("P", *coolprop_inputs)
+
+
+@cache
+def _density(coolprop_inputs: tuple[str | float]):
+    return PropsSI("D", *coolprop_inputs)
+
+
+@cache
+def _enthalpy(coolprop_inputs: tuple[str | float]):
+    return PropsSI("H", *coolprop_inputs)
+
+
+@cache
+def _entropy(coolprop_inputs: tuple[str | float]):
+    return PropsSI("S", *coolprop_inputs)
+
+
+@cache
+def _specific_heat_const_p(coolprop_inputs: tuple[str | float]):
+    return PropsSI("C", *coolprop_inputs)
+
+
+@cache
+def _specific_heat_const_v(coolprop_inputs: tuple[str | float]):
+    return PropsSI("CVMASS", *coolprop_inputs)
+
+
+@cache
+def _viscosity(coolprop_inputs: tuple[str | float]):
+    return PropsSI("V", *coolprop_inputs)
+
+
+@cache
+def _thermal_conductivity(coolprop_inputs: tuple[str | float]):
+    return PropsSI("CONDUCTIVITY", *coolprop_inputs)


### PR DESCRIPTION
There has been a noticeable increase in the runtime of PROCESS recently. Inspecting the call graph, it shows that a majority of our time (46.63%) is spent in the TF coil `protect` method. Most of the time within this method (~39.25% of the total PROCESS runtime) is spent calculating fluid properties via the Coolprop library (`PropsSI` function).  

<img width="915" height="672" alt="image" src="https://github.com/user-attachments/assets/a7c625b9-eeea-4611-8cef-ddc66781911e" />

I have modified our interface to coolprop such that we cache the results from calling Coolprop's `PropsSI`. The new call graph now shows that only 9.53% of PROCESS' runtime is spent in the `protect` method of the TF coils. Calls to `PropsSI` are now not even recorded on the call graph their runtime is so small.

<img width="869" height="692" alt="image" src="https://github.com/user-attachments/assets/bac69089-63e6-4ee5-8ca7-6ce350483ec1" />

