### PR TITLE
c_tf_turn error catching

### DIFF
--- a/process/init.py
+++ b/process/init.py
@@ -334,7 +334,7 @@ def check_process(inputs):  # noqa: ARG001
         data_structure.numerics.ixc[: data_structure.numerics.nvar] == 60
     ).any() and data_structure.tfcoil_variables.i_tf_turns_integer == 1:
         raise ProcessValidationError(
-            "Iteration variable 60 (c_tf_turn) cannot be used when i_tf_turns_integer == 1"
+            "Iteration variable 60 (TF current per turn, c_tf_turn) cannot be used with the TF coil integer turn model (i_tf_turns_integer == 1) as it is a calculated output instead for this model. However, the maximum current per turn can be constrained with constraint 77."
         )
 
     # Can't have icc 77 and ixc 60 at the same time
@@ -342,7 +342,7 @@ def check_process(inputs):  # noqa: ARG001
         data_structure.numerics.icc[: data_structure.numerics.nvar] == 77
     ).any():
         raise ProcessValidationError(
-            "Cannot use iteration variable 60 and constraint 77 simultaneously"
+            "Cannot use iteration variable 60 (TF coil current per turn, c_tf_turn) and constraint 77 (maximum TF current per turn) simultaneously."
         )
 
     if (


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
Check that ixc = 60 (c_tf_turn) is not used when i_tf_turns_integer is 1
Check that ixc = 60 is not used with icc = 77

Updated version of #3114  - this PR was very outdated. Will close #724 

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
