### PR TITLE
:bug: Update WP cross section area label to reflect total steel area …

### DIFF
--- a/process/data_structure/tfcoil_variables.py
+++ b/process/data_structure/tfcoil_variables.py
@@ -61,7 +61,7 @@ a_tf_leg_outboard: float = None
 
 
 a_tf_wp_steel: float = None
-"""winding pack structure area (m2)"""
+"""Total area of all winding pack steel (sum of each conduit steel from each turn) (m2)"""
 
 
 a_tf_wp_extra_void: float = None
@@ -783,7 +783,7 @@ dr_tf_wp_with_insulation: float = None
 
 
 dx_tf_turn_steel: float = None
-"""TF coil conduit case thickness (m) (`iteration variable 58`)"""
+"""TF coil turn steel conduit case thickness (m) (`iteration variable 58`)"""
 
 
 dx_tf_wp_insulation: float = None

--- a/process/tf_coil.py
+++ b/process/tf_coil.py
@@ -976,9 +976,9 @@ class TFCoil:
             )
             po.ovarre(
                 self.outfile,
-                "WP cross section area (per coil) (m2)",
+                "Total steel area in WP (per coil) (m2)",
                 "(a_tf_wp_steel)",
-                superconducting_tf_coil_variables.a_tf_wp_no_insulation,
+                tfcoil_variables.a_tf_wp_steel,
             )
             po.ovarre(
                 self.outfile,


### PR DESCRIPTION
This pull request makes a small update to the output labeling in the `outtf` method of `tf_coil.py`. The label for a particular variable has been clarified to better reflect its meaning, and the corresponding variable reference has been updated to match.

### 🐛 Bug

- Changed the output label from "WP cross section area (per coil) (m2)" to "Total steel area in WP (per coil) (m2)" and updated the variable from `a_tf_wp_no_insulation` to `a_tf_wp_steel` in the `outtf` method of `tf_coil.py`…in TF coil output

## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
