### PR TITLE
Fix message in out.dat when a variable is at or below/above its lower/upper bounds

### DIFF
--- a/process/scan.py
+++ b/process/scan.py
@@ -388,12 +388,14 @@ class Scan:
 
                 if numerics.xcm[i] < xminn:
                     location, bound = "below", "lower"
+                    bounds = numerics.itv_scaled_lower_bounds
                 else:
                     location, bound = "above", "upper"
+                    bounds = numerics.itv_scaled_upper_bounds
                 process_output.write(
                     constants.NOUT,
                     f"   {name:<30}= {xcval} is at or {location} its {bound} bound:"
-                    f" {numerics.itv_scaled_upper_bounds[i] * numerics.scafc[i]}",
+                    f" {bounds[i] * numerics.scafc[i]}",
                 )
 
             # Write optimisation parameters to mfile


### PR DESCRIPTION


## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
Closes #3998 
Before, the message printing if a variable was below its lower bounds it was using the scaled_upper_bounds array so the message was wrong in some cases before:

```* Safety factor at 95% flux surface 
ixc = 18
boundl(18) = 3.0
boundu(18) = 4.0
q95 = 3.0

* TF Current per turn [A]
ixc = 60
boundl(60) = 65000.0
boundu(60) = 90000.0
c_tf_turn = 65000.0
```


<img width="889" height="140" alt="image" src="https://github.com/user-attachments/assets/d2f9b94c-baed-4fe3-a413-842a54ce5ed6" />

Now it prints correctly:
<img width="800" height="124" alt="image" src="https://github.com/user-attachments/assets/d7f44f72-8c70-46c9-855b-0d9fa160465b" />


## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
