### PR TITLE
Write constraint information to output files

### DIFF
--- a/process/scan.py
+++ b/process/scan.py
@@ -514,11 +514,25 @@ class Scan:
 
             for i in range(numerics.neqns, numerics.neqns + numerics.nineqns):
                 name = numerics.lablcc[numerics.icc[i] - 1]
+                constraint_bound = con2[i]
+
+                # assumes f-value is 1
+                # -cc because sign is reversed in constraint_eqns
+                if sym[i] == ">=":
+                    constraint_value = constraint_bound * (1 - -numerics.rcm[i])
+                elif sym[i] == "<=":
+                    constraint_value = constraint_bound * (-numerics.rcm[i] + 1)
+                else:
+                    raise ProcessValueError(
+                        f"Unknown constraint direction '{sym[i]}' for inequality constraint"
+                    )
+
                 inequality_constraint_table.append([
                     name,
+                    f"{constraint_value} {lab[i]}",
                     sym[i],
                     f"{con2[i]} {lab[i]}",
-                    f"{err[i]} {lab[i]}",
+                    f"{numerics.rcm[i]}",
                 ])
                 process_output.ovarre(
                     constants.MFILE,
@@ -533,9 +547,10 @@ class Scan:
                     inequality_constraint_table,
                     headers=[
                         "",
-                        "",
                         "Physical constraint",
-                        "Constraint residue",
+                        "",
+                        "Physical constraint bound",
+                        "Normalised residue",
                     ],
                     numalign="left",
                 ),

--- a/process/scan.py
+++ b/process/scan.py
@@ -541,6 +541,27 @@ class Scan:
                     numerics.rcm[i],
                 )
 
+                process_output.ovarre(
+                    constants.MFILE,
+                    f"{name} physical value",
+                    f"(ineq_value_con{numerics.icc[i]:03d})",
+                    constraint_value,
+                )
+
+                process_output.ovarre(
+                    constants.MFILE,
+                    f"{name} symbol",
+                    f"(ineq_symbol_con{numerics.icc[i]:03d})",
+                    f"'{sym[i]}'",
+                )
+
+                process_output.ovarre(
+                    constants.MFILE,
+                    f"{name} physical bound",
+                    f"(ineq_bound_con{numerics.icc[i]:03d})",
+                    constraint_bound,
+                )
+
             process_output.write(
                 constants.NOUT,
                 tabulate(


### PR DESCRIPTION
# Correcting the inequality constraint table
Firstly, this PR corrects the inequality constraint output table. Before, this table made no sense (#3094) because it contradicted itself about whether a constraint was satisfied (positive normalised residual) or not (negative normalised residual). 

Now, the table shows the constraint value, symbol, bound, and normalised residual. I calculate the constraint value from the symbol, residual, and bound. The calculations are as follows:

## Upper limit
Constraint equation of the form: $c\leq b$
Has a normalised residual: $\widetilde{r}=\frac{c}{b}-f$

Therefore, the constraint value is: $c=b(\widetilde{r}+f)$

Remember, $f=1$

## Lower limit
Constraint equation of the form: $c\geq b$
Has a normalised residual: $\widetilde{r}=1-f\frac{c}{b}$

Therefore, the constraint value is: $c=\frac{b(1-\widetilde{r})}{f}$

Remember, $f=1$



In practice, we negate $\widetilde{r}$ for both types of limit constraint because of https://github.com/ukaea/PROCESS/blob/50cfc493678a06ec5be60b14589de270d60039c0/process/constraints.py#L2433


# Outputting inequality constraints
We now write out, in addition to the normalised residue, the constraint bound, value, and symbol.

# Example
Examples of the new output from `large_tokamak_nof.IN.DAT`
**OUT.DAT Table**
```
 
                                                          Physical constraint            Physical constraint bound    Normalised residue
--------------------------------------------------------  -------------------------  --  ---------------------------  --------------------
Injection power upper limit                               88.67837491742385 MW       <=  200.0 MW                     0.556608
L-H power threshold limit                                 158.45987577083508 MW      >=  95.08268678717913 MW         0.666548
Net electric power lower limit                            418.13832340444515 MW      >=  400.0 MW                     0.0453458
Beta upper limit                                          0.033324494713663          <=  0.04516382537055529          0.262142
Peak toroidal field upper limit                           13.583764792231696 T       <=  16.413978647121024 T         0.172427
CS coil EOF current density limit                         19532151.670199238 A/m2    <=  45424563.998366594 A/m2      0.570009
CS coil BOP current density limit                         19532151.67019924 A/m2     <=  35113280.95190337 A/m2       0.443739
I_op / I_critical (TF coil)                               25907205.686539706 A/m2    <=  36217676.62911642 A/m2       0.284681
Dump voltage upper limit                                  8.846078298429338 V        <=  10.0 V                       0.115392
J_winding pack/J_protection limit                         20166261.647819065 A/m2    <=  21261257.147664327 A/m2      0.0515019
TF coil temp. margin lower limit                          1.5902740514506704 K       >=  1.5 K                        0.0601827
CS temperature margin lower limit                         1.5300039957824714 K       >=  1.5 K                        0.0200027
f_alpha_energy_confinement                                7.563607059566988          >=  5.0                          0.512721
Dump time set by VV stress                                48451688.7943619 Pa        <=  143000000.0 Pa               0.661177
CS Tresca yield criterion                                 735956963.1866131 Pa       <=  750000000.0 Pa               0.018724
nd_plasma_electron_on_axis > nd_plasma_pedestal_electron  1.674019390072089 m-3      >=  1.0 m-3                      0.674019
Upper Lim. on Psep * Bt / q A R                           9.999941015261099 MWT/m    <=  10.0 MWT/m                   5.89847e-06
TF coil case stress upper limit                           750217032.6158159 Pa       <=  750000000.0 Pa               -0.000289377
TF coil conduit stress upper lim                          651879584.5259595 Pa       <=  750000000.0 Pa               0.130827
Density upper limit                                       9.177363581550417e+19 /m3  <=  9.190895688563432e+19 /m3    0.00147234
Neutron wall load upper limit                             1.0693469813034486 MW/m2   <=  2.0 MW/m2                    0.465327
Fusion power upper limit                                  2444.8218437392993 MW      <=  4290.55587588531 MW          0.430185
Burn time lower limit                                     7582.248437010465 sec      >=  7200.0 sec                   0.0530901
```

**MFILE.DAT**
```
Injection_power_upper_limit_______normalised_residue_____________________ (ineq_con030)__________________ 5.56608125412880739e-01 
Injection_power_upper_limit_______physical_value_________________________ (ineq_value_con030)____________ 8.86783749174238523e+01 
Injection_power_upper_limit_______symbol_________________________________ (ineq_symbol_con030)___________         '<=' 
Injection_power_upper_limit_______physical_bound_________________________ (ineq_bound_con030)____________ 2.00000000000000000e+02 
L-H_power_threshold_limit_________normalised_residue_____________________ (ineq_con015)__________________ 6.66548150090786828e-01 
L-H_power_threshold_limit_________physical_value_________________________ (ineq_value_con015)____________ 1.58459875770835083e+02 
L-H_power_threshold_limit_________symbol_________________________________ (ineq_symbol_con015)___________         '>=' 
L-H_power_threshold_limit_________physical_bound_________________________ (ineq_bound_con015)____________ 9.50826867871791279e+01 
Net_electric_power_lower_limit____normalised_residue_____________________ (ineq_con016)__________________ 4.53458085111129172e-02 
Net_electric_power_lower_limit____physical_value_________________________ (ineq_value_con016)____________ 4.18138323404445146e+02 
Net_electric_power_lower_limit____symbol_________________________________ (ineq_symbol_con016)___________         '>=' 
Net_electric_power_lower_limit____physical_bound_________________________ (ineq_bound_con016)____________ 4.00000000000000000e+02 
Beta_upper_limit__________________normalised_residue_____________________ (ineq_con024)__________________ 2.62141892537982035e-01 
Beta_upper_limit__________________physical_value_________________________ (ineq_value_con024)____________ 3.33244947136629999e-02 
Beta_upper_limit__________________symbol_________________________________ (ineq_symbol_con024)___________         '<=' 
Beta_upper_limit__________________physical_bound_________________________ (ineq_bound_con024)____________ 4.51638253705552925e-02 
Peak_toroidal_field_upper_limit___normalised_residue_____________________ (ineq_con025)__________________ 1.72427046222930258e-01 
Peak_toroidal_field_upper_limit___physical_value_________________________ (ineq_value_con025)____________ 1.35837647922316958e+01 
Peak_toroidal_field_upper_limit___symbol_________________________________ (ineq_symbol_con025)___________         '<=' 
Peak_toroidal_field_upper_limit___physical_bound_________________________ (ineq_bound_con025)____________ 1.64139786471210236e+01 
CS_coil_EOF_current_density_limit_normalised_residue_____________________ (ineq_con026)__________________ 5.70009044645941154e-01 
CS_coil_EOF_current_density_limit_physical_value_________________________ (ineq_value_con026)____________ 1.95321516701992378e+07 
CS_coil_EOF_current_density_limit_symbol_________________________________ (ineq_symbol_con026)___________         '<=' 
CS_coil_EOF_current_density_limit_physical_bound_________________________ (ineq_bound_con026)____________ 4.54245639983665943e+07 
CS_coil_BOP_current_density_limit_normalised_residue_____________________ (ineq_con027)__________________ 4.43738917563598734e-01 
CS_coil_BOP_current_density_limit_physical_value_________________________ (ineq_value_con027)____________ 1.95321516701992415e+07 
CS_coil_BOP_current_density_limit_symbol_________________________________ (ineq_symbol_con027)___________         '<=' 
CS_coil_BOP_current_density_limit_physical_bound_________________________ (ineq_bound_con027)____________ 3.51132809519033730e+07 
I_op_/_I_critical_(TF_coil)_______normalised_residue_____________________ (ineq_con033)__________________ 2.84680628416894010e-01 
I_op_/_I_critical_(TF_coil)_______physical_value_________________________ (ineq_value_con033)____________ 2.59072056865397058e+07 
I_op_/_I_critical_(TF_coil)_______symbol_________________________________ (ineq_symbol_con033)___________         '<=' 
I_op_/_I_critical_(TF_coil)_______physical_bound_________________________ (ineq_bound_con033)____________ 3.62176766291164234e+07 
Dump_voltage_upper_limit__________normalised_residue_____________________ (ineq_con034)__________________ 1.15392170157066154e-01 
Dump_voltage_upper_limit__________physical_value_________________________ (ineq_value_con034)____________ 8.84607829842933846e+00 
Dump_voltage_upper_limit__________symbol_________________________________ (ineq_symbol_con034)___________         '<=' 
Dump_voltage_upper_limit__________physical_bound_________________________ (ineq_bound_con034)____________ 1.00000000000000000e+01 
J_winding_pack/J_protection_limit_normalised_residue_____________________ (ineq_con035)__________________ 5.15019169487611617e-02 
J_winding_pack/J_protection_limit_physical_value_________________________ (ineq_value_con035)____________ 2.01662616478190646e+07 
J_winding_pack/J_protection_limit_symbol_________________________________ (ineq_symbol_con035)___________         '<=' 
J_winding_pack/J_protection_limit_physical_bound_________________________ (ineq_bound_con035)____________ 2.12612571476643272e+07 
TF_coil_temp._margin_lower_limit__normalised_residue_____________________ (ineq_con036)__________________ 6.01827009671136448e-02 
TF_coil_temp._margin_lower_limit__physical_value_________________________ (ineq_value_con036)____________ 1.59027405145067036e+00 
TF_coil_temp._margin_lower_limit__symbol_________________________________ (ineq_symbol_con036)___________         '>=' 
TF_coil_temp._margin_lower_limit__physical_bound_________________________ (ineq_bound_con036)____________ 1.50000000000000000e+00 
CS_temperature_margin_lower_limit_normalised_residue_____________________ (ineq_con060)__________________ 2.00026638549808400e-02 
CS_temperature_margin_lower_limit_physical_value_________________________ (ineq_value_con060)____________ 1.53000399578247137e+00 
CS_temperature_margin_lower_limit_symbol_________________________________ (ineq_symbol_con060)___________         '>=' 
CS_temperature_margin_lower_limit_physical_bound_________________________ (ineq_bound_con060)____________ 1.50000000000000000e+00 
f_alpha_energy_confinement________normalised_residue_____________________ (ineq_con062)__________________ 5.12721411913397596e-01 
f_alpha_energy_confinement________physical_value_________________________ (ineq_value_con062)____________ 7.56360705956698798e+00 
f_alpha_energy_confinement________symbol_________________________________ (ineq_symbol_con062)___________         '>=' 
f_alpha_energy_confinement________physical_bound_________________________ (ineq_bound_con062)____________ 5.00000000000000000e+00 
Dump_time_set_by_VV_stress________normalised_residue_____________________ (ineq_con065)__________________ 6.61177001438028711e-01 
Dump_time_set_by_VV_stress________physical_value_________________________ (ineq_value_con065)____________ 4.84516887943618968e+07 
Dump_time_set_by_VV_stress________symbol_________________________________ (ineq_symbol_con065)___________         '<=' 
Dump_time_set_by_VV_stress________physical_bound_________________________ (ineq_bound_con065)____________ 1.43000000000000000e+08 
CS_Tresca_yield_criterion_________normalised_residue_____________________ (ineq_con072)__________________ 1.87240490845158591e-02 
CS_Tresca_yield_criterion_________physical_value_________________________ (ineq_value_con072)____________ 7.35956963186613083e+08 
CS_Tresca_yield_criterion_________symbol_________________________________ (ineq_symbol_con072)___________         '<=' 
CS_Tresca_yield_criterion_________physical_bound_________________________ (ineq_bound_con072)____________ 7.50000000000000000e+08 
nd_plasma_electron_on_axis_>_nd_plasma_pedestal_electron_______________________normalised_residue_ (ineq_con081)__________________ 6.74019390072088997e-01 
nd_plasma_electron_on_axis_>_nd_plasma_pedestal_electron_______________________physical_value_ (ineq_value_con081)____________ 1.67401939007208900e+00 
nd_plasma_electron_on_axis_>_nd_plasma_pedestal_electron_______________________symbol_ (ineq_symbol_con081)___________         '>=' 
nd_plasma_electron_on_axis_>_nd_plasma_pedestal_electron_______________________physical_bound_ (ineq_bound_con081)____________ 1.00000000000000000e+00 
Upper_Lim._on_Psep_*_Bt_/_q_A_R___normalised_residue_____________________ (ineq_con068)__________________ 5.89847389009801049e-06 
Upper_Lim._on_Psep_*_Bt_/_q_A_R___physical_value_________________________ (ineq_value_con068)____________ 9.99994101526109880e+00 
Upper_Lim._on_Psep_*_Bt_/_q_A_R___symbol_________________________________ (ineq_symbol_con068)___________         '<=' 
Upper_Lim._on_Psep_*_Bt_/_q_A_R___physical_bound_________________________ (ineq_bound_con068)____________ 1.00000000000000000e+01 
TF_coil_case_stress_upper_limit___normalised_residue_____________________ (ineq_con031)__________________ -2.89376821087872216e-04 
TF_coil_case_stress_upper_limit___physical_value_________________________ (ineq_value_con031)____________ 7.50217032615815878e+08 
TF_coil_case_stress_upper_limit___symbol_________________________________ (ineq_symbol_con031)___________         '<=' 
TF_coil_case_stress_upper_limit___physical_bound_________________________ (ineq_bound_con031)____________ 7.50000000000000000e+08 
TF_coil_conduit_stress_upper_lim__normalised_residue_____________________ (ineq_con032)__________________ 1.30827220632053987e-01 
TF_coil_conduit_stress_upper_lim__physical_value_________________________ (ineq_value_con032)____________ 6.51879584525959492e+08 
TF_coil_conduit_stress_upper_lim__symbol_________________________________ (ineq_symbol_con032)___________         '<=' 
TF_coil_conduit_stress_upper_lim__physical_bound_________________________ (ineq_bound_con032)____________ 7.50000000000000000e+08 
Density_upper_limit_______________normalised_residue_____________________ (ineq_con005)__________________ 1.47233822160042216e-03 
Density_upper_limit_______________physical_value_________________________ (ineq_value_con005)____________ 9.17736358155041669e+19 
Density_upper_limit_______________symbol_________________________________ (ineq_symbol_con005)___________         '<=' 
Density_upper_limit_______________physical_bound_________________________ (ineq_bound_con005)____________ 9.19089568856343183e+19 
Neutron_wall_load_upper_limit_____normalised_residue_____________________ (ineq_con008)__________________ 4.65326509348275685e-01 
Neutron_wall_load_upper_limit_____physical_value_________________________ (ineq_value_con008)____________ 1.06934698130344863e+00 
Neutron_wall_load_upper_limit_____symbol_________________________________ (ineq_symbol_con008)___________         '<=' 
Neutron_wall_load_upper_limit_____physical_bound_________________________ (ineq_bound_con008)____________ 2.00000000000000000e+00 
Fusion_power_upper_limit__________normalised_residue_____________________ (ineq_con009)__________________ 4.30185291961770244e-01 
Fusion_power_upper_limit__________physical_value_________________________ (ineq_value_con009)____________ 2.44482184373929931e+03 
Fusion_power_upper_limit__________symbol_________________________________ (ineq_symbol_con009)___________         '<=' 
Fusion_power_upper_limit__________physical_bound_________________________ (ineq_bound_con009)____________ 4.29055587588531034e+03 
Burn_time_lower_limit_____________normalised_residue_____________________ (ineq_con013)__________________ 5.30900606958979449e-02 
Burn_time_lower_limit_____________physical_value_________________________ (ineq_value_con013)____________ 7.58224843701046484e+03 
Burn_time_lower_limit_____________symbol_________________________________ (ineq_symbol_con013)___________         '>=' 
Burn_time_lower_limit_____________physical_bound_________________________ (ineq_bound_con013)____________ 7.20000000000000000e+03 
```