### PR TITLE
♻️ Refactor pf coil 4

### DIFF
--- a/process/data_structure/pfcoil_variables.py
+++ b/process/data_structure/pfcoil_variables.py
@@ -484,8 +484,8 @@ vs_cs_pf_total_pulse: float = None
 """total flux swing for pulse (Wb)"""
 
 
-waves: list[float] = None
-"""used in current waveform of PF coils/central solenoid"""
+f_c_pf_cs_peak_time_array: list[float] = None
+"""PF, CS coil current relative to peak current at time points 1 to 6"""
 
 
 m_pf_coil_conductor_total: float = None
@@ -690,7 +690,7 @@ def init_pfcoil_variables():
     global vs_cs_ramp
     global vs_cs_pf_total_ramp
     global vs_cs_pf_total_pulse
-    global waves
+    global f_c_pf_cs_peak_time_array
     global m_pf_coil_conductor_total
     global m_pf_coil_structure_total
     global m_pf_coil_conductor
@@ -792,7 +792,7 @@ def init_pfcoil_variables():
     vs_cs_ramp = 0.0
     vs_cs_pf_total_ramp = 0.0
     vs_cs_pf_total_pulse = 0.0
-    waves = np.zeros((NGC2, 6))
+    f_c_pf_cs_peak_time_array = np.zeros((NGC2, 6))
     m_pf_coil_conductor_total = 0.0
     m_pf_coil_structure_total = 0.0
     m_pf_coil_conductor = np.zeros(NGC2)

--- a/process/data_structure/times_variables.py
+++ b/process/data_structure/times_variables.py
@@ -24,7 +24,7 @@ t_between_pulse: float = None
 t_fusion_ramp: float = None
 """time for plasma temperature and density rise to full values (s)"""
 
-tim: list[float] = None
+t_pulse_cumulative: list[float] = None
 """array of time points during plasma pulse (s)"""
 
 timelabel: list[str] = None
@@ -62,7 +62,7 @@ def init_times_variables():
     global tdown
     global t_between_pulse
     global t_fusion_ramp
-    global tim
+    global t_pulse_cumulative
     global timelabel
     global intervallabel
     global t_current_ramp_up
@@ -78,7 +78,7 @@ def init_times_variables():
     tdown = 0.0
     t_between_pulse = 1800.0
     t_fusion_ramp = 10.0
-    tim = np.zeros(6, dtype=np.float64)
+    t_pulse_cumulative = np.zeros(6, dtype=np.float64)
     timelabel = ["Start", "BOP  ", "EOR  ", "BOF  ", "EOF  ", "EOP  "]
     intervallabel = [
         "t_precharge        ",

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -82,11 +82,9 @@ class PFCoil:
             order="F",
         )
         pfcoil_variables.ccls0 = np.zeros(int(pfcoil_variables.N_PF_GROUPS_MAX / 2))
-        sigma, work2 = np.zeros((2, pfcoil_variables.N_PF_GROUPS_MAX))
-        rc, zc, cc, xc = np.zeros((4, pfcoil_variables.N_PF_COILS_IN_GROUP_MAX))
         brin, bzin, rpts, zpts = np.zeros((4, pfcoil_variables.NPTSMX))
         bfix, bvec = np.zeros((2, lrow1))
-        gmat, umat, vmat = np.zeros((3, lrow1, lcol1), order="F")
+        gmat, _, _ = np.zeros((3, lrow1, lcol1), order="F")
         signn = np.zeros(2)
         aturn = np.zeros(pfcoil_variables.NGC2)
 
@@ -2240,18 +2238,18 @@ class PFCoil:
         # Calculate the field at the inner and outer edges
         # of the coil of interest
         pfcoil_variables.xind[:kk], bri, bzi, psi = bfield(
-            pfcoil_variables.r_pf_cs_current_filaments[:kk],
-            pfcoil_variables.z_pf_cs_current_filaments[:kk],
-            pfcoil_variables.c_pf_cs_current_filaments[:kk],
-            pfcoil_variables.r_pf_coil_inner[i - 1],
-            pfcoil_variables.z_pf_coil_middle[i - 1],
+            r_current_loop=pfcoil_variables.r_pf_cs_current_filaments[:kk],
+            z_current_loop=pfcoil_variables.z_pf_cs_current_filaments[:kk],
+            c_current_loop=pfcoil_variables.c_pf_cs_current_filaments[:kk],
+            r_test_point=pfcoil_variables.r_pf_coil_inner[i - 1],
+            z_test_point=pfcoil_variables.z_pf_coil_middle[i - 1],
         )
         pfcoil_variables.xind[:kk], bro, bzo, psi = bfield(
-            pfcoil_variables.r_pf_cs_current_filaments[:kk],
-            pfcoil_variables.z_pf_cs_current_filaments[:kk],
-            pfcoil_variables.c_pf_cs_current_filaments[:kk],
-            pfcoil_variables.r_pf_coil_outer[i - 1],
-            pfcoil_variables.z_pf_coil_middle[i - 1],
+            r_current_loop=pfcoil_variables.r_pf_cs_current_filaments[:kk],
+            z_current_loop=pfcoil_variables.z_pf_cs_current_filaments[:kk],
+            c_current_loop=pfcoil_variables.c_pf_cs_current_filaments[:kk],
+            r_test_point=pfcoil_variables.r_pf_coil_outer[i - 1],
+            z_test_point=pfcoil_variables.z_pf_coil_middle[i - 1],
         )
 
         # b_pf_coil_peak and bpf2 for the Central Solenoid are calculated in OHCALC
@@ -2679,8 +2677,20 @@ class PFCoil:
 
                 reqv = rp * (1.0e0 + delzoh**2 / (24.0e0 * rp**2))
 
-                xcin, br, bz, psi = bfield(rc, zc, cc, reqv - deltar, zp)
-                xcout, br, bz, psi = bfield(rc, zc, cc, reqv + deltar, zp)
+                xcin, br, bz, psi = bfield(
+                    r_current_loop=rc,
+                    z_current_loop=zc,
+                    c_current_loop=cc,
+                    r_test_point=reqv - deltar,
+                    z_test_point=zp,
+                )
+                xcout, br, bz, psi = bfield(
+                    r_current_loop=rc,
+                    z_current_loop=zc,
+                    c_current_loop=cc,
+                    r_test_point=reqv + deltar,
+                    z_test_point=zp,
+                )
 
                 for ii in range(nplas):
                     xc[ii] = 0.5e0 * (xcin[ii] + xcout[ii])
@@ -2716,7 +2726,13 @@ class PFCoil:
             ncoils = ncoils + pfcoil_variables.n_pf_coils_in_group[i]
             rp = pfcoil_variables.r_pf_coil_middle[ncoils - 1]
             zp = pfcoil_variables.z_pf_coil_middle[ncoils - 1]
-            xc, br, bz, psi = bfield(rc, zc, cc, rp, zp)
+            xc, br, bz, psi = bfield(
+                r_current_loop=rc,
+                z_current_loop=zc,
+                c_current_loop=cc,
+                r_test_point=rp,
+                z_test_point=zp,
+            )
             for ii in range(nplas):
                 xpfpl = xpfpl + xc[ii]
 
@@ -2762,7 +2778,13 @@ class PFCoil:
                 ncoils = ncoils + pfcoil_variables.n_pf_coils_in_group[i]
                 rp = pfcoil_variables.r_pf_coil_middle[ncoils - 1]
                 zp = pfcoil_variables.z_pf_coil_middle[ncoils - 1]
-                xc, br, bz, psi = bfield(rc, zc, cc, rp, zp)
+                xc, br, bz, psi = bfield(
+                    r_current_loop=rc,
+                    z_current_loop=zc,
+                    c_current_loop=cc,
+                    r_test_point=rp,
+                    z_test_point=zp,
+                )
                 for ii in range(noh):
                     xohpf = xohpf + xc[ii]
 
@@ -2799,7 +2821,13 @@ class PFCoil:
 
             rp = pfcoil_variables.r_pf_coil_middle[i]
             zp = pfcoil_variables.z_pf_coil_middle[i]
-            xc, br, bz, psi = bfield(rc, zc, cc, rp, zp)
+            xc, br, bz, psi = bfield(
+                r_current_loop=rc,
+                z_current_loop=zc,
+                c_current_loop=cc,
+                r_test_point=rp,
+                z_test_point=zp,
+            )
             for k in range(pfcoil_variables.nef):
                 if k < i:
                     pfcoil_variables.ind_pf_cs_plasma_mutual[i, k] = (
@@ -4104,26 +4132,42 @@ class PFCoil:
 
 
 @numba.njit(cache=True)
-def bfield(rc, zc, cc, rp, zp):
-    """Calculate the field at a point due to currents in a number
-    of circular poloidal conductor loops.
-    author: P J Knight, CCFE, Culham Science Centre
-    author: D Strickler, ORNL
-    author: J Galambos, ORNL
-    nc : input integer : number of loops
-    rc(nc) : input real array : R coordinates of loops (m)
-    zc(nc) : input real array : Z coordinates of loops (m)
-    cc(nc) : input real array : Currents in loops (A)
-    xc(nc) : output real array : Mutual inductances (H)
-    rp, zp : input real : coordinates of point of interest (m)
-    br : output real : radial field component at (rp,zp) (T)
-    bz : output real : vertical field component at (rp,zp) (T)
-    psi : output real : poloidal flux at (rp,zp) (Wb)
-    This routine calculates the magnetic field components and
-    the poloidal flux at an (R,Z) point, given the locations
-    and currents of a set of conductor loops.
-    <P>The mutual inductances between the loops and a poloidal
-    filament at the (R,Z) point of interest is also found."""
+def bfield(
+    r_current_loop: np.ndarray,
+    z_current_loop: np.ndarray,
+    c_current_loop: np.ndarray,
+    r_test_point: float,
+    z_test_point: float,
+) -> tuple[np.ndarray, float, float, float]:
+    """
+    Calculate the magnetic field and mutual inductance at a point due to currents in circular poloidal conductor loops.
+    - P J Knight, CCFE, Culham Science Centre
+    - D Strickler, ORNL
+    - J Galambos, ORNL
+
+    :param r_current_loop: Array of R coordinates of current loops (m)
+    :type r_current_loop: np.ndarray
+    :param z_current_loop: Array of Z coordinates of current loops (m)
+    :type z_current_loop: np.ndarray
+    :param c_current_loop: Array of currents in loops (A)
+    :type c_current_loop: np.ndarray
+    :param r_test_point: R coordinate of the test point (m)
+    :type r_test_point: float
+    :param z_test_point: Z coordinate of the test point (m)
+    :type z_test_point: float
+
+    :returns: Tuple containing:
+        - ind_mutual_array: Mutual inductances (H) between each loop and the test point
+        - b_test_point_radial: Radial field component at the test point (T)
+        - b_test_point_vertical: Vertical field component at the test point (T)
+        - web_test_point_poloidal: Poloidal flux at the test point (Wb)
+    :rtype: tuple[np.ndarray, float, float, float]
+
+    :notes:
+        - This routine calculates the magnetic field components and the poloidal flux at a given (R, Z) point,
+        given the locations and currents of a set of conductor loops. The mutual inductances between the loops
+        and a poloidal filament at the (R, Z) point of interest are also computed.
+    """
 
     #  Elliptic integral coefficients
 
@@ -4146,16 +4190,18 @@ def bfield(rc, zc, cc, rp, zp):
     d3 = 0.04069697526
     d4 = 0.00526449639
 
-    nc = len(rc)
+    n_current_loops = len(r_current_loop)
 
-    xc = np.empty((nc,))
-    br = 0
-    bz = 0
-    psi = 0
+    ind_mutual_array = np.empty((n_current_loops,))
+    b_test_point_radial = 0
+    b_test_point_vertical = 0
+    web_test_point_poloidal = 0
 
-    for i in range(nc):
-        d = (rp + rc[i]) ** 2 + (zp - zc[i]) ** 2
-        s = 4.0 * rp * rc[i] / d
+    for i in range(n_current_loops):
+        d = (r_test_point + r_current_loop[i]) ** 2 + (
+            z_test_point - z_current_loop[i]
+        ) ** 2
+        s = 4.0 * r_test_point * r_current_loop[i] / d
 
         # Kludge: avoid s >= 1.0, a goes inf
         if s > 0.999999:
@@ -4164,9 +4210,9 @@ def bfield(rc, zc, cc, rp, zp):
         t = 1.0 - s
         a = np.log(1.0 / t)
 
-        dz = zp - zc[i]
+        dz = z_test_point - z_current_loop[i]
         zs = dz**2
-        dr = rp - rc[i]
+        dr = r_test_point - r_current_loop[i]
         sd = np.sqrt(d)
 
         if dr == 0.0:
@@ -4188,31 +4234,39 @@ def bfield(rc, zc, cc, rp, zp):
 
         #  Mutual inductances
 
-        xc[i] = 0.5 * constants.RMU0 * sd * ((2.0 - s) * xk - 2.0 * xe)
+        ind_mutual_array[i] = 0.5 * constants.RMU0 * sd * ((2.0 - s) * xk - 2.0 * xe)
 
         #  Radial, vertical fields
 
         brx = (
             constants.RMU0
-            * cc[i]
+            * c_current_loop[i]
             * dz
-            / (2 * np.pi * rp * sd)
-            * (-xk + (rc[i] ** 2 + rp**2 + zs) / (dr**2 + zs) * xe)
+            / (2 * np.pi * r_test_point * sd)
+            * (
+                -xk
+                + (r_current_loop[i] ** 2 + r_test_point**2 + zs) / (dr**2 + zs) * xe
+            )
         )
         bzx = (
             constants.RMU0
-            * cc[i]
+            * c_current_loop[i]
             / (2 * np.pi * sd)
-            * (xk + (rc[i] ** 2 - rp**2 - zs) / (dr**2 + zs) * xe)
+            * (xk + (r_current_loop[i] ** 2 - r_test_point**2 - zs) / (dr**2 + zs) * xe)
         )
 
         #  Sum fields, flux
 
-        br += brx
-        bz += bzx
-        psi += xc[i] * cc[i]
+        b_test_point_radial += brx
+        b_test_point_vertical += bzx
+        web_test_point_poloidal += ind_mutual_array[i] * c_current_loop[i]
 
-    return xc, br, bz, psi
+    return (
+        ind_mutual_array,
+        b_test_point_radial,
+        b_test_point_vertical,
+        web_test_point_poloidal,
+    )
 
 
 @numba.njit(cache=True)
@@ -4322,7 +4376,13 @@ def fixb(lrow1, npts, rpts, zpts, nfix, rfix, zfix, cfix):
     for i in range(npts):
         # bfield() only operates correctly on nfix slices of array
         # arguments, not entire arrays
-        _, brw, bzw, _ = bfield(rfix[:nfix], zfix[:nfix], cfix[:nfix], rpts[i], zpts[i])
+        _, brw, bzw, _ = bfield(
+            r_current_loop=rfix[:nfix],
+            z_current_loop=zfix[:nfix],
+            c_current_loop=cfix[:nfix],
+            r_test_point=rpts[i],
+            z_test_point=zpts[i],
+        )
         bfix[i] = brw
         bfix[npts + i] = bzw
 
@@ -4403,11 +4463,11 @@ def mtrx(
             nc = n_pf_coils_in_group[j]
 
             _, gmat[i, j], gmat[i + npts, j], _ = bfield(
-                r_pf_coil_middle_group_array[j, :nc],
-                z_pf_coil_middle_group_array[j, :nc],
-                cc[:nc],
-                rpts[i],
-                zpts[i],
+                r_current_loop=r_pf_coil_middle_group_array[j, :nc],
+                z_current_loop=z_pf_coil_middle_group_array[j, :nc],
+                c_current_loop=cc[:nc],
+                r_test_point=rpts[i],
+                z_test_point=zpts[i],
             )
 
     # Add constraint equations

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -686,7 +686,7 @@ class PFCoil:
 
         # Set up coil current waveforms, normalised to the peak current in
         # each coil
-        self.waveform()  # sets c_pf_cs_coils_peak_ma(), waves()
+        self.waveform()  # sets c_pf_cs_coils_peak_ma(), f_c_pf_cs_peak_time_array()
 
         # Calculate PF coil geometry, current and number of turns
         # Dimensions are those of the winding pack, and exclude
@@ -1033,11 +1033,12 @@ class PFCoil:
         # user-provided waveforms etc. (c_pf_coil_turn_peak_input, f_j_cs_start_pulse_end_flat_top, f_j_cs_start_end_flat_top)
         for k in range(6):  # time points
             for i in range(pfcoil_variables.n_pf_cs_plasma_circuits - 1):
-                pfcoil_variables.c_pf_coil_turn[i, k] = pfcoil_variables.waves[
-                    i, k
-                ] * math.copysign(
-                    pfcoil_variables.c_pf_coil_turn_peak_input[i],
-                    pfcoil_variables.c_pf_cs_coils_peak_ma[i],
+                pfcoil_variables.c_pf_coil_turn[i, k] = (
+                    pfcoil_variables.f_c_pf_cs_peak_time_array[i, k]
+                    * math.copysign(
+                        pfcoil_variables.c_pf_coil_turn_peak_input[i],
+                        pfcoil_variables.c_pf_cs_coils_peak_ma[i],
+                    )
                 )
 
         # Plasma wave form
@@ -2108,7 +2109,7 @@ class PFCoil:
         if bv.iohcl != 0 and n_coil == pfcoil_variables.n_cs_pf_coils:
             # Peak field is to be calculated at the Central Solenoid itself,
             # so exclude its own contribution; its self field is
-            # dealt with externally using routine BFMAX
+            # dealt with externally using routine calculate_cs_peak_field()
             kk = 0
         else:
             # Check different times for maximum current
@@ -2156,7 +2157,7 @@ class PFCoil:
                 # Current in each filament representing part of the Central Solenoid
                 for iohc in range(pfcoil_variables.nfxf):
                     pfcoil_variables.c_pf_cs_current_filaments[iohc] = (
-                        pfcoil_variables.waves[
+                        pfcoil_variables.f_c_pf_cs_peak_time_array[
                             pfcoil_variables.n_cs_pf_coils - 1, t_b_field_peak - 1
                         ]
                         * pfcoil_variables.j_cs_flat_top_end
@@ -2192,7 +2193,9 @@ class PFCoil:
                     )
                     pfcoil_variables.c_pf_cs_current_filaments[kk - 1] = (
                         pfcoil_variables.c_pf_cs_coils_peak_ma[jj - 1]
-                        * pfcoil_variables.waves[jj - 1, t_b_field_peak - 1]
+                        * pfcoil_variables.f_c_pf_cs_peak_time_array[
+                            jj - 1, t_b_field_peak - 1
+                        ]
                         * 0.25e6
                     )
                     kk = kk + 1
@@ -2204,7 +2207,9 @@ class PFCoil:
                     )
                     pfcoil_variables.c_pf_cs_current_filaments[kk - 1] = (
                         pfcoil_variables.c_pf_cs_coils_peak_ma[jj - 1]
-                        * pfcoil_variables.waves[jj - 1, t_b_field_peak - 1]
+                        * pfcoil_variables.f_c_pf_cs_peak_time_array[
+                            jj - 1, t_b_field_peak - 1
+                        ]
                         * 0.25e6
                     )
                     kk = kk + 1
@@ -2216,7 +2221,9 @@ class PFCoil:
                     )
                     pfcoil_variables.c_pf_cs_current_filaments[kk - 1] = (
                         pfcoil_variables.c_pf_cs_coils_peak_ma[jj - 1]
-                        * pfcoil_variables.waves[jj - 1, t_b_field_peak - 1]
+                        * pfcoil_variables.f_c_pf_cs_peak_time_array[
+                            jj - 1, t_b_field_peak - 1
+                        ]
                         * 0.25e6
                     )
                     kk = kk + 1
@@ -2228,7 +2235,9 @@ class PFCoil:
                     )
                     pfcoil_variables.c_pf_cs_current_filaments[kk - 1] = (
                         pfcoil_variables.c_pf_cs_coils_peak_ma[jj - 1]
-                        * pfcoil_variables.waves[jj - 1, t_b_field_peak - 1]
+                        * pfcoil_variables.f_c_pf_cs_peak_time_array[
+                            jj - 1, t_b_field_peak - 1
+                        ]
                         * 0.25e6
                     )
 
@@ -2243,7 +2252,9 @@ class PFCoil:
                     )
                     pfcoil_variables.c_pf_cs_current_filaments[kk - 1] = (
                         pfcoil_variables.c_pf_cs_coils_peak_ma[jj - 1]
-                        * pfcoil_variables.waves[jj - 1, t_b_field_peak - 1]
+                        * pfcoil_variables.f_c_pf_cs_peak_time_array[
+                            jj - 1, t_b_field_peak - 1
+                        ]
                         * 1.0e6
                     )
 
@@ -3892,12 +3903,12 @@ class PFCoil:
 
         author: P J Knight, CCFE, Culham Science Centre
         This routine sets up the PF coil current waveforms.
-        waves[i,j] is the current in coil i, at time j,
+        f_c_pf_cs_peak_time_array[i,j] is the current in coil i, at time j,
         normalized to the peak current in that coil at any time.
         """
         nplas = pfcoil_variables.n_cs_pf_coils + 1
         for it in range(6):
-            pfcoil_variables.waves[nplas - 1, it] = 1.0e0
+            pfcoil_variables.f_c_pf_cs_peak_time_array[nplas - 1, it] = 1.0e0
 
         for ic in range(pfcoil_variables.n_cs_pf_coils):
             # Find where the peak current occurs
@@ -3938,24 +3949,24 @@ class PFCoil:
                 )
 
             # Set normalized current waveforms
-            pfcoil_variables.waves[ic, 0] = 0.0e0
-            pfcoil_variables.waves[ic, 1] = (
+            pfcoil_variables.f_c_pf_cs_peak_time_array[ic, 0] = 0.0e0
+            pfcoil_variables.f_c_pf_cs_peak_time_array[ic, 1] = (
                 pfcoil_variables.c_pf_cs_coil_pulse_start_ma[ic]
                 / pfcoil_variables.c_pf_cs_coils_peak_ma[ic]
             )
-            pfcoil_variables.waves[ic, 2] = (
+            pfcoil_variables.f_c_pf_cs_peak_time_array[ic, 2] = (
                 pfcoil_variables.c_pf_cs_coil_flat_top_ma[ic]
                 / pfcoil_variables.c_pf_cs_coils_peak_ma[ic]
             )
-            pfcoil_variables.waves[ic, 3] = (
+            pfcoil_variables.f_c_pf_cs_peak_time_array[ic, 3] = (
                 pfcoil_variables.c_pf_cs_coil_flat_top_ma[ic]
                 / pfcoil_variables.c_pf_cs_coils_peak_ma[ic]
             )
-            pfcoil_variables.waves[ic, 4] = (
+            pfcoil_variables.f_c_pf_cs_peak_time_array[ic, 4] = (
                 pfcoil_variables.c_pf_cs_coil_pulse_end_ma[ic]
                 / pfcoil_variables.c_pf_cs_coils_peak_ma[ic]
             )
-            pfcoil_variables.waves[ic, 5] = 0.0e0
+            pfcoil_variables.f_c_pf_cs_peak_time_array[ic, 5] = 0.0e0
 
     def superconpf(
         self, bmax, fhe, fcu, jwp, isumat, fhts, strain, thelium, bcritsc, tcritsc

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -136,12 +136,12 @@ class PFCoil:
         )
 
         # Set up array of times
-        tv.tim[0] = 0.0e0
-        tv.tim[1] = tv.t_precharge
-        tv.tim[2] = tv.tim[1] + tv.t_current_ramp_up
-        tv.tim[3] = tv.tim[2] + tv.t_fusion_ramp
-        tv.tim[4] = tv.tim[3] + tv.t_burn
-        tv.tim[5] = tv.tim[4] + tv.t_ramp_down
+        tv.t_pulse_cumulative[0] = 0.0e0
+        tv.t_pulse_cumulative[1] = tv.t_precharge
+        tv.t_pulse_cumulative[2] = tv.t_pulse_cumulative[1] + tv.t_current_ramp_up
+        tv.t_pulse_cumulative[3] = tv.t_pulse_cumulative[2] + tv.t_fusion_ramp
+        tv.t_pulse_cumulative[4] = tv.t_pulse_cumulative[3] + tv.t_burn
+        tv.t_pulse_cumulative[5] = tv.t_pulse_cumulative[4] + tv.t_ramp_down
 
         # Set up call to MHD scaling routine for coil currents.
         # First break up Central Solenoid solenoid into 'filaments'
@@ -3707,7 +3707,7 @@ class PFCoil:
         op.write(self.outfile, "\t" * 8 + "time (sec)")
         line = "\t\t"
         for k in range(6):
-            line += f"\t\t{tv.tim[k]:.2f}"
+            line += f"\t\t{tv.t_pulse_cumulative[k]:.2f}"
         op.write(self.outfile, line)
 
         line = "\t\t"

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -2237,14 +2237,14 @@ class PFCoil:
 
         # Calculate the field at the inner and outer edges
         # of the coil of interest
-        pfcoil_variables.xind[:kk], bri, bzi, psi = bfield(
+        pfcoil_variables.xind[:kk], bri, bzi, psi = calculate_b_field_at_point(
             r_current_loop=pfcoil_variables.r_pf_cs_current_filaments[:kk],
             z_current_loop=pfcoil_variables.z_pf_cs_current_filaments[:kk],
             c_current_loop=pfcoil_variables.c_pf_cs_current_filaments[:kk],
             r_test_point=pfcoil_variables.r_pf_coil_inner[i - 1],
             z_test_point=pfcoil_variables.z_pf_coil_middle[i - 1],
         )
-        pfcoil_variables.xind[:kk], bro, bzo, psi = bfield(
+        pfcoil_variables.xind[:kk], bro, bzo, psi = calculate_b_field_at_point(
             r_current_loop=pfcoil_variables.r_pf_cs_current_filaments[:kk],
             z_current_loop=pfcoil_variables.z_pf_cs_current_filaments[:kk],
             c_current_loop=pfcoil_variables.c_pf_cs_current_filaments[:kk],
@@ -2677,14 +2677,14 @@ class PFCoil:
 
                 reqv = rp * (1.0e0 + delzoh**2 / (24.0e0 * rp**2))
 
-                xcin, br, bz, psi = bfield(
+                xcin, br, bz, psi = calculate_b_field_at_point(
                     r_current_loop=rc,
                     z_current_loop=zc,
                     c_current_loop=cc,
                     r_test_point=reqv - deltar,
                     z_test_point=zp,
                 )
-                xcout, br, bz, psi = bfield(
+                xcout, br, bz, psi = calculate_b_field_at_point(
                     r_current_loop=rc,
                     z_current_loop=zc,
                     c_current_loop=cc,
@@ -2726,7 +2726,7 @@ class PFCoil:
             ncoils = ncoils + pfcoil_variables.n_pf_coils_in_group[i]
             rp = pfcoil_variables.r_pf_coil_middle[ncoils - 1]
             zp = pfcoil_variables.z_pf_coil_middle[ncoils - 1]
-            xc, br, bz, psi = bfield(
+            xc, br, bz, psi = calculate_b_field_at_point(
                 r_current_loop=rc,
                 z_current_loop=zc,
                 c_current_loop=cc,
@@ -2778,7 +2778,7 @@ class PFCoil:
                 ncoils = ncoils + pfcoil_variables.n_pf_coils_in_group[i]
                 rp = pfcoil_variables.r_pf_coil_middle[ncoils - 1]
                 zp = pfcoil_variables.z_pf_coil_middle[ncoils - 1]
-                xc, br, bz, psi = bfield(
+                xc, br, bz, psi = calculate_b_field_at_point(
                     r_current_loop=rc,
                     z_current_loop=zc,
                     c_current_loop=cc,
@@ -2821,7 +2821,7 @@ class PFCoil:
 
             rp = pfcoil_variables.r_pf_coil_middle[i]
             zp = pfcoil_variables.z_pf_coil_middle[i]
-            xc, br, bz, psi = bfield(
+            xc, br, bz, psi = calculate_b_field_at_point(
                 r_current_loop=rc,
                 z_current_loop=zc,
                 c_current_loop=cc,
@@ -4132,7 +4132,7 @@ class PFCoil:
 
 
 @numba.njit(cache=True)
-def bfield(
+def calculate_b_field_at_point(
     r_current_loop: np.ndarray,
     z_current_loop: np.ndarray,
     c_current_loop: np.ndarray,
@@ -4374,9 +4374,9 @@ def fixb(lrow1, npts, rpts, zpts, nfix, rfix, zfix, cfix):
         return bfix
 
     for i in range(npts):
-        # bfield() only operates correctly on nfix slices of array
+        # calculate_b_field_at_point() only operates correctly on nfix slices of array
         # arguments, not entire arrays
-        _, brw, bzw, _ = bfield(
+        _, brw, bzw, _ = calculate_b_field_at_point(
             r_current_loop=rfix[:nfix],
             z_current_loop=zfix[:nfix],
             c_current_loop=cfix[:nfix],
@@ -4462,7 +4462,7 @@ def mtrx(
         for j in range(n_pf_coil_groups):
             nc = n_pf_coils_in_group[j]
 
-            _, gmat[i, j], gmat[i + npts, j], _ = bfield(
+            _, gmat[i, j], gmat[i + npts, j], _ = calculate_b_field_at_point(
                 r_current_loop=r_pf_coil_middle_group_array[j, :nc],
                 z_current_loop=z_pf_coil_middle_group_array[j, :nc],
                 c_current_loop=cc[:nc],

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -815,7 +815,7 @@ class PFCoil:
 
                 if ij == 0:
                     # Index args +1ed
-                    bri, bro, bzi, bzo = self.peakb(
+                    bri, bro, bzi, bzo = self.peak_b_field_at_pf_coil(
                         i + 1, iii + 1, it
                     )  # returns b_pf_coil_peak, bpf2
 
@@ -1757,7 +1757,9 @@ class PFCoil:
 
         # Peak field due to other PF coils plus plasma
         timepoint = 5
-        bri, bro, bzi, bzo = self.peakb(pfcoil_variables.n_cs_pf_coils, 99, timepoint)
+        bri, bro, bzi, bzo = self.peak_b_field_at_pf_coil(
+            pfcoil_variables.n_cs_pf_coils, 99, timepoint
+        )
 
         pfcoil_variables.b_cs_peak_flat_top_end = abs(bzi - bmaxoh2)
 
@@ -1780,7 +1782,9 @@ class PFCoil:
             ],
         )
         timepoint = 2
-        bri, bro, bzi, bzo = self.peakb(pfcoil_variables.n_cs_pf_coils, 99, timepoint)
+        bri, bro, bzi, bzo = self.peak_b_field_at_pf_coil(
+            pfcoil_variables.n_cs_pf_coils, 99, timepoint
+        )
 
         pfcoil_variables.b_cs_peak_pulse_start = abs(
             pfcoil_variables.b_cs_peak_pulse_start + bzi
@@ -2071,7 +2075,7 @@ class PFCoil:
             dr_cs_full,
         )
 
-    def peakb(self, i, ii, it):
+    def peak_b_field_at_pf_coil(self, i, ii, it):
         """Calculates the peak field at a PF coil.
 
         author: P J Knight, CCFE, Culham Science Centre

--- a/tests/integration/test_pfcoil_int.py
+++ b/tests/integration/test_pfcoil_int.py
@@ -150,7 +150,7 @@ def test_pfcoil(monkeypatch, pfcoil):
     monkeypatch.setattr(tfv, "bcritsc", 2.4e1)
     monkeypatch.setattr(tfv, "b_crit_upper_nbti", 1.486e1)
     monkeypatch.setattr(tfv, "t_crit_nbti", 9.04)
-    monkeypatch.setattr(tv, "tim", np.full(6, 0.0))
+    monkeypatch.setattr(tv, "t_pulse_cumulative", np.full(6, 0.0))
     monkeypatch.setattr(tv, "t_precharge", 5.0e2)
     monkeypatch.setattr(tv, "t_burn", 7.1263e-1)
     monkeypatch.setattr(tv, "t_current_ramp_up", 1.82538e2)

--- a/tests/integration/test_pfcoil_int.py
+++ b/tests/integration/test_pfcoil_int.py
@@ -107,7 +107,9 @@ def test_pfcoil(monkeypatch, pfcoil):
     monkeypatch.setattr(pfcoil_variables, "n_pf_cs_plasma_circuits", 8)
     monkeypatch.setattr(pfcoil_variables, "rho_pf_coil", 2.5e-8)
     monkeypatch.setattr(pfcoil_variables, "c_pf_coil_turn", np.full([22, 6], 0.0))
-    monkeypatch.setattr(pfcoil_variables, "waves", np.full([22, 6], 0.0))
+    monkeypatch.setattr(
+        pfcoil_variables, "f_c_pf_cs_peak_time_array", np.full([22, 6], 0.0)
+    )
     monkeypatch.setattr(
         pfcoil_variables, "ind_pf_cs_plasma_mutual", np.full([22, 22], 0.0)
     )
@@ -262,7 +264,9 @@ def test_ohcalc(monkeypatch, reinitialise_error_module, pfcoil):
 
     # Mocks for peak_b_field_at_pf_coil()
     monkeypatch.setattr(bv, "iohcl", 1)
-    monkeypatch.setattr(pfcoil_variables, "waves", np.full([22, 6], 0.0))
+    monkeypatch.setattr(
+        pfcoil_variables, "f_c_pf_cs_peak_time_array", np.full([22, 6], 0.0)
+    )
     monkeypatch.setattr(pfcoil_variables, "n_pf_coil_groups", 4)
     monkeypatch.setattr(
         pfcoil_variables,
@@ -2335,7 +2339,7 @@ def test_peakb(monkeypatch: pytest.MonkeyPatch, pfcoil: PFCoil):
     )
     monkeypatch.setattr(
         pfcoil_variables,
-        "waves",
+        "f_c_pf_cs_peak_time_array",
         np.array(
             [
                 [0.0, 1.0, 0.00457346, 0.00457346, 0.00457346, 0.0],

--- a/tests/integration/test_pfcoil_int.py
+++ b/tests/integration/test_pfcoil_int.py
@@ -260,7 +260,7 @@ def test_ohcalc(monkeypatch, reinitialise_error_module, pfcoil):
     monkeypatch.setattr(tfv, "t_crit_nbti", 9.04)
     monkeypatch.setattr(constants, "den_copper", 8.9e3)
 
-    # Mocks for peakb()
+    # Mocks for peak_b_field_at_pf_coil()
     monkeypatch.setattr(bv, "iohcl", 1)
     monkeypatch.setattr(pfcoil_variables, "waves", np.full([22, 6], 0.0))
     monkeypatch.setattr(pfcoil_variables, "n_pf_coil_groups", 4)
@@ -1993,7 +1993,7 @@ def test_fixb(pfcoil: PFCoil):
 def test_peakb(monkeypatch: pytest.MonkeyPatch, pfcoil: PFCoil):
     """Test peakb subroutine.
 
-    peakb() requires specific arguments in order to work; these were discovered
+    peak_b_field_at_pf_coil() requires specific arguments in order to work; these were discovered
     using gdb to break on the first subroutine call when running the baseline
     2018 IN.DAT.
     :param monkeypatch: mocking fixture
@@ -2555,7 +2555,7 @@ def test_peakb(monkeypatch: pytest.MonkeyPatch, pfcoil: PFCoil):
     bzi_exp = 1.049564e1
     bzo_exp = -6.438987
 
-    bri, bro, bzi, bzo = pfcoil.peakb(i, ii, it)
+    bri, bro, bzi, bzo = pfcoil.peak_b_field_at_pf_coil(i, ii, it)
 
     assert pytest.approx(bri) == bri_exp
     assert pytest.approx(bro) == bro_exp

--- a/tests/unit/test_pfcoil.py
+++ b/tests/unit/test_pfcoil.py
@@ -991,7 +991,7 @@ def test_bfield():
     bz_exp = -0.3537283013510894
     psi_exp = 232.7112153010189
 
-    xc, br, bz, psi = calculate_b_field_at_point(rc, zc, cc, rp, zp)
+    xc, br, bz, psi = pfcoil.calculate_b_field_at_point(rc, zc, cc, rp, zp)
 
     assert_array_almost_equal(xc, xc_exp)
     assert pytest.approx(br) == br_exp

--- a/tests/unit/test_pfcoil.py
+++ b/tests/unit/test_pfcoil.py
@@ -10,7 +10,7 @@ from process.cs_fatigue import CsFatigue
 from process.data_structure import build_variables as bv
 from process.data_structure import pfcoil_variables
 from process.data_structure import tfcoil_variables as tfv
-from process.pfcoil import PFCoil, bfield, rsid
+from process.pfcoil import PFCoil, rsid
 
 
 @pytest.fixture
@@ -913,7 +913,7 @@ def test_rsid(pfcoil):
 def test_bfield():
     """Test bfield function.
 
-    bfield() requires specific arguments in order to work; these were discovered
+    calculate_b_field_at_point() requires specific arguments in order to work; these were discovered
     using gdb to break on the first subroutine call when running the baseline
     2018 IN.DAT.
 
@@ -991,7 +991,7 @@ def test_bfield():
     bz_exp = -0.3537283013510894
     psi_exp = 232.7112153010189
 
-    xc, br, bz, psi = bfield(rc, zc, cc, rp, zp)
+    xc, br, bz, psi = calculate_b_field_at_point(rc, zc, cc, rp, zp)
 
     assert_array_almost_equal(xc, xc_exp)
     assert pytest.approx(br) == br_exp

--- a/tests/unit/test_pfcoil.py
+++ b/tests/unit/test_pfcoil.py
@@ -10,7 +10,7 @@ from process.cs_fatigue import CsFatigue
 from process.data_structure import build_variables as bv
 from process.data_structure import pfcoil_variables
 from process.data_structure import tfcoil_variables as tfv
-from process.pfcoil import PFCoil, rsid
+from process.pfcoil import PFCoil, calculate_b_field_at_point, rsid
 
 
 @pytest.fixture
@@ -991,7 +991,7 @@ def test_bfield():
     bz_exp = -0.3537283013510894
     psi_exp = 232.7112153010189
 
-    xc, br, bz, psi = pfcoil.calculate_b_field_at_point(rc, zc, cc, rp, zp)
+    xc, br, bz, psi = calculate_b_field_at_point(rc, zc, cc, rp, zp)
 
     assert_array_almost_equal(xc, xc_exp)
     assert pytest.approx(br) == br_exp
@@ -1053,7 +1053,7 @@ def test_waveform(monkeypatch, pfcoil):
     discovered using gdb to break on the first subroutine call when running the
     baseline 2018 IN.DAT.
 
-    waveform() alters both c_pf_cs_coils_peak_ma and waves in the pfcoil_variables module, so
+    waveform() alters both c_pf_cs_coils_peak_ma and f_c_pf_cs_peak_time_array in the pfcoil_variables module, so
     these are asserted on.
     :param monkeypatch: mocking fixture
     :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
@@ -1063,7 +1063,9 @@ def test_waveform(monkeypatch, pfcoil):
     ngc2 = 22
     monkeypatch.setattr(pfcoil_variables, "c_pf_cs_coils_peak_ma", np.zeros(ngc2))
     monkeypatch.setattr(pfcoil_variables, "n_cs_pf_coils", 7)
-    monkeypatch.setattr(pfcoil_variables, "waves", np.zeros((ngc2, 6), order="F"))
+    monkeypatch.setattr(
+        pfcoil_variables, "f_c_pf_cs_peak_time_array", np.zeros((ngc2, 6), order="F")
+    )
     monkeypatch.setattr(
         pfcoil_variables,
         "c_pf_cs_coil_pulse_start_ma",
@@ -1203,7 +1205,7 @@ def test_waveform(monkeypatch, pfcoil):
     pfcoil.waveform()
 
     assert_array_almost_equal(pfcoil_variables.c_pf_cs_coils_peak_ma, ric_exp)
-    assert_array_almost_equal(pfcoil_variables.waves, waves_exp)
+    assert_array_almost_equal(pfcoil_variables.f_c_pf_cs_peak_time_array, waves_exp)
 
 
 def test_vsec(pfcoil, monkeypatch):

--- a/tests/unit/test_power.py
+++ b/tests/unit/test_power.py
@@ -230,7 +230,7 @@ class PfpwrParam(NamedTuple):
 
     ioptimz: Any = None
 
-    tim: Any = None
+    t_pulse_cumulative: Any = None
 
     intervallabel: Any = None
 
@@ -956,7 +956,7 @@ class PfpwrParam(NamedTuple):
                 False,
             ),
             ioptimz=1,
-            tim=np.array(
+            t_pulse_cumulative=np.array(
                 np.array(
                     (
                         0,
@@ -1699,7 +1699,7 @@ class PfpwrParam(NamedTuple):
                 False,
             ),
             ioptimz=1,
-            tim=np.array(
+            t_pulse_cumulative=np.array(
                 np.array(
                     (
                         0,
@@ -1865,7 +1865,9 @@ def test_pfpwr(pfpwrparam, monkeypatch, power):
 
     monkeypatch.setattr(numerics, "ioptimz", pfpwrparam.ioptimz)
 
-    monkeypatch.setattr(times_variables, "tim", pfpwrparam.tim)
+    monkeypatch.setattr(
+        times_variables, "t_pulse_cumulative", pfpwrparam.t_pulse_cumulative
+    )
 
     monkeypatch.setattr(
         times_variables, "t_current_ramp_up", pfpwrparam.t_current_ramp_up


### PR DESCRIPTION
This pull request refactors and clarifies the handling of time and waveform variables for poloidal field (PF) and central solenoid (CS) coils, and improves code readability and maintainability by renaming variables, updating function signatures, and enhancing documentation. The changes also replace a legacy function with a more descriptive and robust version for calculating peak magnetic fields at PF coils, and consistently use a new helper function for magnetic field calculations.

### 🔄 Renames

`peakb()` -> `peak_b_field_at_pf_coil()`
`bfield()` -> `calculate_b_field_at_point()`

`waves` -> `f_c_pf_cs_peak_time_array`
`tim` -> `t_pulse_cumulative`





## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
