### PR TITLE
Handle IOTTY output in process_output

### DIFF
--- a/process/process_output.py
+++ b/process/process_output.py
@@ -48,6 +48,8 @@ def write(file, string: str):
         OutputFileManager._mfile.write(f"{string}\n")  # noqa: SLF001
     elif file == constants.NOUT:
         OutputFileManager._outfile.write(f"{string}\n")  # noqa: SLF001
+    elif file == constants.IOTTY:
+        print(string)
 
 
 def ocentr(file, string: str, width: int, *, character="*"):


### PR DESCRIPTION
I forgot to add a handler for terminal output to the Pythonised `write` function