### PR TITLE
Fix formatting in power density and plasma information plots; adjust …

### DIFF
--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -2150,7 +2150,7 @@ def plot_main_power_flow(
         (
             f"Plant base load:\n{mfile_data.data['p_plant_electric_base_total_mw'].get_scan(scan):.3f} MWe\n"
             f"Minimum base load:\n{mfile_data.data['p_plant_electric_base'].get_scan(scan) * 1.0e-6:.3f} MWe\n"
-            f"Plant floor power density:\n{mfile_data.data['pflux_plant_floor_electric'].get_scan(scan) * 1.0e-3:.3f} kW/m^2"
+            f"Plant floor power density:\n{mfile_data.data['pflux_plant_floor_electric'].get_scan(scan) * 1.0e-3:.3f} kW$\\text{{m}}^{{-2}}$"
         ),
         fontsize=9,
         verticalalignment="bottom",
@@ -2501,7 +2501,7 @@ def plot_main_plasma_information(
         f"$\\mathbf{{Shaping:}}$\n \n"
         f"$\\kappa_{{95}}$: {mfile_data.data['kappa95'].get_scan(scan):.2f} | $\\delta_{{95}}$: {mfile_data.data['triang95'].get_scan(scan):.2f} | $\\zeta$: {mfile_data.data['plasma_square'].get_scan(scan):.2f}\n"
         f"A: {mfile_data.data['aspect'].get_scan(scan):.2f}\n"
-        f"$ V_{{\\text{{p}}}}:$ {mfile_data.data['vol_plasma'].get_scan(scan):.2f}$ \\ \\text{{m}}^3$\n"
+        f"$ V_{{\\text{{p}}}}:$ {mfile_data.data['vol_plasma'].get_scan(scan):,.2f}$ \\ \\text{{m}}^3$\n"
         f"$ A_{{\\text{{p,surface}}}}:$ {mfile_data.data['a_plasma_surface'].get_scan(scan):,.2f}$ \\ \\text{{m}}^2$\n"
         f"$ A_{{\\text{{p_poloidal}}}}:$ {mfile_data.data['a_plasma_poloidal'].get_scan(scan):,.2f}$ \\ \\text{{m}}^2$\n"
         f"$ L_{{\\text{{p_poloidal}}}}:$ {mfile_data.data['len_plasma_poloidal'].get_scan(scan):,.2f}$ \\ \\text{{m}}$"
@@ -2586,13 +2586,13 @@ def plot_main_plasma_information(
         f"Current driving power {mfile_data.data['p_hcd_primary_injected_mw'].get_scan(scan):.4f} MW\n"
         f"Extra heat power: {mfile_data.data['p_hcd_primary_extra_heat_mw'].get_scan(scan):.4f} MW\n"
         f"$\\gamma_{{\\text{{CD,prim}}}}$: {mfile_data.data['eta_cd_hcd_primary'].get_scan(scan):.4f} A/W\n"
-        f"$\\eta_{{\\text{{CD,prim}}}}$: {mfile_data.data['eta_cd_norm_hcd_primary'].get_scan(scan):.2f} $\\times 10^{{20}}  \\mathrm{{A}} / \\mathrm{{Wm}}^2$\n"
+        f"$\\eta_{{\\text{{CD,prim}}}}$: {mfile_data.data['eta_cd_norm_hcd_primary'].get_scan(scan):.4f} $\\times 10^{{20}}  \\mathrm{{A}} / \\mathrm{{Wm}}^2$\n"
         f"Current driven by primary: {mfile_data.data['c_hcd_primary_driven'].get_scan(scan) / 1e6:.3f} MA\n\n"
         f"$\\mathbf{{Secondary \\ system: {secondary_heating}}}$ \n"
         f"Current driving power {mfile_data.data['p_hcd_secondary_injected_mw'].get_scan(scan):.4f} MW\n"
         f"Extra heat power: {mfile_data.data['p_hcd_secondary_extra_heat_mw'].get_scan(scan):.4f} MW\n"
         f"$\\gamma_{{\\text{{CD,sec}}}}$: {mfile_data.data['eta_cd_hcd_secondary'].get_scan(scan):.4f} A/W\n"
-        f"$\\eta_{{\\text{{CD,sec}}}}$: {mfile_data.data['eta_cd_norm_hcd_secondary'].get_scan(scan):.2f} $\\times 10^{{20}}  \\mathrm{{A}} / \\mathrm{{Wm}}^2$\n"
+        f"$\\eta_{{\\text{{CD,sec}}}}$: {mfile_data.data['eta_cd_norm_hcd_secondary'].get_scan(scan):.4f} $\\times 10^{{20}}  \\mathrm{{A}} / \\mathrm{{Wm}}^2$\n"
         f"Current driven by secondary: {mfile_data.data['c_hcd_secondary_driven'].get_scan(scan) / 1e6:.3f} MA\n"
     )
 
@@ -11933,7 +11933,7 @@ def plot_plasma_outboard_toroidal_ripple_map(
     # Determine a sensible integer range of TF coils to scan around nominal
     n_nom = int(n_tf_coils)
     span = max(2, int(min(12, n_nom // 2)))  # choose a span based on nominal
-    n_min = max(12, n_nom - span)
+    n_min = max(10, n_nom - span)
     n_max = n_nom + span
     n_vals = np.arange(n_min, n_max + 1, dtype=int)
 


### PR DESCRIPTION
This pull request makes several improvements to the formatting and precision of plotted output in `process/io/plot_proc.py`, primarily focusing on more accurate scientific notation, better readability of numerical values, and a minor adjustment to the toroidal field coil scan range. The changes enhance the clarity and professionalism of the plots generated for power flow, plasma information, and ripple maps.

Formatting and precision improvements:

* Updated the unit formatting for plant floor power density in `plot_main_power_flow` to use proper LaTeX notation for meters squared (`kW$\text{m}^{-2}).
* Improved the readability of plasma volume, surface area, and poloidal area outputs in `plot_main_plasma_information` by adding thousands separators.
* Increased the precision of normalized current drive efficiency outputs in `plot_main_plasma_information` from two to four decimal places for both primary and secondary systems.

Toroidal field coil scan adjustment:

* Reduced the minimum number of TF coils scanned in `plot_plasma_outboard_toroidal_ripple_map` from 12 to 10, allowing a slightly broader scan range.
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
