### PR TITLE
🐛 TF non integer turn `plot_proc` bugs

### DIFF
--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -6593,7 +6593,6 @@ def plot_tf_cable_in_conduit_turn(axis, fig, mfile_data, scan: int) -> None:
     axis.set_title("WP Turn Structure")
     axis.set_xlabel("r [m]")
     axis.set_ylabel("x [m]")
-    axis.grid(True, which="both", linestyle="--", linewidth=0.5, alpha=0.5)
 
     # Add info about the steel casing surrounding the WP
     textstr_turn_insulation = (
@@ -6623,7 +6622,7 @@ def plot_tf_cable_in_conduit_turn(axis, fig, mfile_data, scan: int) -> None:
     )
 
     axis.text(
-        0.55,
+        0.65,
         0.9,
         textstr_turn_steel,
         fontsize=9,
@@ -6651,8 +6650,8 @@ def plot_tf_cable_in_conduit_turn(axis, fig, mfile_data, scan: int) -> None:
     elif i_tf_turns_integer == 1:
         textstr_turn_cable_space = (
             f"$\\mathbf{{Cable \\ Space:}}$\n\n"
-            f"Cable space: \n{cable_space_width_radial:.3e} m radial width \n"
-            f"{cable_space_width_toroidal:.3e} m toroidal width \n"
+            f"Cable space: \n$\\Delta r$: {cable_space_width_radial:.3e} m \n"
+            f"$\\Delta x$: {cable_space_width_toroidal:.3e} m \n"
             f"Corner radius, $r$: {radius_tf_turn_cable_space_corners:.3e} m\n"
             f"Cable area with no cooling channel or gaps: {a_tf_turn_cable_space_no_void:.3e} m$^2$\n"
             f"Extra cable space area void fraction: {f_a_tf_turn_cable_space_extra_void}\n"
@@ -6670,6 +6669,36 @@ def plot_tf_cable_in_conduit_turn(axis, fig, mfile_data, scan: int) -> None:
         bbox={
             "boxstyle": "round",
             "facecolor": "royalblue",
+            "alpha": 1.0,
+            "linewidth": 2,
+        },
+    )
+
+    if i_tf_turns_integer == 0:
+        textstr_turn = (
+            f"$\\mathbf{{Turn:}}$\n\n"
+            f"$\\Delta r$: {turn_width:.3e} m\n"
+            f"$\\Delta x$: {turn_width:.3e} m"
+        )
+
+    if i_tf_turns_integer == 1:
+        textstr_turn = (
+            f"$\\mathbf{{Turn:}}$\n\n"
+            f"$\\Delta r$: {turn_width:.3e} m\n"
+            f"$\\Delta x$: {turn_height:.3e} m"
+        )
+
+    axis.text(
+        0.525,
+        0.9,
+        textstr_turn,
+        fontsize=9,
+        verticalalignment="top",
+        horizontalalignment="left",
+        transform=fig.transFigure,
+        bbox={
+            "boxstyle": "round",
+            "facecolor": "wheat",
             "alpha": 1.0,
             "linewidth": 2,
         },


### PR DESCRIPTION
This pull request makes several improvements and corrections to the plotting logic and labeling in the `_pack_strands_rectangular_with_obstacles` function in `process/io/plot_proc.py`. The main focus is on improving the accuracy of geometric calculations, clarifying axis labels, and enhancing the information displayed in plot annotations.

Key changes include:

**Geometric and Calculation Corrections:**

* Fixed a bug where the width and height of the cable space rectangle were incorrectly calculated using `turn_width` for both dimensions; now uses `turn_height` for the vertical dimension.
* Updated the parameters passed to the `_pack_strands_rectangular_with_obstacles` function to use explicit keyword arguments, improving clarity and reducing risk of errors.

**Plot Annotation and Labeling Improvements:**

* Changed axis labels from `"X [m]"` and `"Y [m]"` to `"r [m]"` and `"x [m]"` for more accurate physical representation.
* Improved the formatting and content of cable space and turn information in plot text annotations, including clearer variable names, better formatting, and more precise placement in the figure. 

<img width="846" height="583" alt="image" src="https://github.com/user-attachments/assets/3cda10f7-6849-40fe-be62-70bbbe7a0140" />


<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
