### PR TITLE
Replace constants PI/TWOPI with numpy

### DIFF
--- a/process/build.py
+++ b/process/build.py
@@ -80,7 +80,7 @@ class Build:
         # Have kept the single letter variable names to match the original code and documentation diagram.
         radius_beam_tangency = f_radius_beam_tangency_rmajor * rmajor
 
-        omega = constants.TWOPI / n_tf_coils
+        omega = 2.0 * np.pi / n_tf_coils
 
         a = 0.5e0 * dx_tf_inboard_out_toroidal
         try:

--- a/process/constants.py
+++ b/process/constants.py
@@ -270,12 +270,8 @@ TEMP_ROOM = 293.15
 Assume the room is at 20 degrees Celsius
 """
 
-PI = 3.1415926535897932
-
 RMU0 = 1.256637062e-6
 """permeability of free space  [H/m]"""
-
-TWOPI = 6.2831853071795862
 
 UMASS = 1.660538921e-27
 """unified atomic mass unit [kg]"""

--- a/process/costs.py
+++ b/process/costs.py
@@ -1690,7 +1690,8 @@ class Costs:
         for i in range(pfcoil_variables.n_cs_pf_coils):
             pfwndl = (
                 pfwndl
-                + constants.TWOPI
+                + 2.0
+                * np.pi
                 * pfcoil_variables.r_pf_coil_middle[i]
                 * pfcoil_variables.n_pf_coil_turns[i]
             )
@@ -1787,7 +1788,8 @@ class Costs:
 
             cost_variables.c22221 = cost_variables.c22221 + (
                 1.0e-6
-                * constants.TWOPI
+                * 2.0
+                * np.pi
                 * pfcoil_variables.r_pf_coil_middle[i]
                 * pfcoil_variables.n_pf_coil_turns[i]
                 * cpfconpm
@@ -1865,7 +1867,8 @@ class Costs:
 
             cost_variables.c22221 = cost_variables.c22221 + (
                 1.0e-6
-                * constants.TWOPI
+                * 2.0
+                * np.pi
                 * pfcoil_variables.r_pf_coil_middle[pfcoil_variables.n_cs_pf_coils - 1]
                 * pfcoil_variables.n_pf_coil_turns[pfcoil_variables.n_cs_pf_coils - 1]
                 * cpfconpm

--- a/process/divertor.py
+++ b/process/divertor.py
@@ -1,5 +1,7 @@
 import math
 
+import numpy as np
+
 from process import constants
 from process import process_output as po
 from process.data_structure import build_variables as bv
@@ -153,11 +155,11 @@ class Divertor:
 
         #  Vertical plate area
 
-        a1 = 2.0e0 * constants.PI * r1 * dz_divertor
+        a1 = 2.0e0 * np.pi * r1 * dz_divertor
 
         #  Horizontal plate area
 
-        a2 = constants.PI * (r2 * r2 - r1 * r1)
+        a2 = np.pi * (r2 * r2 - r1 * r1)
 
         #  Diagonal plate area
 
@@ -323,12 +325,7 @@ class Divertor:
 
         # Wetted area
         area_wetted = (
-            2
-            * constants.PI
-            * rmajor
-            * lambda_int
-            * f_div_flux_expansion
-            * math.sin(theta_div)
+            2 * np.pi * rmajor * lambda_int * f_div_flux_expansion * math.sin(theta_div)
         )
 
         # Divertor heat load

--- a/process/pfcoil.py
+++ b/process/pfcoil.py
@@ -605,8 +605,8 @@ class PFCoil:
 
             ddics = (
                 4.0e-7
-                * constants.PI
-                * constants.PI
+                * np.pi
+                * np.pi
                 * (
                     (bv.dr_bore * bv.dr_bore)
                     + (bv.dr_cs * bv.dr_cs) / 6.0e0
@@ -862,7 +862,7 @@ class PFCoil:
 
                 rll = (
                     2.0e0
-                    * constants.PI
+                    * np.pi
                     * pfcoil_variables.r_pf_coil_middle[i]
                     * pfcoil_variables.n_pf_coil_turns[i]
                 )
@@ -960,7 +960,7 @@ class PFCoil:
                 pfcoil_variables.m_pf_coil_structure[i] = (
                     areaspf
                     * 2.0e0
-                    * constants.PI
+                    * np.pi
                     * pfcoil_variables.r_pf_coil_middle[i]
                     * fwbsv.den_steel
                 )
@@ -1939,7 +1939,7 @@ class PFCoil:
                     rl = abs(
                         pfcoil_variables.z_pf_coil_upper[k]
                         - pfcoil_variables.z_pf_coil_lower[k]
-                    ) / math.sqrt(constants.PI)
+                    ) / math.sqrt(np.pi)
                     pfcoil_variables.ind_pf_cs_plasma_mutual[k, k] = (
                         constants.RMU0
                         * pfcoil_variables.n_pf_coil_turns[k] ** 2
@@ -3085,17 +3085,15 @@ class CSCoil:
         dr_cs_turn = f_dr_dz_cs_turn * dz_cs_turn
 
         # Calculate radius of cable space in CS turn
-        radius_cs_turn_cable_space = -(
-            (dr_cs_turn - dz_cs_turn) / constants.PI
-        ) + math.sqrt(
-            (((dr_cs_turn - dz_cs_turn) / constants.PI) ** 2)
+        radius_cs_turn_cable_space = -((dr_cs_turn - dz_cs_turn) / np.pi) + math.sqrt(
+            (((dr_cs_turn - dz_cs_turn) / np.pi) ** 2)
             + (
                 (
                     (dr_cs_turn * dz_cs_turn)
-                    - (4 - constants.PI) * (radius_cs_turn_corners**2)
+                    - (4 - np.pi) * (radius_cs_turn_corners**2)
                     - (a_cs_turn * f_a_cs_turn_steel)
                 )
-                / constants.PI
+                / np.pi
             )
         )
 
@@ -3416,7 +3414,7 @@ class CSCoil:
         pfcoil_variables.m_pf_coil_structure[pfcoil_variables.n_cs_pf_coils - 1] = (
             areaspf
             * 2.0e0
-            * constants.PI
+            * np.pi
             * pfcoil_variables.r_pf_coil_middle[pfcoil_variables.n_cs_pf_coils - 1]
             * fwbsv.den_steel
         )
@@ -3437,7 +3435,7 @@ class CSCoil:
                 pfcoil_variables.awpoh
                 * (1.0e0 - pfcoil_variables.f_a_cs_void)
                 * 2.0e0
-                * constants.PI
+                * np.pi
                 * pfcoil_variables.r_pf_coil_middle[pfcoil_variables.n_cs_pf_coils - 1]
                 * tfv.dcond[pfcoil_variables.i_cs_superconductor - 1]
             )
@@ -3446,7 +3444,7 @@ class CSCoil:
                 pfcoil_variables.awpoh
                 * (1.0e0 - pfcoil_variables.f_a_cs_void)
                 * 2.0e0
-                * constants.PI
+                * np.pi
                 * pfcoil_variables.r_pf_coil_middle[pfcoil_variables.n_cs_pf_coils - 1]
                 * constants.den_copper
             )
@@ -3538,7 +3536,7 @@ class CSCoil:
 
             pfcoil_variables.p_cs_resistive_flat_top = (
                 2.0e0
-                * constants.PI
+                * np.pi
                 * pfcoil_variables.r_cs_middle
                 * pfcoil_variables.rho_pf_coil
                 / (
@@ -3763,7 +3761,7 @@ class CSCoil:
         forc_z_cs_self_peak_midplane = axial_term_1 * (axial_term_2 - axial_term_3)
 
         # axial area [m2]
-        area_ax = constants.PI * (r_cs_outer**2 - r_cs_inner**2)
+        area_ax = np.pi * (r_cs_outer**2 - r_cs_inner**2)
 
         # Calculate unsmeared axial stress
         # Average axial stress at the interface of each half of the coil

--- a/process/physics.py
+++ b/process/physics.py
@@ -3924,7 +3924,7 @@ class Physics:
         # Main plasma current calculation using the fq value from the different settings
         if i_plasma_current != 2:
             plasma_current = (
-                (constants.TWOPI / constants.RMU0)
+                (2.0 * np.pi / constants.RMU0)
                 * rminor**2
                 / (rmajor * q95)
                 * fq

--- a/process/plasma_geometry.py
+++ b/process/plasma_geometry.py
@@ -452,7 +452,8 @@ class PlasmaGeom:
 
         rc = rmajor - rminor + xi
         vin = (
-            constants.TWOPI
+            2.0
+            * np.pi
             * xi
             * (
                 rc**2 * np.sin(thetai)
@@ -465,7 +466,8 @@ class PlasmaGeom:
 
         rc = rmajor + rminor - xo
         vout = (
-            constants.TWOPI
+            2.0
+            * np.pi
             * xo
             * (
                 rc**2 * np.sin(thetao)

--- a/process/tf_coil.py
+++ b/process/tf_coil.py
@@ -2209,9 +2209,7 @@ class TFCoil:
         )  # Cooling cross-sectional area
         dcool = 2.0e0 * tfcoil_variables.rcool  # Diameter
         lcool = 2.0e0 * (bv.z_tf_inside_half + bv.dr_tf_outboard)  # Length
-        tfcoil_variables.ncool = acool / (
-            constants.PI * tfcoil_variables.rcool**2
-        )  # Number
+        tfcoil_variables.ncool = acool / (np.pi * tfcoil_variables.rcool**2)  # Number
 
         # Average conductor cross-sectional area to cool (with cooling area)
         acpav = (
@@ -2220,7 +2218,7 @@ class TFCoil:
             / (bv.z_tf_inside_half + bv.dr_tf_outboard)
             + acool
         )
-        ro = (acpav / (constants.PI * tfcoil_variables.ncool)) ** 0.5
+        ro = (acpav / (np.pi * tfcoil_variables.ncool)) ** 0.5
 
         # Inner legs total heating power (to be removed by coolant)
         ptot = tfcoil_variables.p_cp_resistive + fwbs_variables.pnuc_cp_tf * 1.0e6
@@ -2307,12 +2305,7 @@ class TFCoil:
         nuselt = 0.023e0 * reyn**0.8e0 * prndtl**0.4e0
         h = nuselt * coolant_th_cond / dcool
         dtfilmav = ptot / (
-            h
-            * 2.0e0
-            * constants.PI
-            * tfcoil_variables.rcool
-            * tfcoil_variables.ncool
-            * lcool
+            h * 2.0e0 * np.pi * tfcoil_variables.rcool * tfcoil_variables.ncool * lcool
         )
 
         # Average film temperature (in contact with te conductor)
@@ -3094,7 +3087,7 @@ class TFCoil:
             ind_tf_coil = (
                 (z_tf_inside_half + dr_tf_outboard)
                 * constants.RMU0
-                / constants.PI
+                / np.pi
                 * np.log(r_tf_outboard_mid / r_tf_inboard_mid)
             )
 
@@ -3124,7 +3117,8 @@ class TFCoil:
         tfcoil_variables.tfcryoarea = (
             2.0e0
             * tfcoil_variables.len_tf_coil
-            * constants.TWOPI
+            * 2.0
+            * np.pi
             * 0.5e0
             * (build_variables.r_tf_inboard_mid + build_variables.r_tf_outboard_mid)
         )


### PR DESCRIPTION
Replaces use of our own `constants.PI` and `constants.TWOPI` with `np.pi` and `2.0 * np.pi`, respectively.