### PR TITLE
Fix power model call order

### DIFF
--- a/process/core/caller.py
+++ b/process/core/caller.py
@@ -353,6 +353,14 @@ class Caller:
         # Buildings model
         self.models.buildings.run()
 
+        # These two methods need to be run after vacuum/buildings otherwise output changes quite a lot
+        # TODO: split these two sections into a new model with a .run method
+        # Plant AC power requirements
+        self.models.power.acpow(output=False)
+
+        # Plant heat transport pt 2 & 3
+        self.models.power.plant_electric_production()
+
         # Availability model
         self.models.availability.run()
 

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -63,12 +63,6 @@ class Power(Model):
         # Cryoplant loads
         self.calculate_cryo_loads()
 
-        # Plant AC power requirements
-        self.acpow(output=False)
-
-        # Plant heat transport pt 2 & 3
-        self.plant_electric_production()
-
     def pfpwr(self, output: bool):
         """PF coil power supply requirements
 


### PR DESCRIPTION
Hotfixes a mistake in the call order that changes the results of PROCESS.
An issue needs to be made to turn the second half of the power model into its own model with just one run method. 