### PR TITLE
:bug: Fix stacked plots functionality by ensuring multiple output var…

### DIFF
--- a/process/core/io/plot/scans.py
+++ b/process/core/io/plot/scans.py
@@ -709,11 +709,11 @@ def plot_scan(
             else:
                 extra_str = f"{output_name}{f'_vs_{output_name2}' if len(output_names2) > 0 else ''}"
 
-            plt.savefig(
-                outputdir / f"scan_{scan_var_name}_vs_{extra_str}.{save_format}",
-                dpi=300,
-            )
             if not stack_plots:  # Display plot (used in Jupyter notebooks)
+                plt.savefig(
+                    outputdir / f"scan_{scan_var_name}_vs_{extra_str}.{save_format}",
+                    dpi=300,
+                )
                 plt.show()
                 plt.clf()
         # ------------

--- a/process/core/io/plot/scans.py
+++ b/process/core/io/plot/scans.py
@@ -353,9 +353,7 @@ def plot_scan(
         # Plot section
         # -----------
         for index, output_name in enumerate(output_names):
-            if stack_plots:
-                pass
-            else:
+            if not stack_plots:
                 fig, ax = plt.subplots()
                 if len(output_names2) > 0:
                     ax2 = ax.twinx()

--- a/process/core/io/plot/scans.py
+++ b/process/core/io/plot/scans.py
@@ -354,18 +354,7 @@ def plot_scan(
         # -----------
         for index, output_name in enumerate(output_names):
             if stack_plots:
-                # check stack plots will work
-                if len(output_names) <= 1:
-                    raise ValueError(
-                        "For stack plots to be used need more than 1 output variable"
-                    )
-                fig, axs = plt.subplots(
-                    len(output_names),
-                    1,
-                    figsize=(8.0, (3.5 + (1 * len(output_names)))),
-                    sharex=True,
-                )
-                fig.subplots_adjust(hspace=0.0)
+                pass
             else:
                 fig, ax = plt.subplots()
                 if len(output_names2) > 0:
@@ -442,7 +431,22 @@ def plot_scan(
                     plt.tight_layout()
                 else:
                     if stack_plots:
-                        axs[output_names.index(output_name)].plot(
+                        # check stack plots will work
+                        if len(output_names) <= 1:
+                            raise ValueError(
+                                "For stack plots need more than 1 output variable"
+                            )
+                        # Create subplots only once for the first output
+                        if index == 0:
+                            fig, axs = plt.subplots(
+                                len(output_names),
+                                1,
+                                figsize=(8.0, (3.5 + (1 * len(output_names)))),
+                                sharex=True,
+                            )
+                            fig.subplots_adjust(hspace=0.0)
+
+                        axs[index].plot(
                             scan_var_array[input_file],
                             output_arrays[input_file][output_name],
                             "--o",

--- a/process/core/io/plot/scans.py
+++ b/process/core/io/plot/scans.py
@@ -432,7 +432,7 @@ def plot_scan(
                         # check stack plots will work
                         if len(output_names) <= 1:
                             raise ValueError(
-                                "For stack plots need more than 1 output variable"
+                                "stack_plots requires at least two output variables"
                             )
                         # Create subplots only once for the first output
                         if index == 0:
@@ -709,13 +709,14 @@ def plot_scan(
             else:
                 extra_str = f"{output_name}{f'_vs_{output_name2}' if len(output_names2) > 0 else ''}"
 
-            if not stack_plots:  # Display plot (used in Jupyter notebooks)
+            if (not stack_plots) or (stack_plots and output_names[-1] == output_name):
                 plt.savefig(
-                    outputdir / f"scan_{scan_var_name}_vs_{extra_str}.{save_format}",
+                    f"{outputdir}/scan_{scan_var_name}_vs_{extra_str}.{save_format}",
                     dpi=300,
                 )
                 plt.show()
                 plt.clf()
+                plt.close()
         # ------------
 
     # In case of a 2D scan


### PR DESCRIPTION
This pull request refactors the logic for handling stacked plots in the `main` function of `process/io/plot_scans.py`. The main improvement is to ensure that subplots for stacked plots are created only once, and only when needed, thereby fixing potential issues with subplot creation and improving code clarity.

Plotting logic improvements:

* Moved the creation of subplots for stacked plots (`fig, axs = plt.subplots(...)`) from the outer loop to occur only once, at the first relevant iteration, preventing redundant subplot creation and related errors.
* Removed the previous subplot creation block from the outer loop and replaced it with a `pass` statement, since subplot creation is now handled inside the plotting logic.
* Added a check to raise a `ValueError` if stacked plots are requested with only one output variable, ensuring proper usage and error handling.…iables are handled correctly

## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
