### PR TITLE
Use Clarabel instead of OSQP to solve QPP in VMCON

### DIFF
--- a/process/solver.py
+++ b/process/solver.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 from abc import ABC, abstractmethod
 
+import cvxpy
 import numpy as np
 from pyvmcon import (
     AbstractProblem,
@@ -217,7 +218,7 @@ class Vmcon(_Solver):
                 np.array(self.bndu),
                 max_iter=global_variables.maxcal,
                 epsilon=self.tolerance,
-                qsp_options={"adaptive_rho_interval": 25},
+                qsp_options={"solver": cvxpy.CLARABEL},
                 initial_B=bb,
                 callback=_solver_callback,
                 additional_convergence=_ineq_cons_satisfied


### PR DESCRIPTION
I am noticing some non-determinisim in solver (specifically for the spherical tokamak regression test) where an "inaccurate solution" is returned from OSQP and this results in a non-deterministic step length. Clarbel was recommended for its determinism and accuracy (https://github.com/osqp/osqp-python/issues/116)