### PR TITLE
Fixed negativity in sqrt in costs.py by np.clip.

### DIFF
--- a/process/costs.py
+++ b/process/costs.py
@@ -3030,18 +3030,17 @@ class Costs:
         #  Annual cost of operation and maintenance
 
         if heat_transport_variables.p_plant_electric_net_mw < 0:
-            sqrt_p_plant_electric_net_mw = 0.0
+            sqrt_p_plant_electric_net_mw_1200 = 0.0
             logger.warning(
                 "p_plant_electric_net_mw has gone negative! Clamping it to 0 for the calculation of annoam and annwst (cost of maintenance and cost of waste)."
             )
         else:
-            sqrt_p_plant_electric_net_mw = np.sqrt(
-                heat_transport_variables.p_plant_electric_net_mw
+            sqrt_p_plant_electric_net_mw_1200 = np.sqrt(
+                heat_transport_variables.p_plant_electric_net_mw / 1200.0e0
             )
         annoam = (
             cost_variables.ucoam[cost_variables.lsa - 1]
-            * sqrt_p_plant_electric_net_mw
-            / 1200.0e0
+            * sqrt_p_plant_electric_net_mw_1200
         )
 
         #  Additional cost due to pulsed reactor thermal storage
@@ -3058,7 +3057,7 @@ class Costs:
         #
         #  Scale with net electric power
         #
-        #         annoam1 = annoam1 * sqrt_p_plant_electric_net_mw/1200.0e0
+        #         annoam1 = annoam1 * heat_transport_variables.p_plant_electric_net_mw/1200.0e0
         #
         #  It is necessary to convert from 1992 pounds to 1990 dollars
         #  Reasonable guess for the exchange rate + inflation factor
@@ -3113,8 +3112,7 @@ class Costs:
 
         annwst = (
             cost_variables.ucwst[cost_variables.lsa - 1]
-            * sqrt_p_plant_electric_net_mw
-            / 1200.0e0
+            * sqrt_p_plant_electric_net_mw_1200
         )
 
         #  Cost of electricity due to waste disposal


### PR DESCRIPTION
## Description

Patches away the RuntimeWarning caused by sqrt(p_plant_electric_net_mw/1200), where p_plant_electric_net_mw may cross over to negative values briefly during the optimization process (but is expected to always converge on a positive value).

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made. (N/A)
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly. (N/A)
- [x] I have added documentation for my change, if appropriate. (N/A)
