### PR TITLE
Add EBW/ECRH coupling efficiency graph plotting functionality

### DIFF
--- a/process/current_drive.py
+++ b/process/current_drive.py
@@ -2136,6 +2136,12 @@ class CurrentDrive:
                 "(n_ecrh_harmonic)",
                 current_drive_variables.n_ecrh_harmonic,
             )
+            po.ovarre(
+                self.outfile,
+                "EBW coupling efficiency",
+                "(xi_ebw)",
+                current_drive_variables.xi_ebw,
+            )
         if current_drive_variables.i_hcd_primary == 13:
             po.ovarin(
                 self.outfile,

--- a/process/io/plot_proc.py
+++ b/process/io/plot_proc.py
@@ -12458,7 +12458,7 @@ def plot_ebw_ecrh_coupling_graph(axis, mfile_data, scan):
                 / 1e20,
                 b_plasma_toroidal_on_axis=b,
                 n_ecrh_harmonic=n_harmonic,
-                xi_ebw=0.8,
+                xi_ebw=mfile_data.data["xi_ebw"].get_scan(scan),
             )
             eta_ecrh_omode = ecrg.electron_cyclotron_freethy(
                 te=mfile_data.data["temp_plasma_electron_vol_avg_kev"].get_scan(scan),
@@ -12603,7 +12603,7 @@ def main_plot(
     plot_power_info(fig1.add_subplot(235), m_file_data, scan)
 
     # Current drive
-    plot_current_drive_info(fig1.add_subplot(236), m_file_data, scan)
+    # plot_current_drive_info(fig1.add_subplot(236), m_file_data, scan)
     fig1.subplots_adjust(wspace=0.25, hspace=0.25)
 
     ax7 = fig2.add_subplot(121)


### PR DESCRIPTION
This pull request adds a new plot to visualize the coupling efficiency of Electron Bernstein Waves (EBW) and Electron Cyclotron Resonance Heating (ECRH) as a function of the toroidal B-field. The implementation includes the creation of a new plotting function, integration of this plot into the main plotting workflow, and necessary imports and resource management updates. Additionally, there is a minor correction in the calculation of the electron cyclotron frequency.

**New EBW/ECRH Coupling Efficiency Plot Integration:**

* Added a new function `plot_ebw_ecrh_coupling_graph` to `plot_proc.py` that generates a plot of EBW and ECRH coupling efficiency versus the on-axis toroidal B-field for the first three harmonics, including both O-mode and X-mode for ECRH. The plot is styled with different colors and line styles for clarity.
* Integrated the new plot into the main plotting workflow by:
  - Adding a new figure (`fig26`/`page26`) for the plot. 
  - Calling the new plotting function within `main_plot` and saving/closing the figure in the appropriate places. 
  - Passing the new figure throughout the plotting pipeline.
* Imported `ElectronBernstein` and `ElectronCyclotron` from `process.current_drive` to support the new plotting function.
<img width="1024" height="749" alt="image" src="https://github.com/user-attachments/assets/0efadee7-6a91-4953-8ab5-59b6c20bc6c3" />


------------------

🐛 Bugs

* Removed unnecessary division by `1.0e19` in the calculation of the electron cyclotron frequency in `electron_cyclotron_freethy`. This caused the EC to always never couple 🤯 

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
