### PR TITLE
Write NaN to other H-factor table if calculation fails

### DIFF
--- a/process/physics.py
+++ b/process/physics.py
@@ -6775,10 +6775,15 @@ class Physics:
                 physics_variables.zeff,
             )
 
-            # Calculate the H-factor for the same confinement time in other scalings
-            physics_variables.hfac[i_confinement_time - 1] = self.find_other_h_factors(
-                i_confinement_time
-            )
+            try:
+                # Calculate the H-factor for the same confinement time in other scalings
+                physics_variables.hfac[i_confinement_time - 1] = (
+                    self.find_other_h_factors(i_confinement_time)
+                )
+            except ValueError:
+                # This is only used for a table in the OUT.DAT so if it fails
+                # just write a NaN--its not worth crashing PROCESS over.
+                physics_variables.hfac[i_confinement_time - 1] = np.nan
 
             po.ocmmnt(
                 self.outfile,


### PR DESCRIPTION
Fixes one of the errors in #3957. This error occurs when calculating comparison H-factors for a table in the OUT.DAT. It does not matter if these values are not in the OUT.DAT and so this PR sets it as a NaN if the calculation fails. 