### PR TITLE
Add cs stress profiles

### DIFF
--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -46,8 +46,8 @@ from process.models.geometry.vacuum_vessel import (
     vacuum_vessel_geometry_double_null,
     vacuum_vessel_geometry_single_null,
 )
-from process.models.physics.bootstrap_current import BootstrapCurrentFractionModel
 from process.models.pfcoil import CSCoil
+from process.models.physics.bootstrap_current import BootstrapCurrentFractionModel
 from process.models.physics.confinement_time import (
     ConfinementTimeModel,
     PlasmaConfinementTime,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -47,6 +47,7 @@ from process.models.geometry.vacuum_vessel import (
     vacuum_vessel_geometry_single_null,
 )
 from process.models.physics.bootstrap_current import BootstrapCurrentFractionModel
+from process.models.pfcoil import CSCoil
 from process.models.physics.confinement_time import (
     ConfinementTimeModel,
     PlasmaConfinementTime,
@@ -9763,8 +9764,8 @@ def plot_cs_coil_structure(
     )
 
     axis.text(
-        0.6,
-        0.75,
+        0.45,
+        0.375,
         textstr_cs,
         fontsize=9,
         verticalalignment="bottom",
@@ -9878,8 +9879,8 @@ def plot_cs_turn_structure(axis: plt.Axes, fig, mfile: MFile, scan: int):
     )
 
     axis.text(
-        0.6,
-        0.5,
+        0.7,
+        0.375,
         textstr_turn,
         fontsize=9,
         verticalalignment="bottom",
@@ -14448,11 +14449,15 @@ def main_plot(
 
     plot_current_profiles_over_time(figs[29].add_subplot(111), m_file, scan)
 
+    CSCoil.plot_stress_time_profile(
+        axis=figs[30].add_subplot(311), mfile=m_file, scan=scan
+    )
+
     plot_cs_coil_structure(
-        figs[30].add_subplot(121, aspect="equal"), figs[30], m_file, scan
+        figs[30].add_subplot(223, aspect="equal"), figs[30], m_file, scan
     )
     plot_cs_turn_structure(
-        figs[30].add_subplot(224, aspect="equal"), figs[30], m_file, scan
+        figs[30].add_subplot(326, aspect="equal"), figs[30], m_file, scan
     )
 
     plot_first_wall_top_down_cross_section(

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -47,7 +47,6 @@ from process.models.geometry.vacuum_vessel import (
     vacuum_vessel_geometry_double_null,
     vacuum_vessel_geometry_single_null,
 )
-from process.models.pfcoil import CSCoil
 from process.models.physics.bootstrap_current import BootstrapCurrentFractionModel
 from process.models.physics.confinement_time import (
     ConfinementTimeModel,
@@ -9798,6 +9797,55 @@ def plot_cs_coil_structure(
     axis.legend()
 
 
+def plot_cs_stress_time_profile(axis: plt.Axes, mfile: MFile, scan: int) -> None:
+    """Function to plot the time profile of the CS stress during the pulse."""
+    t_plant_pulse_coil_precharge = mfile.get("t_plant_pulse_coil_precharge", scan=scan)
+    t_plant_pulse_plasma_current_ramp_up = mfile.get(
+        "t_plant_pulse_plasma_current_ramp_up", scan=scan
+    )
+    t_plant_pulse_fusion_ramp = mfile.get("t_plant_pulse_fusion_ramp", scan=scan)
+    t_plant_pulse_burn = mfile.get("t_plant_pulse_burn", scan=scan)
+    t_plant_pulse_plasma_current_ramp_down = mfile.get(
+        "t_plant_pulse_plasma_current_ramp_down", scan=scan
+    )
+
+    # Define a cumulative sum list for each point in the pulse
+    t_steps = np.cumsum([
+        0,
+        t_plant_pulse_coil_precharge,
+        t_plant_pulse_plasma_current_ramp_up,
+        t_plant_pulse_fusion_ramp,
+        t_plant_pulse_burn,
+        t_plant_pulse_plasma_current_ramp_down,
+    ])
+
+    stress_times = t_steps[
+        :6
+    ]  # Get the first 6 time points corresponding to the stress profile
+
+    stress_z_cs_self_midplane_profile = np.zeros(6)
+    for i in range(6):
+        stress_z_cs_self_midplane_profile[i] = mfile.get(
+            f"stress_z_cs_self_midplane_profile[{i}]", scan=scan
+        )
+
+    # Plot stress vs time
+    axis.plot(
+        stress_times,
+        stress_z_cs_self_midplane_profile / 1e6,
+        "o-",
+        linewidth=2,
+        markersize=8,
+        label="Midplane Axial Stress",
+    )
+    axis.set_xlabel("Pulse Time (s)")
+    axis.set_ylabel("Stress (MPa)")
+    axis.minorticks_on()
+    axis.legend(loc="best")
+    axis.set_title("Central Solenoid Stress")
+    axis.grid(True, alpha=0.3)
+
+
 def plot_cs_turn_structure(axis: plt.Axes, fig, mfile: MFile, scan: int):
     a_cs_turn = mfile.get("a_cs_turn", scan=scan)
     dz_cs_turn = mfile.get("dz_cs_turn", scan=scan)
@@ -14448,9 +14496,7 @@ def main_plot(
 
     plot_current_profiles_over_time(figs[29].add_subplot(111), m_file, scan)
 
-    CSCoil.plot_stress_time_profile(
-        axis=figs[30].add_subplot(311), mfile=m_file, scan=scan
-    )
+    plot_cs_stress_time_profile(axis=figs[30].add_subplot(311), mfile=m_file, scan=scan)
 
     plot_cs_coil_structure(
         figs[30].add_subplot(223, aspect="equal"), figs[30], m_file, scan

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -47,8 +47,8 @@ from process.models.geometry.vacuum_vessel import (
     vacuum_vessel_geometry_double_null,
     vacuum_vessel_geometry_single_null,
 )
-from process.models.physics.bootstrap_current import BootstrapCurrentFractionModel
 from process.models.pfcoil import CSCoil
+from process.models.physics.bootstrap_current import BootstrapCurrentFractionModel
 from process.models.physics.confinement_time import (
     ConfinementTimeModel,
     PlasmaConfinementTime,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -48,6 +48,7 @@ from process.models.geometry.vacuum_vessel import (
     vacuum_vessel_geometry_single_null,
 )
 from process.models.physics.bootstrap_current import BootstrapCurrentFractionModel
+from process.models.pfcoil import CSCoil
 from process.models.physics.confinement_time import (
     ConfinementTimeModel,
     PlasmaConfinementTime,
@@ -9762,8 +9763,8 @@ def plot_cs_coil_structure(
     )
 
     axis.text(
-        0.6,
-        0.75,
+        0.45,
+        0.375,
         textstr_cs,
         fontsize=9,
         verticalalignment="bottom",
@@ -9877,8 +9878,8 @@ def plot_cs_turn_structure(axis: plt.Axes, fig, mfile: MFile, scan: int):
     )
 
     axis.text(
-        0.6,
-        0.5,
+        0.7,
+        0.375,
         textstr_turn,
         fontsize=9,
         verticalalignment="bottom",
@@ -14447,11 +14448,15 @@ def main_plot(
 
     plot_current_profiles_over_time(figs[29].add_subplot(111), m_file, scan)
 
+    CSCoil.plot_stress_time_profile(
+        axis=figs[30].add_subplot(311), mfile=m_file, scan=scan
+    )
+
     plot_cs_coil_structure(
-        figs[30].add_subplot(121, aspect="equal"), figs[30], m_file, scan
+        figs[30].add_subplot(223, aspect="equal"), figs[30], m_file, scan
     )
     plot_cs_turn_structure(
-        figs[30].add_subplot(224, aspect="equal"), figs[30], m_file, scan
+        figs[30].add_subplot(326, aspect="equal"), figs[30], m_file, scan
     )
 
     plot_first_wall_top_down_cross_section(

--- a/process/data_structure/pfcoil_variables.py
+++ b/process/data_structure/pfcoil_variables.py
@@ -587,7 +587,7 @@ def init_pfcoil_module():
     ricpf = 0.0
     ssq0 = 0.0
     stress_z_cs_self_peak_midplane = 0.0
-    stress_z_cs_self_midplane_profile = []
+    stress_z_cs_self_midplane_profile = np.zeros(6)
     sig_hoop = 0.0
     forc_z_cs_self_peak_midplane = 0.0
 

--- a/process/data_structure/pfcoil_variables.py
+++ b/process/data_structure/pfcoil_variables.py
@@ -32,6 +32,9 @@ ssq0: float = None
 stress_z_cs_self_peak_midplane: float = None
 """Peak axial stress (z) in central solenoid at midplane due to its own field (when at peak current) (Pa)"""
 
+stress_z_cs_self_midplane_profile: list[float] = None
+"""Axial stress (z) in central solenoid at midplane due to its own field at each time point (Pa)"""
+
 sig_hoop: float = None
 
 forc_z_cs_self_peak_midplane: float = None
@@ -563,6 +566,7 @@ def init_pfcoil_module():
         ricpf, \
         ssq0, \
         stress_z_cs_self_peak_midplane, \
+        stress_z_cs_self_midplane_profile, \
         sig_hoop, \
         forc_z_cs_self_peak_midplane, \
         r_pf_cs_current_filaments, \
@@ -583,6 +587,7 @@ def init_pfcoil_module():
     ricpf = 0.0
     ssq0 = 0.0
     stress_z_cs_self_peak_midplane = 0.0
+    stress_z_cs_self_midplane_profile = []
     sig_hoop = 0.0
     forc_z_cs_self_peak_midplane = 0.0
 

--- a/process/data_structure/pfcoil_variables.py
+++ b/process/data_structure/pfcoil_variables.py
@@ -37,8 +37,10 @@ class PFCoilData:
     stress_z_cs_self_peak_midplane: float = 0.0
     """Peak axial stress (z) in central solenoid at midplane due to its own field (when at peak current) (Pa)"""
 
-stress_z_cs_self_midplane_profile: list[float] = None
-"""Axial stress (z) in central solenoid at midplane due to its own field at each time point (Pa)"""
+    stress_z_cs_self_midplane_profile: list[float] = field(
+        default_factory=lambda: np.zeros(6)
+    )
+    """Axial stress (z) in central solenoid at midplane due to its own field at each time point (Pa)"""
 
     sig_hoop: float = 0.0
 

--- a/process/data_structure/pfcoil_variables.py
+++ b/process/data_structure/pfcoil_variables.py
@@ -37,6 +37,9 @@ class PFCoilData:
     stress_z_cs_self_peak_midplane: float = 0.0
     """Peak axial stress (z) in central solenoid at midplane due to its own field (when at peak current) (Pa)"""
 
+stress_z_cs_self_midplane_profile: list[float] = None
+"""Axial stress (z) in central solenoid at midplane due to its own field at each time point (Pa)"""
+
     sig_hoop: float = 0.0
 
     forc_z_cs_self_peak_midplane: float = 0.0

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -1,12 +1,15 @@
 import logging
 import math
 
+import matplotlib.pyplot as plt
 import numba
 import numpy as np
 from scipy import optimize
 from scipy.linalg import svd
 from scipy.special import ellipe, ellipk
 
+import process.core.io.mfile as mf
+import process.models.superconductors as superconductors
 from process.core import constants
 from process.core import process_output as op
 from process.core.exceptions import ProcessValueError
@@ -2538,6 +2541,13 @@ class PFCoil(Model):
                 f"(b_pf_coil_peak[{k}])",
                 pfcoil_variables.b_pf_coil_peak[k],
             )
+        for time in range(6):
+            op.ovarre(
+                self.mfile,
+                f"CS coil midplane axial stress at time point {time} (MPa)",
+                f"(stress_z_cs_self_midplane_profile[{time}])",
+                pfcoil_variables.stress_z_cs_self_midplane_profile[time],
+            )
         self.tf_pf_collision_detector()
 
         # Central Solenoid, if present
@@ -3543,6 +3553,7 @@ class CSCoil(Model):
             pfcoil_variables.p_pf_coil_resistive_total_flat_top += (
                 pfcoil_variables.p_cs_resistive_flat_top
             )
+        self.calculate_cs_self_midplane_axial_stress_time_profile()
 
     def calculate_cs_self_peak_magnetic_field(
         self,
@@ -3766,6 +3777,29 @@ class CSCoil(Model):
 
         return s_axial, forc_z_cs_self_peak_midplane
 
+    def calculate_cs_self_midplane_axial_stress_time_profile(
+        self,
+    ) -> None:
+        for time in range(6):
+            stress_value, _ = self.calculate_cs_self_peak_midplane_axial_stress(
+                r_cs_outer=pfcoil_variables.r_pf_coil_outer[
+                    pfcoil_variables.n_cs_pf_coils - 1
+                ],
+                r_cs_inner=pfcoil_variables.r_pf_coil_inner[
+                    pfcoil_variables.n_cs_pf_coils - 1
+                ],
+                dz_cs_half=pfcoil_variables.dz_cs_full / 2.0,
+                c_cs_peak=(
+                    pfcoil_variables.c_pf_coil_turn[
+                        pfcoil_variables.n_cs_pf_coils - 1, time
+                    ]
+                    * pfcoil_variables.n_pf_coil_turns[
+                        pfcoil_variables.n_cs_pf_coils - 1
+                    ]
+                ),
+            )
+            pfcoil_variables.stress_z_cs_self_midplane_profile[time] = stress_value
+
     def hoop_stress(self, r):
         """Calculation of hoop stress of central solenoid.
 
@@ -3837,6 +3871,56 @@ class CSCoil(Model):
         s_hoop_nom = hp_term_1 * hp_term_2 - hp_term_3 * hp_term_4
 
         return s_hoop_nom / pfcoil_variables.f_a_cs_turn_steel
+
+    @staticmethod
+    def plot_stress_time_profile(axis: plt.Axes, mfile: mf.MFile, scan: int):
+        t_plant_pulse_coil_precharge = mfile.get(
+            "t_plant_pulse_coil_precharge", scan=scan
+        )
+        t_plant_pulse_plasma_current_ramp_up = mfile.get(
+            "t_plant_pulse_plasma_current_ramp_up", scan=scan
+        )
+        t_plant_pulse_fusion_ramp = mfile.get("t_plant_pulse_fusion_ramp", scan=scan)
+        t_plant_pulse_burn = mfile.get("t_plant_pulse_burn", scan=scan)
+        t_plant_pulse_plasma_current_ramp_down = mfile.get(
+            "t_plant_pulse_plasma_current_ramp_down", scan=scan
+        )
+
+        # Define a cumulative sum list for each point in the pulse
+        t_steps = np.cumsum([
+            0,
+            t_plant_pulse_coil_precharge,
+            t_plant_pulse_plasma_current_ramp_up,
+            t_plant_pulse_fusion_ramp,
+            t_plant_pulse_burn,
+            t_plant_pulse_plasma_current_ramp_down,
+        ])
+
+        stress_times = t_steps[
+            :6
+        ]  # Get the first 6 time points corresponding to the stress profile
+
+        stress_z_cs_self_midplane_profile = np.zeros(6)
+        for i in range(6):
+            stress_z_cs_self_midplane_profile[i] = mfile.get(
+                f"stress_z_cs_self_midplane_profile[{i}]", scan=scan
+            )
+
+        # Plot stress vs time
+        axis.plot(
+            stress_times,
+            stress_z_cs_self_midplane_profile / 1e6,
+            "o-",
+            linewidth=2,
+            markersize=8,
+            label="Midplane Axial Stress",
+        )
+        axis.set_xlabel("Pulse Time (s)")
+        axis.set_ylabel("Stress (MPa)")
+        axis.minorticks_on()
+        axis.legend(loc="best")
+        axis.set_title("Central Solenoid Stress")
+        axis.grid(True, alpha=0.3)
 
 
 def peak_b_field_at_pf_coil(

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -9,7 +9,6 @@ from scipy.linalg import svd
 from scipy.special import ellipe, ellipk
 
 import process.core.io.mfile as mf
-import process.models.superconductors as superconductors
 from process.core import constants
 from process.core import process_output as op
 from process.core.exceptions import ProcessValueError

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -1,14 +1,12 @@
 import logging
 import math
 
-import matplotlib.pyplot as plt
 import numba
 import numpy as np
 from scipy import optimize
 from scipy.linalg import svd
 from scipy.special import ellipe, ellipk
 
-import process.core.io.mfile as mf
 from process.core import constants
 from process.core import process_output as op
 from process.core.exceptions import ProcessValueError
@@ -2550,7 +2548,7 @@ class PFCoil(Model):
                 self.mfile,
                 f"CS coil midplane axial stress at time point {time} (MPa)",
                 f"(stress_z_cs_self_midplane_profile[{time}])",
-                pfcoil_variables.stress_z_cs_self_midplane_profile[time],
+                self.data.pf_coil.stress_z_cs_self_midplane_profile[time],
             )
         self.tf_pf_collision_detector()
 
@@ -3736,15 +3734,16 @@ class CSCoil(Model):
                 The first element is the unsmeared axial stress in MPa.
                 The second element is the axial force in newtons (N).
 
-        :note:
-           The axial force is computed using elliptic-integral based terms and the
-           unsmeared axial stress is obtained by dividing the axial force by
-           the effective steel area associated with the CS turns.
+        Notes
+        -----
+        The axial force is computed using elliptic-integral based terms and the
+        unsmeared axial stress is obtained by dividing the axial force by
+        the effective steel area associated with the CS turns.
 
         References
         ----------
-            - Case Studies in Superconducting Magnets. Boston, MA: Springer US, 2009.
-              doi: https://doi.org/10.1007/b112047.
+        [1] Case Studies in Superconducting Magnets. Boston, MA: Springer US, 2009.
+            doi: https://doi.org/10.1007/b112047.
         """
         # kb term for elliptical integrals
         # kb2 = SQRT((4.0e0*b**2)/(4.0e0*b**2 + hl**2))
@@ -3796,23 +3795,23 @@ class CSCoil(Model):
     ) -> None:
         for time in range(6):
             stress_value, _ = self.calculate_cs_self_peak_midplane_axial_stress(
-                r_cs_outer=pfcoil_variables.r_pf_coil_outer[
-                    pfcoil_variables.n_cs_pf_coils - 1
+                r_cs_outer=self.data.pf_coil.r_pf_coil_outer[
+                    self.data.pf_coil.n_cs_pf_coils - 1
                 ],
-                r_cs_inner=pfcoil_variables.r_pf_coil_inner[
-                    pfcoil_variables.n_cs_pf_coils - 1
+                r_cs_inner=self.data.pf_coil.r_pf_coil_inner[
+                    self.data.pf_coil.n_cs_pf_coils - 1
                 ],
-                dz_cs_half=pfcoil_variables.dz_cs_full / 2.0,
+                dz_cs_half=self.data.pf_coil.dz_cs_full / 2.0,
                 c_cs_peak=(
-                    pfcoil_variables.c_pf_coil_turn[
-                        pfcoil_variables.n_cs_pf_coils - 1, time
+                    self.data.pf_coil.c_pf_coil_turn[
+                        self.data.pf_coil.n_cs_pf_coils - 1, time
                     ]
-                    * pfcoil_variables.n_pf_coil_turns[
-                        pfcoil_variables.n_cs_pf_coils - 1
+                    * self.data.pf_coil.n_pf_coil_turns[
+                        self.data.pf_coil.n_cs_pf_coils - 1
                     ]
                 ),
             )
-            pfcoil_variables.stress_z_cs_self_midplane_profile[time] = stress_value
+            self.data.pf_coil.stress_z_cs_self_midplane_profile[time] = stress_value
 
     def hoop_stress(self, r):
         """Calculation of hoop stress of central solenoid.
@@ -3885,56 +3884,6 @@ class CSCoil(Model):
         s_hoop_nom = hp_term_1 * hp_term_2 - hp_term_3 * hp_term_4
 
         return s_hoop_nom / self.data.pf_coil.f_a_cs_turn_steel
-
-    @staticmethod
-    def plot_stress_time_profile(axis: plt.Axes, mfile: mf.MFile, scan: int):
-        t_plant_pulse_coil_precharge = mfile.get(
-            "t_plant_pulse_coil_precharge", scan=scan
-        )
-        t_plant_pulse_plasma_current_ramp_up = mfile.get(
-            "t_plant_pulse_plasma_current_ramp_up", scan=scan
-        )
-        t_plant_pulse_fusion_ramp = mfile.get("t_plant_pulse_fusion_ramp", scan=scan)
-        t_plant_pulse_burn = mfile.get("t_plant_pulse_burn", scan=scan)
-        t_plant_pulse_plasma_current_ramp_down = mfile.get(
-            "t_plant_pulse_plasma_current_ramp_down", scan=scan
-        )
-
-        # Define a cumulative sum list for each point in the pulse
-        t_steps = np.cumsum([
-            0,
-            t_plant_pulse_coil_precharge,
-            t_plant_pulse_plasma_current_ramp_up,
-            t_plant_pulse_fusion_ramp,
-            t_plant_pulse_burn,
-            t_plant_pulse_plasma_current_ramp_down,
-        ])
-
-        stress_times = t_steps[
-            :6
-        ]  # Get the first 6 time points corresponding to the stress profile
-
-        stress_z_cs_self_midplane_profile = np.zeros(6)
-        for i in range(6):
-            stress_z_cs_self_midplane_profile[i] = mfile.get(
-                f"stress_z_cs_self_midplane_profile[{i}]", scan=scan
-            )
-
-        # Plot stress vs time
-        axis.plot(
-            stress_times,
-            stress_z_cs_self_midplane_profile / 1e6,
-            "o-",
-            linewidth=2,
-            markersize=8,
-            label="Midplane Axial Stress",
-        )
-        axis.set_xlabel("Pulse Time (s)")
-        axis.set_ylabel("Stress (MPa)")
-        axis.minorticks_on()
-        axis.legend(loc="best")
-        axis.set_title("Central Solenoid Stress")
-        axis.grid(True, alpha=0.3)
 
 
 def peak_b_field_at_pf_coil(

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -1,12 +1,15 @@
 import logging
 import math
 
+import matplotlib.pyplot as plt
 import numba
 import numpy as np
 from scipy import optimize
 from scipy.linalg import svd
 from scipy.special import ellipe, ellipk
 
+import process.core.io.mfile as mf
+import process.models.superconductors as superconductors
 from process.core import constants
 from process.core import process_output as op
 from process.core.exceptions import ProcessValueError
@@ -2543,6 +2546,13 @@ class PFCoil(Model):
                 f"(b_pf_coil_peak[{k}])",
                 self.data.pf_coil.b_pf_coil_peak[k],
             )
+        for time in range(6):
+            op.ovarre(
+                self.mfile,
+                f"CS coil midplane axial stress at time point {time} (MPa)",
+                f"(stress_z_cs_self_midplane_profile[{time}])",
+                pfcoil_variables.stress_z_cs_self_midplane_profile[time],
+            )
         self.tf_pf_collision_detector()
 
         # Central Solenoid, if present
@@ -3558,6 +3568,7 @@ class CSCoil(Model):
             self.data.pf_coil.p_pf_coil_resistive_total_flat_top += (
                 self.data.pf_coil.p_cs_resistive_flat_top
             )
+        self.calculate_cs_self_midplane_axial_stress_time_profile()
 
     def calculate_cs_self_peak_magnetic_field(
         self,
@@ -3781,6 +3792,29 @@ class CSCoil(Model):
 
         return s_axial, forc_z_cs_self_peak_midplane
 
+    def calculate_cs_self_midplane_axial_stress_time_profile(
+        self,
+    ) -> None:
+        for time in range(6):
+            stress_value, _ = self.calculate_cs_self_peak_midplane_axial_stress(
+                r_cs_outer=pfcoil_variables.r_pf_coil_outer[
+                    pfcoil_variables.n_cs_pf_coils - 1
+                ],
+                r_cs_inner=pfcoil_variables.r_pf_coil_inner[
+                    pfcoil_variables.n_cs_pf_coils - 1
+                ],
+                dz_cs_half=pfcoil_variables.dz_cs_full / 2.0,
+                c_cs_peak=(
+                    pfcoil_variables.c_pf_coil_turn[
+                        pfcoil_variables.n_cs_pf_coils - 1, time
+                    ]
+                    * pfcoil_variables.n_pf_coil_turns[
+                        pfcoil_variables.n_cs_pf_coils - 1
+                    ]
+                ),
+            )
+            pfcoil_variables.stress_z_cs_self_midplane_profile[time] = stress_value
+
     def hoop_stress(self, r):
         """Calculation of hoop stress of central solenoid.
 
@@ -3852,6 +3886,56 @@ class CSCoil(Model):
         s_hoop_nom = hp_term_1 * hp_term_2 - hp_term_3 * hp_term_4
 
         return s_hoop_nom / self.data.pf_coil.f_a_cs_turn_steel
+
+    @staticmethod
+    def plot_stress_time_profile(axis: plt.Axes, mfile: mf.MFile, scan: int):
+        t_plant_pulse_coil_precharge = mfile.get(
+            "t_plant_pulse_coil_precharge", scan=scan
+        )
+        t_plant_pulse_plasma_current_ramp_up = mfile.get(
+            "t_plant_pulse_plasma_current_ramp_up", scan=scan
+        )
+        t_plant_pulse_fusion_ramp = mfile.get("t_plant_pulse_fusion_ramp", scan=scan)
+        t_plant_pulse_burn = mfile.get("t_plant_pulse_burn", scan=scan)
+        t_plant_pulse_plasma_current_ramp_down = mfile.get(
+            "t_plant_pulse_plasma_current_ramp_down", scan=scan
+        )
+
+        # Define a cumulative sum list for each point in the pulse
+        t_steps = np.cumsum([
+            0,
+            t_plant_pulse_coil_precharge,
+            t_plant_pulse_plasma_current_ramp_up,
+            t_plant_pulse_fusion_ramp,
+            t_plant_pulse_burn,
+            t_plant_pulse_plasma_current_ramp_down,
+        ])
+
+        stress_times = t_steps[
+            :6
+        ]  # Get the first 6 time points corresponding to the stress profile
+
+        stress_z_cs_self_midplane_profile = np.zeros(6)
+        for i in range(6):
+            stress_z_cs_self_midplane_profile[i] = mfile.get(
+                f"stress_z_cs_self_midplane_profile[{i}]", scan=scan
+            )
+
+        # Plot stress vs time
+        axis.plot(
+            stress_times,
+            stress_z_cs_self_midplane_profile / 1e6,
+            "o-",
+            linewidth=2,
+            markersize=8,
+            label="Midplane Axial Stress",
+        )
+        axis.set_xlabel("Pulse Time (s)")
+        axis.set_ylabel("Stress (MPa)")
+        axis.minorticks_on()
+        axis.legend(loc="best")
+        axis.set_title("Central Solenoid Stress")
+        axis.grid(True, alpha=0.3)
 
 
 def peak_b_field_at_pf_coil(


### PR DESCRIPTION
This pull request adds the capability to calculate, store, and visualize the time evolution of the central solenoid (CS) midplane axial stress throughout the machine pulse. The changes include new data structures, calculation logic, output handling, and a plotting function, along with updates to the main plotting routine to display the new stress profile.

**Central Solenoid Stress Time Profile Support:**

* Added a new variable `stress_z_cs_self_midplane_profile` to `pfcoil_variables.py` to store the CS midplane axial stress at each time point, updated initialization, and included it in the module's variable list. 
* Implemented the calculation of the CS midplane axial stress profile over time in `CSCoil.calculate_cs_self_midplane_axial_stress_time_profile`, and integrated it into the OH coil calculation workflow.
* Modified the output logic to write each time point's stress value to the output file for later retrieval and plotting.

**Visualization Enhancements:**

<img width="958" height="695" alt="image" src="https://github.com/user-attachments/assets/427c0b5a-c222-4615-81ac-ee53123bd98d" />


* Added a static method `plot_stress_time_profile` to `CSCoil` for plotting the CS midplane axial stress vs. time, including retrieval of relevant timing and stress data from the output file.
* Updated the main plotting routine in `plot_proc.py` to include the new CS stress time profile plot and reorganized subplot positions for clarity.
* Adjusted placement of annotation text in CS coil structure and turn structure plots for improved readability.

**Imports and Dependencies:**

* Added necessary imports for plotting and data access in both `plot_proc.py` and `pfcoil.py`.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
