### PR TITLE
Install example dependencies when installing test dependencies

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install PROCESS
         # Editable install to match default install
         run: |
-          pip install -e '.[test, examples]'
+          pip install -e '.[test]'
       - name: Install poppler
         run: |
           sudo apt update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ test = [
   "requests>=2.30",
   "testbook>=0.4",
   "pytest-cov>=3.0.0",
-  "pytest-xdist>=2.5.0"
+  "pytest-xdist>=2.5.0",
+  "process[examples]"
 ]
 examples = ["jupyter==1.0.0"]
 plotly = ["plotly>=5.15.0,<6"]


### PR DESCRIPTION
When installing `process` with `test` optional dependencies, it will also install the `examples` optional dependencies