### PR TITLE
Add new obsolete variable mappings for pulse plant parameters

### DIFF
--- a/process/io/obsolete_vars.py
+++ b/process/io/obsolete_vars.py
@@ -466,7 +466,7 @@ OBS_VARS = {
     "t_fusion_ramp": "t_plant_pulse_fusion_ramp",
     "t_current_ramp_up": "t_plant_pulse_plasma_current_ramp_up",
     "t_ramp_down": "t_plant_pulse_plasma_current_ramp_down",
-    "t_between_pulses": "t_plant_pulse_dwell",
+    "t_between_pulse": "t_plant_pulse_dwell",
     "t_precharge": "t_plant_pulse_coil_precharge",
     "t_burn": "t_plant_pulse_burn",
 }


### PR DESCRIPTION
This pull request adds new mappings to the obsolete variable translation dictionary in `obsolete_vars.py`, helping to map several time-related legacy variable names to their updated equivalents.

New obsolete variable mappings:

* Added mappings for time-related variables, including `t_fusion_ramp`, `t_current_ramp_up`, `t_current_ramp_down`, `t_between_pulses`, `t_precharge`, and `t_burn`, translating them to their new standardized names in the dictionary.## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
