### PR TITLE
Write an additional log file in PROCESS working directory

### DIFF
--- a/process/main.py
+++ b/process/main.py
@@ -111,6 +111,8 @@ from process.water_use import WaterUse
 
 os.environ["PYTHON_PROCESS_ROOT"] = os.path.join(os.path.dirname(__file__))
 
+PACKAGE_LOGGING = True
+"""Can be set False to disable package-level logging, e.g. in the test suite"""
 logger = logging.getLogger("process")
 
 
@@ -737,12 +739,19 @@ logging_model_handler.setFormatter(logging_formatter)
 def setup_loggers(working_directory_log_path: Path | None = None):
     """A function that adds our handlers to the appropriate logger object."""
     # Remove all of the existing handlers from the 'process' package logger
+
     logger.handlers.clear()
+
+    # we always want to add this handler because otherwise PROCESS' error
+    # handling system won't work properly
+    logger.addHandler(logging_model_handler)
+
+    if not PACKAGE_LOGGING:
+        return
 
     # (Re)add the loggers to the 'process' package logger (and its children)
     logger.addHandler(logging_stream_handler)
     logger.addHandler(logging_file_handler)
-    logger.addHandler(logging_model_handler)
 
     if working_directory_log_path is not None:
         logging_file_input_location_handler = logging.FileHandler(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from _pytest.fixtures import SubRequest
 from system_check import system_compatible
 
+from process import main
 from process.log import logging_model_handler
 
 
@@ -157,3 +158,12 @@ def return_to_root():
     cwd = os.getcwd()
     yield
     os.chdir(cwd)
+
+
+@pytest.fixture(autouse=True)
+def disable_package_logger(monkeypatch):
+    """Various parts of PROCESS change directories and do not always change back.
+    This fixture ensures that, at the end of each test, the cwd is reset to what it
+    was at the beginning of the test.
+    """
+    monkeypatch.setattr(main, "PACKAGE_LOGGING", False)


### PR DESCRIPTION
Writes an additional logfile in the PROCESS working directory (where the input file is) that follows the name of the input file:
- `my.IN.DAT` produces a `my.process.log` 
- `my_IN.DAT` produces a `my_process.log`

<img width="205" height="153" alt="image" src="https://github.com/user-attachments/assets/b414f64b-0ca6-401c-b356-59ef55f52348" />

This does not remove the old `process.log` file which is created in the terminal working directory.