### PR TITLE
fix: update broken installation guide URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PROCESS was originally a Fortran code, but is now a pure-Python command line pro
 
 
 ## Getting Started
-Please see the [installation guide](https://ukaea.github.io/PROCESS/installation/introduction/) and the [usage guide](https://ukaea.github.io/PROCESS/usage/running-process/). Once installed, take a look at the [examples page](https://ukaea.github.io/PROCESS/usage/examples/) for examples of how PROCESS can be run, and its results visualised. 
+Please see the [installation guide](https://ukaea.github.io/PROCESS/installation/installation/) and the [usage guide](https://ukaea.github.io/PROCESS/usage/running-process/). Once installed, take a look at the [examples page](https://ukaea.github.io/PROCESS/usage/examples/) for examples of how PROCESS can be run, and its results visualised. 
 
 ## Documentation
 To read about how the code works and the modules in it see the [documentation](https://ukaea.github.io/PROCESS/).


### PR DESCRIPTION
## Description

This PR fixes a broken URL in the README.md file. The installation guide link was pointing to `/installation/introduction/` which doesn't exist in the documentation. The correct URL path is `/installation/installation/` which matches the actual documentation structure.

### Changes Made
- Updated the installation guide URL from `https://ukaea.github.io/PROCESS/installation/introduction/` to `https://ukaea.github.io/PROCESS/installation/installation/`

Fixes #3990

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.