### PR TITLE
Specify dr_tf_inboard in ST eval file

### DIFF
--- a/tests/regression/input_files/spherical_tokamak_eval.IN.DAT
+++ b/tests/regression/input_files/spherical_tokamak_eval.IN.DAT
@@ -337,7 +337,7 @@ i_pulsed_plant   = 0 * Switch for reactor model;
 
 
 *-----------------Tfcoil Variables-----------------*
-
+dr_tf_inboard = 0.9 * TF coil inboard leg radial thickness (m)
 sig_tf_case_max = 850.0e6 * Allowable maximum shear stress (Tresca criterion) in TF coil case (Pa)
 sig_tf_wp_max = 700.0e6 * Allowable maximum shear stress (Tresca criterion) in TF coil conduit (Pa)
 f_dr_tf_plasma_case = 1.0e-12 * inboard TF coil case plasma side thickness as a fraction of tfcth


### PR DESCRIPTION
Adds `dr_tf_inboard = 0.9` to `spherical_tokamak_eval.IN.DAT`, the value is taken from the `st_regression.IN.DAT` optimised solution. 

This was causing the winding pack to become excessively large, meaning the cable plotting algorithm was iterating over trillions of elements:
1. `dr_tf_inboard` was `0` (its default) which caused `dr_tf_wp_with_insulation` to become negative https://github.com/ukaea/PROCESS/blob/40782b5c86efd377fb331cc26bb05b400fd1b2cf/process/build.py#L1783-L1790
2. Which causes `j_tf_wf` to become `1` https://github.com/ukaea/PROCESS/blob/40782b5c86efd377fb331cc26bb05b400fd1b2cf/process/superconducting_tf_coil.py#L2722-L2729
3. Which causes the turn area to become excessively large (6 orders of magnitude larger than in `st_regression.IN.DAT`) and `dx_tf_turn_general` is consequently larger (~250m rather than a couple of cm/mm). https://github.com/ukaea/PROCESS/blob/40782b5c86efd377fb331cc26bb05b400fd1b2cf/process/superconducting_tf_coil.py#L2784-L2787
4. In plot_proc, this unreasonably large winding pack causes the number of rows and columns in the cable plotting routine to become large (`n_rows = 340377`, `n_cols = 294775`) which causes the for loop to iterate ~ $10^{11}$ times rather than the few hundred times it iterates for `st_regression.IN.DAT`