### PR TITLE
fix: Correct installation guide URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PROCESS was originally a Fortran code, but is now a pure-Python command line pro
 
 
 ## Getting Started
-Please see the [installation guide](https://ukaea.github.io/PROCESS/installation/introduction/) and the [usage guide](https://ukaea.github.io/PROCESS/usage/running-process/). Once installed, take a look at the [examples page](https://ukaea.github.io/PROCESS/usage/examples/) for examples of how PROCESS can be run, and its results visualised. 
+Please see the [installation guide](https://ukaea.github.io/PROCESS/installation/installation/) and the [usage guide](https://ukaea.github.io/PROCESS/usage/running-process/). Once installed, take a look at the [examples page](https://ukaea.github.io/PROCESS/usage/examples/) for examples of how PROCESS can be run, and its results visualised. 
 
 ## Documentation
 To read about how the code works and the modules in it see the [documentation](https://ukaea.github.io/PROCESS/).


### PR DESCRIPTION
Updated the installation guide URL from installation/introduction/ to installation/installation/ as the documentation structure has changed.

Fixes #3990

## Description

This PR corrects the broken installation guide URL in the README.md file. The documentation structure has changed, and the old URL path `installation/introduction/` no longer exists. The correct path is now `installation/installation/`.
## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
