### PR TITLE
Apply absolute tolerance when testing plane_stress

### DIFF
--- a/tests/unit/test_tfcoil.py
+++ b/tests/unit/test_tfcoil.py
@@ -5140,10 +5140,10 @@ def test_plane_stress(planestressparam, monkeypatch):
         j=planestressparam.j,
     )
 
-    assert sigr == pytest.approx(planestressparam.expected_sigr)
-    assert sigt == pytest.approx(planestressparam.expected_sigt)
-    assert r_deflect == pytest.approx(planestressparam.expected_r_deflect)
-    assert rradius == pytest.approx(planestressparam.expected_rradius)
+    np.testing.assert_allclose(sigr, planestressparam.expected_sigr, atol=1e-6)
+    np.testing.assert_allclose(sigt, planestressparam.expected_sigt)
+    np.testing.assert_allclose(rradius, planestressparam.expected_rradius)
+    np.testing.assert_allclose(r_deflect, planestressparam.expected_r_deflect)
 
 
 class ExtendedPlaneStrainParam(NamedTuple):


### PR DESCRIPTION
This is not the solution I hoped to reach with this issue. I have determined that the cause of this issue is a difference in the `scipy.linalg.solve` implementations between X86_64 and ARM architectures. Despite the fact we use `np.linalg.solve` in the code, when we `numba` compile it actually uses the `scipy` solver. The issue comments contain my findings testing various combinations of operating systems and linear algebra solvers. 

Since this is a difference comes from a dependency being slightly different between hardware architectures, I do not think this is a) a massive problem or b) anything we can fix. Therefore, I propose that we just increase the tolerance on the test :( unless anyone has a better idea.

NOTE: none of the regression tests (`0.0` tolerance) fail on the Mac M1 despite these slight differences coming from the `plane_stress` routine. This further suggests to me that this is not really an issue.