### PR TITLE
Re-enable the ST evaluation regression test

### DIFF
--- a/tests/regression/test_process_input_files.py
+++ b/tests/regression/test_process_input_files.py
@@ -274,11 +274,6 @@ def test_input_file(
     should be compared in the test.
     :type opt_params_only: bool
     """
-    if input_file.name == "spherical_tokamak_eval.IN.DAT":
-        pytest.skip(
-            "The spherical tokamak evaluation currently encounters a divide by zero."
-        )
-
     new_input_file = tmp_path / input_file.name
     shutil.copy(input_file, new_input_file)
 


### PR DESCRIPTION
The ST evaluation regression file _appears_ to be running again without issue. It was disabled in #3646 because of divide by 0 errors and was set to be fixed in #3654. While the divide by 0 does not occur anymore and the file can be tested against, #3654 should still be resolved!