### PR TITLE
Track the runtime of PROCESS regression tests

### DIFF
--- a/process/caller.py
+++ b/process/caller.py
@@ -8,12 +8,12 @@ import numpy as np
 from tabulate import tabulate
 
 import process.constraints as constraints
-from process import data_structure
+from process import constants, data_structure
 from process.final import finalise
 from process.io.mfile import MFile
 from process.iteration_variables import set_scaled_iteration_variable
 from process.objectives import objective_function
-from process.process_output import OutputFileManager
+from process.process_output import OutputFileManager, ovarre
 
 if TYPE_CHECKING:
     from process.main import Models
@@ -380,7 +380,7 @@ class Caller:
         # FISPACT and LOCA model (not used)- removed
 
 
-def write_output_files(models: Models, ifail: int):
+def write_output_files(models: Models, ifail: int, *, runtime: float | None = None):
     """Evaluate models and write output files (OUT.DAT and MFILE.DAT).
 
     Parameters
@@ -394,6 +394,13 @@ def write_output_files(models: Models, ifail: int):
     x = data_structure.numerics.xcm[:n]
     # Call models, ensuring output mfiles are fully idempotent
     caller = Caller(models)
+    if runtime is not None:
+        ovarre(
+            constants.MFILE,
+            "Runtime of PROCESS in seconds",
+            "(process_runtime)",
+            runtime,
+        )
     caller.call_models_and_write_output(
         xc=x,
         ifail=ifail,

--- a/process/scan.py
+++ b/process/scan.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from dataclasses import astuple, dataclass
 from enum import Enum
 
@@ -220,8 +221,11 @@ class Scan:
         if scan_variables.isweep == 0:
             # Solve single problem, rather than an array of problems (scan)
             # doopt() can also run just an evaluation
+            start_time = time.time()
             ifail = self.doopt()
-            write_output_files(models=self.models, ifail=ifail)
+            write_output_files(
+                models=self.models, ifail=ifail, runtime=time.time() - start_time
+            )
             show_errors(constants.NOUT)
             return
 
@@ -818,9 +822,12 @@ class Scan:
 
         for iscan in range(1, scan_variables.isweep + 1):
             self.scan_1d_write_point_header(iscan)
+            start_time = time.time()
             ifail = self.doopt()
             scan_1d_ifail_dict[iscan] = ifail
-            write_output_files(models=self.models, ifail=ifail)
+            write_output_files(
+                models=self.models, ifail=ifail, runtime=time.time() - start_time
+            )
 
             show_errors(constants.NOUT)
             logging_model_handler.clear_logs()
@@ -873,9 +880,11 @@ class Scan:
         for iscan_1 in range(1, scan_variables.isweep + 1):
             for iscan_2 in range(1, scan_variables.isweep_2 + 1):
                 self.scan_2d_write_point_header(iscan, iscan_1, iscan_2)
+                start_time = time.time()
                 ifail = self.doopt()
-
-                write_output_files(models=self.models, ifail=ifail)
+                write_output_files(
+                    models=self.models, ifail=ifail, runtime=time.time() - start_time
+                )
 
                 show_errors(constants.NOUT)
                 logging_model_handler.clear_logs()

--- a/tests/regression/test_process_input_files.py
+++ b/tests/regression/test_process_input_files.py
@@ -32,6 +32,7 @@ EXCLUSIONS = {
     r"sig_tf_r_max\(1\)",  # weird value, flips between 0 and very low?
     r"normres[0-9]+",
     r"nitvar[0-9]+",
+    "process_runtime",
 }
 
 

--- a/tracking/tracking_data.py
+++ b/tracking/tracking_data.py
@@ -62,6 +62,7 @@ logging.basicConfig(level=logging.INFO, filename="tracker.log")
 logger = logging.getLogger("PROCESS Tracker")
 
 DEFAULT_TRACKING_VARIABLES = {
+    "Metadata.process_runtime",
     "CurrentDrive.p_hcd_primary_extra_heat_mw",
     "CurrentDrive.f_c_plasma_bootstrap",
     "CurrentDrive.p_hcd_injected_total_mw",


### PR DESCRIPTION
There has been some desire to track the runtime of PROCESS so we can reason about the speed impact of pull requests. Obviously, this tracking won't be perfect and we expect reasonable fluctuations depending on the GitHub runner, the load of the runner, and other random factors. However, it will shows us the trend and will be able to flag any drastic changes. 