### PR TITLE
Only run CI on pushes to main, pull requests, or manual request

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -4,6 +4,9 @@ name: PROCESS main/develop testing
 on:
   pull_request:
   push:
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Updates what events our CI runs `on`.
- `pull_request`: when a PR is opened, re-opened, or the branch is updated
- `branch`: only when the main branch is pushed to
- `workflow_dispatch`: when a user manually requests the CI to be run via the GitHub UI