### PR TITLE
Add runtime information to plot cover page output

### DIFF
--- a/process/core/io/plot_proc.py
+++ b/process/core/io/plot_proc.py
@@ -11405,7 +11405,8 @@ def plot_cover_page(
         f"{objective_text}\n"
         f"• Constraint Residuals (sqrt sum sq): {sqsumsq}\n"
         f"• Convergence Parameter: {convergence_parameter}\n"
-        f"• Solver Iterations: {nviter}"
+        f"• Solver Iterations: {nviter}\n"
+        f"• Runtime: {mfile.get('process_runtime', scan=-1):.6f} seconds"
     )
     axis.text(
         0.1,


### PR DESCRIPTION
This pull request makes a minor update to the `plot_cover_page` function in `plot_proc.py` by adding a line to display the process runtime in seconds on the cover page plot.

* Added display of process runtime (in seconds) to the cover page output in `plot_cover_page` (`plot_proc.py`).

<img width="791" height="92" alt="image" src="https://github.com/user-attachments/assets/fb521ecd-0255-4c1f-a674-3241ecb5cdea" />


<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
