### PR TITLE
Add switch to toggle strict inequality convergence criteria in VMCON

### DIFF
--- a/process/data_structure/numerics.py
+++ b/process/data_structure/numerics.py
@@ -425,6 +425,17 @@ xcs: list[float] = None
 
 vlam: list[float] = None
 
+force_vmcon_inequality_satisfication: int = None
+"""If 1, adds an additional convergence criteria to the VMCON solver
+that enforces the inequality constraints with zero margin/tolerance.
+I.e. VMCON cannot converge until all inequality constraints are
+exactly satisfied.
+
+Default is 0.
+
+NOTE: this only affects the VMCON solver.
+"""
+
 
 def init_numerics():
     global ipnvars
@@ -468,6 +479,7 @@ def init_numerics():
     global xcm
     global xcs
     global vlam
+    global force_vmcon_inequality_satisfication
 
     """Initialise module variables"""
     ioptimz = 1
@@ -627,3 +639,4 @@ def init_numerics():
     xcs = np.array([0.0] * ipnvars)
     vlam = np.array([0.0] * ipnvars)
     name_xc = [""] * ipnvars
+    force_vmcon_inequality_satisfication = 0

--- a/process/input.py
+++ b/process/input.py
@@ -2304,6 +2304,11 @@ INPUT_VARIABLES = {
         additional_actions=_icc_additional_actions,
         set_variable=False,
     ),
+    "force_vmcon_inequality_satisfication": InputVariable(
+        data_structure.numerics,
+        int,
+        choices=(0, 1),
+    ),
 }
 
 

--- a/process/solver.py
+++ b/process/solver.py
@@ -218,7 +218,9 @@ class Vmcon(_Solver):
                 qsp_options={"eps_rel": 1e-1, "adaptive_rho_interval": 25},
                 initial_B=bb,
                 callback=_solver_callback,
-                additional_convergence=_ineq_cons_satisfied,
+                additional_convergence=_ineq_cons_satisfied
+                if numerics.force_vmcon_inequality_satisfication
+                else None,
             )
         except VMCONConvergenceException as e:
             if isinstance(e, LineSearchConvergenceException):


### PR DESCRIPTION
Adds a new switch `force_vmcon_inequality_satisfication` that allows one to turn on "strict" inequality mode: where an additional convergence criteria is added to VMCON that ensures all inequality constraints are exactly satisfied. 

By default, this will be off (returning PROCESS to how it was pre-#3240).

I have tested this with `large_tokamak_nof` which is now failing with `--reg-tolerance = 0.0`; setting `force_vmcon_inequality_satisfication = 1` causes the test to pass. 