### PR TITLE
Fix c tf turn error in low aspect demo file

### DIFF
--- a/tests/regression/input_files/low_aspect_ratio_DEMO.IN.DAT
+++ b/tests/regression/input_files/low_aspect_ratio_DEMO.IN.DAT
@@ -269,8 +269,6 @@ boundu(59) = 0.94
 * JUSTIFICATION:
 
 c_tf_turn = 6.5e4 *5.90832367922454432e+04
-boundl(60) = 5.9e4
-boundu(60) = 9.0e4
 * DESCRIPTION:   Max TF coil current per turn [A]
 * JUSTIFICATION: Calculate turn area consistent with TF currents 
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
removed ixc=60 from low aspect ratio demo input file

Outputs:
[low_aspect_ratio_DEMO_results.zip](https://github.com/user-attachments/files/24767511/low_aspect_ratio_DEMO_results.zip)

Regression test failures:

<img width="1427" height="228" alt="image" src="https://github.com/user-attachments/assets/dc646434-2fb0-4cfa-b52c-ca6685b0d71a" />


<img width="1427" height="228" alt="image" src="https://github.com/user-attachments/assets/edc49ede-ddd4-40f5-8870-ca1100bee82b" />


<img width="1427" height="228" alt="image" src="https://github.com/user-attachments/assets/0f0e7a56-256e-45fc-97c2-86484c1b8476" />


<img width="1427" height="228" alt="image" src="https://github.com/user-attachments/assets/23996e6f-8138-4fa4-8e9b-f7e739b5aaa7" />




## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
