### PR TITLE
Preempt possible unit test failures from ill-conditioned matrices

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def skip_if_incompatible_system():
     if not system_compatible():
         pytest.skip(
             "This test could fail on your system due to differences caused by "
-            "floating-point rounding error"
+            "floating-point rounding differences in np.linalg.solve"
         )
 
 

--- a/tests/system_check.py
+++ b/tests/system_check.py
@@ -11,6 +11,7 @@ can be identified and compared against a known system.
 """
 
 import numpy as np
+import pytest
 
 
 def _hilbert_matrix(n):
@@ -38,4 +39,4 @@ def system_compatible():
     rel_diff = np.linalg.norm(x - x_perturbed) / np.linalg.norm(x)
 
     # check that relative difference against a known solution
-    return rel_diff == 5.8813403984318865e-05
+    return rel_diff == pytest.approx(5.8813403984318865e-05)


### PR DESCRIPTION
Closes #4000 

The random unit test failures come from linear algebra on ill-conditioned systems of equations. Some systems (combinations of OS, software, processor, architecture) produce slightly different results for the same calculations near system epsilon. We can identify systems where this will happen and skip problematic tests. 