### PR TITLE
`i_confinement_time` ITPA20-IL Scaling equation fix

### DIFF
--- a/documentation/source/physics-models/plasma_confinement.md
+++ b/documentation/source/physics-models/plasma_confinement.md
@@ -54,7 +54,7 @@ The loss power $P_{\text{L}}$ [$\mathtt{p\_plasma\_loss\_mw}$] is calculated fro
 Published confinement scalings are all based on low radiation pulses. A power
 plant will certainly be a high radiation machine, both in the core, due to
 bremsstrahlung and synchrotron radiation, and in the edge due to impurity
-seeding. The scaling data does not predict this radiation [^24] [^25], that needs to be
+seeding. The scaling data does not predict this radiation [^23] [^24], that needs to be
 done by the radiation model. However, if the transport is very "stiff", as
 predicted by some models, then the additional radiation causes an almost equal
 drop in power transported by ions and electrons, leaving the confinement
@@ -639,7 +639,7 @@ $$
 
 #### 50: ITPA20-IL scaling (H-mode) | `itpa20_il_confinement_time()`
 
-Is selected with `i_confinement_time = 50` [^23]
+Is selected with `i_confinement_time = 50` [^22]
 
 $$
 \tau_{\text{E}} =  0.067 I_{\text{p}}^{1.29} B_{\text{T}}^{-0.13} P_{\text{L}}^{-0.644} \overline{n}_{19}^{0.15} M^{0.3} R^{1.19} \left(1+\delta \right)^{0.56} \kappa_{\text{IPB}}^{0.67} 
@@ -729,7 +729,6 @@ The value of `f_alpha_energy_confinement_min` can be set to the desired minimum 
 [^20]: J. E. Menard, “Compact steady-state tokamak performance dependence on magnet and core physics limits,” Philosophical Transactions of the Royal Society A, vol. 377, no. 2141, pp. 20170440-20170440, Feb. 2019, doi: https://doi.org/10.1098/rsta.2017.0440.
 [^21]: P. F. Buxton, L. Connor, A. E. Costley, M. Gryaznevich, and S. McNamara, “On the energy confinement time in spherical tokamaks: implications for the design of pilot plants and fusion reactors,” vol. 61, no. 3, pp. 035006-035006, Jan. 2019, doi: https://doi.org/10.1088/1361-6587/aaf7e5.
 [^22]: G. Verdoolaege et al., “The updated ITPA global H-mode confinement database: description and analysis,” Nuclear Fusion, vol. 61, no. 7, pp. 076006-076006, Jan. 2021, doi: https://doi.org/10.1088/1741-4326/abdb91.
-[^23]: T. Luda et al., “Validation of a full-plasma integrated modeling approach on ASDEX Upgrade,” Nuclear Fusion, vol. 61, no. 12, pp. 126048-126048, Nov. 2021, doi: https://doi.org/10.1088/1741-4326/ac3293.
-[^24]: H. Lux, R. Kemp, E. Fable, and R. Wenninger, “Radiation and confinement in 0D fusion systems codes,” Plasma Physics and Controlled Fusion, vol. 58, no. 7, pp. 075001–075001, May 2016, doi: https://doi.org/10.1088/0741-3335/58/7/075001.
-[^25]: H. Lux, R. Kemp, D. J. Ward, and M. Sertoli, “Impurity radiation in DEMO systems modelling,” Fusion Engineering and Design, vol. 101, pp. 42–51, Dec. 2015, doi: https://doi.org/10.1016/j.fusengdes.2015.10.002.
+[^23]: H. Lux, R. Kemp, E. Fable, and R. Wenninger, “Radiation and confinement in 0D fusion systems codes,” Plasma Physics and Controlled Fusion, vol. 58, no. 7, pp. 075001–075001, May 2016, doi: https://doi.org/10.1088/0741-3335/58/7/075001.
+[^24]: H. Lux, R. Kemp, D. J. Ward, and M. Sertoli, “Impurity radiation in DEMO systems modelling,” Fusion Engineering and Design, vol. 101, pp. 42–51, Dec. 2015, doi: https://doi.org/10.1016/j.fusengdes.2015.10.002.
 ‌

--- a/process/models/physics/confinement_time.py
+++ b/process/models/physics/confinement_time.py
@@ -3940,8 +3940,8 @@ class PlasmaConfinementTime:
             * pcur**0.98
             * b_plasma_toroidal_on_axis**0.22
             * dnla19**0.24
-            * p_plasma_loss_mw ** (-0.669)
-            * rmajor**1.71
+            * p_plasma_loss_mw ** (-0.67)
+            * rmajor**1.7
             * (1 + triang) ** 0.36
             * kappa_ipb**0.8
             * eps**0.35
@@ -3999,10 +3999,10 @@ class PlasmaConfinementTime:
             0.067
             * pcur**1.29
             * b_plasma_toroidal_on_axis**-0.13
-            * p_plasma_loss_mw ** (-0.644)
             * dnla19**0.15
-            * aion**0.3
-            * rmajor**1.19
+            * p_plasma_loss_mw ** (-0.644)
+            * rmajor**1.2
             * (1 + triang) ** 0.56
             * kappa_ipb**0.67
+            * aion**0.3
         )

--- a/process/models/physics/confinement_time.py
+++ b/process/models/physics/confinement_time.py
@@ -3936,16 +3936,16 @@ class PlasmaConfinementTime:
             Nuclear Fusion, vol. 61, no. 7, pp. 076006-076006, Jan. 2021, doi: https://doi.org/10.1088/1741-4326/abdb91.
         """
         return (
-            0.053
-            * pcur**0.98
-            * b_plasma_toroidal_on_axis**0.22
-            * dnla19**0.24
-            * p_plasma_loss_mw ** (-0.67)
-            * rmajor**1.7
-            * (1 + triang) ** 0.36
-            * kappa_ipb**0.8
-            * eps**0.35
-            * aion**0.2
+            0.0534
+            * pcur**0.976
+            * b_plasma_toroidal_on_axis**0.218
+            * dnla19**0.2442
+            * p_plasma_loss_mw ** (-0.6687)
+            * rmajor**1.710
+            * (1 + triang) ** 0.362
+            * kappa_ipb**0.799
+            * eps**0.354
+            * aion**0.195
         )
 
     @staticmethod
@@ -3996,13 +3996,13 @@ class PlasmaConfinementTime:
             Nuclear Fusion, vol. 61, no. 12, pp. 126048-126048, Nov. 2021, doi: https://doi.org/10.1088/1741-4326/ac3293.
         """
         return (
-            0.067
-            * pcur**1.29
-            * b_plasma_toroidal_on_axis**-0.13
-            * dnla19**0.15
-            * p_plasma_loss_mw ** (-0.644)
-            * rmajor**1.2
-            * (1 + triang) ** 0.56
-            * kappa_ipb**0.67
-            * aion**0.3
+            0.0670
+            * pcur**1.291
+            * b_plasma_toroidal_on_axis**-0.134
+            * dnla19**0.1473
+            * p_plasma_loss_mw ** (-0.6442)
+            * rmajor**1.194
+            * (1 + triang) ** 0.560
+            * kappa_ipb**0.673
+            * aion**0.302
         )

--- a/tests/unit/models/physics/test_confinement_time.py
+++ b/tests/unit/models/physics/test_confinement_time.py
@@ -235,7 +235,7 @@ from process.models.physics.confinement_time import PlasmaConfinementTime
         (
             PlasmaConfinementTime.itpa20_confinement_time,
             (1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
-            0.06802157257083392,
+            0.06863001842086452,
         ),
         (
             PlasmaConfinementTime.itpa20_il_confinement_time,


### PR DESCRIPTION
## Description

Closes #4017 
reference [^23] is dereferenced into [^22].

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
