### PR TITLE
Scale linear system of equations in plane_stress and skip test if incompatible system

### DIFF
--- a/documentation/installation/installation.md
+++ b/documentation/installation/installation.md
@@ -14,6 +14,11 @@ PROCESS is a command-line Python program. As such, it should be supported by a w
     wsl --install
     ```
 
+!!! Warning "Users of 'incompatible' systems"
+    PROCESS is a complex numerical code that performs thousands of calculations and, on certain systems (e.g. Mac and some non-Ubuntu Linux systems), we have observed that floating-point rounding error can slightly alter the results of individual models--they are not wrong, just different. However, in a code like PROCESS, this error _could_ accumulate over many iterations of the optimiser to cause non-convergence/convergence to a very different design point. To be clear, this does not happen at the moment in any of our regression tests, but is theoretically possible. 
+
+    In our test suite, we skip a couple of tests if the system is not Linux or has an `ldd` version less than `2.31` because of this floating-point rounding difference: you can look for tests using the `skip_if_incompatible_system` fixture. While we encourage users of all systems to use PROCESS, we highly recommend you check your results on our officially support systems (listed above) and Python versions. 
+
 
 Start by downloading the PROCESS source code using `git`:
 

--- a/process/tf_coil.py
+++ b/process/tf_coil.py
@@ -5036,12 +5036,23 @@ def plane_stress(nu, rad, ey, j, nlayers, n_radial_array):
     # out of numba, running the code, and then copying the result
     # back in. This means that the linear algebra solve is not compiled and runs
     # as if it were written in normal Python.
-    # This is necessary because numba compiles against the SciPy algebra library,
-    # not the Numpy one. There are differences in the Scipy solvers depending on
-    # operating system/architecture/Scipy version that cause tests to fail.
+    # This is necessary because it uses mpmath solvers that cannot be numba compiled.
+    # We do this because scipy and numpy linear algebra solvers produce
+    # slightly different results depending on the system (e.g. Mac and Linux) which mean
+    # PROCESS can produce different results depending on where it is run!
     # https://github.com/ukaea/PROCESS/issues/3027
     # https://github.com/scipy/scipy/issues/23639
     with numba.objmode(cc="float64[:]"):
+        # These matrices can often end up being very ill-conditioned which can lead to numerical
+        # instability when solving below.
+        # Scaling the matrix can help reduce numerical instability by reducing the condition of matrix.
+        # Here, we scale aa such that the largest element on a given row is 1.0. This does not
+        # change the solution provided each element of a given row is scaled by the same scalar
+        # and the corresponding entry in bb is also scaled the same amount.
+        row_scale = np.max(np.abs(aa), axis=1)
+        aa /= np.repeat(row_scale[:, np.newaxis], aa.shape[0], axis=1)
+        bb /= row_scale
+
         cc = np.linalg.solve(aa, bb)
 
     #  Multiply c by (-1) (John Last, internal CCFE memorandum, 21/05/2013)

--- a/tests/unit/test_tfcoil.py
+++ b/tests/unit/test_tfcoil.py
@@ -5128,7 +5128,7 @@ class PlaneStressParam(NamedTuple):
         ),
     ),
 )
-def test_plane_stress(planestressparam, monkeypatch):
+def test_plane_stress(planestressparam, skip_if_incompatible_system):
     """
     Automatically generated Regression Unit Test for plane_stress.
 


### PR DESCRIPTION
Sadly, #3856 was short lived and enabling `numpy>=2` re-introduced the issues observed in #3027. 

I have been unable to find an acceptably fast solution that will ensure parity on different systems when solving $Ax=b$ in the `plane_stress` function. The issue arises (I believe) because the matrix `aa` is ill-conditioned (on the order of $10^{12}$). 

The first thing this PR introduces is a row-wise scaling of the `aa` matrix and `bb` vector such that the largest value on a row of `aa` will be `1.0`. This reduces the condition of `aa` significantly (to be on the order of $10^{3}$). However, one of the `plane_stress` tests still failed on Mac, the other two passed.

The second thing I have done is skip this test if the system is deemed incompatible (we actually already had a function for this that I wrote back in 2021). This means that the `plane_stress` tests are skipped on incompatible systems (e.g. Mac, Windows, CSD3) and will run when we think it should pass (on Ubuntu VMs and the CI). Maybe the reviewer could check that these tests don't get skipped on WSL/their Ubuntu laptop. 

I have also added a warning to the installation page to ensure this issue is abundantly obvious.

<img width="755" height="289" alt="image" src="https://github.com/user-attachments/assets/85f312fb-6d85-4fde-ba62-84a5978e512f" />
