### PR TITLE
♻️ Create outboard blanket class

### DIFF
--- a/process/blanket_library.py
+++ b/process/blanket_library.py
@@ -3201,7 +3201,7 @@ class OutboardBlanket(BlanketLibrary):
             fwbs_variables.radius_blkt_channel_180_bend,
         ) = self.calculate_pipe_bend_radius(i_ps=1)
 
-    def set_blanket_outboard_module_geometry(
+    def calculate_blanket_outboard_module_geometry(
         self,
         n_blkt_outboard_modules_toroidal: int,
         rmajor: float,
@@ -3240,7 +3240,7 @@ class InboardBlanket(BlanketLibrary):
 
         self.set_blanket_module_geometry()
 
-    def set_blanket_inboard_module_geometry(
+    def calculate_blanket_inboard_module_geometry(
         self,
         n_blkt_inboard_modules_toroidal: int,
         rmajor: float,

--- a/process/dcll.py
+++ b/process/dcll.py
@@ -98,13 +98,13 @@ class DCLL(InboardBlanket, OutboardBlanket):
 
         self.set_blanket_module_geometry()
 
-        blanket_library.len_blkt_inboard_segment_toroidal = self.set_blanket_inboard_module_geometry(
+        blanket_library.len_blkt_inboard_segment_toroidal = self.calculate_blanket_inboard_module_geometry(
             n_blkt_inboard_modules_toroidal=fwbs_variables.n_blkt_inboard_modules_toroidal,
             rmajor=physics_variables.rmajor,
             rminor=physics_variables.rminor,
             dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
         )
-        blanket_library.len_blkt_outboard_segment_toroidal = self.set_blanket_outboard_module_geometry(
+        blanket_library.len_blkt_outboard_segment_toroidal = self.calculate_blanket_outboard_module_geometry(
             n_blkt_outboard_modules_toroidal=fwbs_variables.n_blkt_outboard_modules_toroidal,
             rmajor=physics_variables.rmajor,
             rminor=physics_variables.rminor,

--- a/process/hcpb.py
+++ b/process/hcpb.py
@@ -55,13 +55,13 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
 
         self.set_blanket_module_geometry()
 
-        blanket_library.len_blkt_inboard_segment_toroidal = self.set_blanket_inboard_module_geometry(
+        blanket_library.len_blkt_inboard_segment_toroidal = self.calculate_blanket_inboard_module_geometry(
             n_blkt_inboard_modules_toroidal=fwbs_variables.n_blkt_inboard_modules_toroidal,
             rmajor=physics_variables.rmajor,
             rminor=physics_variables.rminor,
             dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
         )
-        blanket_library.len_blkt_outboard_segment_toroidal = self.set_blanket_outboard_module_geometry(
+        blanket_library.len_blkt_outboard_segment_toroidal = self.calculate_blanket_outboard_module_geometry(
             n_blkt_outboard_modules_toroidal=fwbs_variables.n_blkt_outboard_modules_toroidal,
             rmajor=physics_variables.rmajor,
             rminor=physics_variables.rminor,


### PR DESCRIPTION
This pull request refactors the blanket geometry and pumping power calculation logic in the blanket library and its users. The main improvements are the introduction of dedicated `InboardBlanket` and `OutboardBlanket` classes with clearer geometry calculation methods, and the refactoring of the pumping power calculation into a function with explicit arguments and return values. These changes increase modularity, clarity, and maintainability of the code, especially for the DCLL and HCPB blanket models.

**Refactoring and modularization of blanket geometry:**

* Introduced new `InboardBlanket` and `OutboardBlanket` classes in `blanket_library.py`, each encapsulating their respective geometry calculations, and updated DCLL and HCPB blanket models to inherit from these classes instead of the generic `BlanketLibrary` (`process/blanket_library.py`, `process/dcll.py`, `process/hcpb.py`). [[1]](diffhunk://#diff-858473efc2b36dd626fbfa3ddfed2ba855a93ca40250b7c68674c49fdd85d35cR3191-R3266) [[2]](diffhunk://#diff-851e09957150122579c85765a32f8d87af1ba62536f68f2b1d60ac0cd1da8e59L6-R6) [[3]](diffhunk://#diff-851e09957150122579c85765a32f8d87af1ba62536f68f2b1d60ac0cd1da8e59L18-R18) [[4]](diffhunk://#diff-bc8026713206d98d6a7f290544bbbb116edee4694b1a10e6fc2eda4555c14846L11-R11) [[5]](diffhunk://#diff-bc8026713206d98d6a7f290544bbbb116edee4694b1a10e6fc2eda4555c14846L30-R30)
* Moved the calculation of toroidal segment lengths for inboard and outboard blankets into dedicated methods (`set_blanket_inboard_module_geometry`, `set_blanket_outboard_module_geometry`) and updated their usage in DCLL and HCPB `run` methods (`process/blanket_library.py`, `process/dcll.py`, `process/hcpb.py`). [[1]](diffhunk://#diff-858473efc2b36dd626fbfa3ddfed2ba855a93ca40250b7c68674c49fdd85d35cR3191-R3266) [[2]](diffhunk://#diff-851e09957150122579c85765a32f8d87af1ba62536f68f2b1d60ac0cd1da8e59R99-R113) [[3]](diffhunk://#diff-bc8026713206d98d6a7f290544bbbb116edee4694b1a10e6fc2eda4555c14846R56-R70)
* Removed the direct calculation of segment lengths from `set_blanket_module_geometry`, delegating this responsibility to the new methods and the respective blanket classes (`process/blanket_library.py`).

**Refactoring of pumping power calculation:**

* Refactored `set_pumping_powers_as_fractions` from a state-mutating function to a pure function with explicit arguments and return values, improving clarity and testability. Updated all usages to unpack the returned tuple and assign the results (`process/blanket_library.py`, `process/dcll.py`, `process/hcpb.py`). [[1]](diffhunk://#diff-858473efc2b36dd626fbfa3ddfed2ba855a93ca40250b7c68674c49fdd85d35cL2981-R3020) [[2]](diffhunk://#diff-851e09957150122579c85765a32f8d87af1ba62536f68f2b1d60ac0cd1da8e59L312-R346) [[3]](diffhunk://#diff-bc8026713206d98d6a7f290544bbbb116edee4694b1a10e6fc2eda4555c14846L816-R850)

**Code cleanup and logic improvements:**

* Removed redundant or now-unnecessary calls to geometry setup methods in the thermo-hydraulic model, as this is now handled in the blanket-specific classes (`process/blanket_library.py`).

These changes collectively make the codebase more modular, easier to extend for new blanket types, and clearer in terms of data flow and responsibility separation.## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
