### PR TITLE
Remove unnecessary radius calculation in TFCoil class

### DIFF
--- a/process/models/tfcoil/base.py
+++ b/process/models/tfcoil/base.py
@@ -2019,26 +2019,14 @@ class TFCoil:
             )
 
         # Radial build consistency check
-        if (
+        if not (
             abs(radius - build_variables.r_tf_inboard_in - build_variables.dr_tf_inboard)
             < 10.0e0 * np.finfo(float(radius)).eps
         ):
-            po.ocmmnt(self.outfile, "TF coil dimensions are consistent")
-        else:
-            po.ocmmnt(self.outfile, "ERROR: TF coil dimensions are NOT consistent:")
-            po.ovarre(
-                self.outfile,
-                "Radius of plasma-facing side of inner leg SHOULD BE [m]",
-                "",
-                build_variables.r_tf_inboard_in + build_variables.dr_tf_inboard,
+            logger.error(
+                "TF coil dimensions are not consistent. Radius of plasma-facing side of inner leg should be "
+                f"{build_variables.r_tf_inboard_in + build_variables.dr_tf_inboard}m"
             )
-            po.ovarre(
-                self.outfile,
-                "Inboard TF coil radial thickness [m]",
-                "(dr_tf_inboard)",
-                build_variables.dr_tf_inboard,
-            )
-            po.oblnkl(self.outfile)
 
         tf_total_height = (
             build_variables.dh_tf_inner_bore + 2 * build_variables.dr_tf_inboard


### PR DESCRIPTION
## Description

This is a legacy issue and should be solved by #3748 . There was error checking in the output (should not be there...) that was missed in #3748 and so the $\cos\left(\frac{\pi}{N_{TF}}\right)$ has now been removed

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
