### PR TITLE
:recycle: Refactor TF coil stress calculations to use a_cs_poloidal a…

### DIFF
--- a/process/resistive_tf_coil.py
+++ b/process/resistive_tf_coil.py
@@ -131,8 +131,6 @@ class ResistiveTFCoil(TFCoil):
                 int(tfcoil_variables.i_tf_bucking),
                 float(build_variables.r_tf_inboard_in),
                 build_variables.dr_bore,
-                build_variables.z_tf_inside_half,
-                pfcoil_variables.f_z_cs_tf_internal,
                 build_variables.dr_cs,
                 build_variables.i_tf_inside_cs,
                 build_variables.dr_tf_inboard,
@@ -192,6 +190,7 @@ class ResistiveTFCoil(TFCoil):
                 tfcoil_variables.a_tf_coil_inboard_case,
                 tfcoil_variables.vforce,
                 tfcoil_variables.a_tf_turn_steel,
+                pfcoil_variables.a_cs_poloidal,
             )
 
             tfcoil_variables.sig_tf_case = (

--- a/process/superconducting_tf_coil.py
+++ b/process/superconducting_tf_coil.py
@@ -155,8 +155,6 @@ class SuperconductingTFCoil(TFCoil):
                 int(tfcoil_variables.i_tf_bucking),
                 float(build_variables.r_tf_inboard_in),
                 build_variables.dr_bore,
-                build_variables.z_tf_inside_half,
-                pfcoil_variables.f_z_cs_tf_internal,
                 build_variables.dr_cs,
                 build_variables.i_tf_inside_cs,
                 build_variables.dr_tf_inboard,
@@ -216,6 +214,7 @@ class SuperconductingTFCoil(TFCoil):
                 tfcoil_variables.a_tf_coil_inboard_case,
                 tfcoil_variables.vforce,
                 tfcoil_variables.a_tf_turn_steel,
+                pfcoil_variables.a_cs_poloidal,
             )
 
             tfcoil_variables.sig_tf_case = (

--- a/process/tf_coil.py
+++ b/process/tf_coil.py
@@ -3138,8 +3138,6 @@ class TFCoil:
         i_tf_bucking,
         r_tf_inboard_in,
         dr_bore,
-        z_tf_inside_half,
-        f_z_cs_tf_internal,
         dr_cs,
         i_tf_inside_cs,
         dr_tf_inboard,
@@ -3199,6 +3197,7 @@ class TFCoil:
         a_tf_coil_inboard_case,
         vforce,
         a_tf_turn_steel,
+        a_cs_poloidal,
     ):
         """TF coil stress routine
 
@@ -3335,21 +3334,12 @@ class TFCoil:
                 # as the TF is called before CS in caller.f90
                 # -#
 
-                # CS vertical cross-section area [m2]
-                if i_tf_inside_cs == 1:
-                    a_oh = (
-                        2.0e0
-                        * z_tf_inside_half
-                        * f_z_cs_tf_internal
-                        * (dr_bore - dr_tf_inboard)
-                    )
-                else:
-                    a_oh = 2.0e0 * z_tf_inside_half * f_z_cs_tf_internal * dr_cs
-
                 # Maximum current in Central Solenoid, at either BOP or EOF [MA-turns]
                 # Absolute value
                 curr_oh_max = (
-                    1.0e-6 * np.maximum(j_cs_flat_top_end, j_cs_pulse_start) * a_oh
+                    1.0e-6
+                    * np.maximum(j_cs_flat_top_end, j_cs_pulse_start)
+                    * a_cs_poloidal
                 )
 
                 #  Number of turns
@@ -3360,7 +3350,7 @@ class TFCoil:
                 )
 
                 # CS Turn vertical cross-sectionnal area
-                a_cs_turn = a_oh / n_oh_turns
+                a_cs_turn = a_cs_poloidal / n_oh_turns
 
                 # CS coil turn geometry calculation - stadium shape
                 # Literature: https://doi.org/10.1016/j.fusengdes.2017.04.052

--- a/tests/unit/test_tfcoil.py
+++ b/tests/unit/test_tfcoil.py
@@ -852,7 +852,7 @@ class StressclParam(NamedTuple):
 
     dr_cs_tf_gap: Any = None
 
-    z_tf_inside_half: Any = None
+    a_cs_poloidal: Any = None
 
     r_tf_inboard_in: Any = None
 
@@ -962,8 +962,6 @@ class StressclParam(NamedTuple):
 
     f_a_cs_turn_steel: Any = None
 
-    f_z_cs_tf_internal: Any = None
-
     j_cs_flat_top_end: Any = None
 
     j_cs_pulse_start: Any = None
@@ -1031,9 +1029,9 @@ class StressclParam(NamedTuple):
             r_tf_inboard_mid=3.5979411851091103,
             dr_bore=2.3322000000000003,
             dr_cs=0.55242000000000002,
-            z_tf_inside_half=9.0730900215620327,
             r_tf_inboard_in=2.9939411851091102,
             casestr=0,
+            a_cs_poloidal=9.021881501,
             n_tf_coil_turns=200,
             dr_tf_wp_with_insulation=0.54261087836601019,
             i_tf_tresca=0,
@@ -1086,7 +1084,6 @@ class StressclParam(NamedTuple):
             n_tf_wp_stress_layers=5,
             i_pf_conductor=0,
             f_a_cs_turn_steel=0.57874999999999999,
-            f_z_cs_tf_internal=0.90000000000000002,
             j_cs_flat_top_end=20726000,
             j_cs_pulse_start=0,
             n_pf_coils_in_group=np.array(
@@ -1154,10 +1151,10 @@ class StressclParam(NamedTuple):
             r_tf_inboard_mid=3.5979411851091103,
             dr_bore=2.3322000000000003,
             dr_cs=0.55242000000000002,
-            z_tf_inside_half=9.0730900215620327,
             r_tf_inboard_in=2.9939411851091102,
             casestr=0.00094360452596334093,
             n_tf_coil_turns=200,
+            a_cs_poloidal=9.021881501,
             dr_tf_wp_with_insulation=0.54261087836601019,
             i_tf_tresca=0,
             a_tf_turn_cable_space_no_void=0.001293323051622732,
@@ -1209,7 +1206,6 @@ class StressclParam(NamedTuple):
             n_tf_wp_stress_layers=5,
             i_pf_conductor=0,
             f_a_cs_turn_steel=0.57874999999999999,
-            f_z_cs_tf_internal=0.90000000000000002,
             j_cs_flat_top_end=20726000,
             j_cs_pulse_start=19311657.760000002,
             n_pf_coils_in_group=np.array(
@@ -1327,8 +1323,6 @@ def test_stresscl(stressclparam, monkeypatch, tfcoil):
         stressclparam.i_tf_bucking,
         stressclparam.r_tf_inboard_in,
         stressclparam.dr_bore,
-        stressclparam.z_tf_inside_half,
-        stressclparam.f_z_cs_tf_internal,
         stressclparam.dr_cs,
         stressclparam.i_tf_inside_cs,
         stressclparam.dr_tf_inboard,
@@ -1388,6 +1382,7 @@ def test_stresscl(stressclparam, monkeypatch, tfcoil):
         stressclparam.a_tf_coil_inboard_case,
         stressclparam.vforce,
         stressclparam.a_tf_turn_steel,
+        stressclparam.a_cs_poloidal,
     )
 
     assert casestr == pytest.approx(stressclparam.expected_casestr, rel=0.01)


### PR DESCRIPTION
This pull request refactors the calculation of the central solenoid (CS) cross-sectional area in the toroidal field (TF) coil stress routine. The main change is to remove the dependence on the geometric parameters `z_tf_inside_half` and `f_z_cs_tf_internal` and instead use a new parameter, `a_cs_poloidal`, which represents the CS poloidal cross-sectional area. This simplifies the interface and makes the code more robust and maintainable. The changes are consistently applied across the main codebase and the unit tests.

**Refactoring of CS cross-sectional area calculation:**

* The `stresscl` function in `process/tf_coil.py` now takes `a_cs_poloidal` as an argument instead of calculating the CS area from `z_tf_inside_half` and `f_z_cs_tf_internal`. The code for this calculation has been removed, and all usages now reference `a_cs_poloidal` directly. 
* The `run` methods in both `process/resistive_tf_coil.py` and `process/superconducting_tf_coil.py` have been updated to pass `a_cs_poloidal` to `stresscl`, and the now-unused parameters have been removed from the function calls. 

**Updates to unit tests:**

* The `StressclParam` test parameter class and all test cases in `tests/unit/test_tfcoil.py` have been updated to use `a_cs_poloidal` instead of `z_tf_inside_half` and `f_z_cs_tf_internal`. All relevant test code and expected values have been modified accordingly. 

## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
