### PR TITLE
Add option for density pedestal setting

### DIFF
--- a/documentation/source/physics-models/profiles/plasma_density_profile.md
+++ b/documentation/source/physics-models/profiles/plasma_density_profile.md
@@ -148,4 +148,32 @@ $$\begin{aligned}
 
 5. Profile is then integrated with `integrate_profile_y()` using Simpsons integration from the profile abstract base class
 
+-----------------------
+
+### Setting pedestal and separatrix values | `set_pedestal_and_separatrix_values()`
+
+The switch `i_nd_plasma_pedestal_separatrix` controls how the values of the density pedestal and separatrix are set.
+
+#### User input
+
+If `i_nd_plasma_pedestal_separatrix == 0` then the values of `nd_plasma_pedestal_electron` and `nd_plasma_separatrix_electron` are taken directly from the input file
+
+#### Fraction of Greenwald Limit
+
+If `i_nd_plasma_pedestal_separatrix == 1`, the values of $n_{\text{ped}}$ and $n_{\text{sep}}$ are set as fractions of the [Greenwald](https://wiki.fusion.ciemat.es/wiki/Greenwald_limit) limit such as:
+
+$$
+n_{\text{ped}} = \overbrace{f_{\text{GW,ped}}}^{\texttt{f_nd_plasma_pedestal_greenwald}} \times \frac{I_p [\text{A}]}{\pi a^2 [\text{m}^2]} \times 10^{14}
+$$
+
+$$
+n_{\text{sep}} = \overbrace{f_{\text{GW,sep}}}^{\texttt{f_nd_plasma_separatrix_greenwald}} \times \frac{I_p [\text{A}]}{\pi a^2 [\text{m}^2]} \times 10^{14}
+$$
+
+
+$\texttt{f_nd_plasma_pedestal_greenwald}$ and $\texttt{f_nd_plasma_separatrix_greenwald}$ can be set as iteration variables respectively by using `ixc = 45`
+and `ixc = 152` respectively
+
+------
+
 [^1]: Jean, J. (2011). *HELIOS: A Zero-Dimensional Tool for Next Step and Reactor Studies*. Fusion Science and Technology, 59(2), 308–349. <https://doi.org/10.13182/FST11-A11650>

--- a/documentation/source/physics-models/profiles/plasma_density_profile.md
+++ b/documentation/source/physics-models/profiles/plasma_density_profile.md
@@ -171,7 +171,7 @@ n_{\text{sep}} = \overbrace{f_{\text{GW,sep}}}^{\texttt{f_nd_plasma_separatrix_g
 $$
 
 
-$\texttt{f_nd_plasma_pedestal_greenwald}$ and $\texttt{f_nd_plasma_separatrix_greenwald}$ can be set as iteration variables respectively by using `ixc = 45`
+$\texttt{f_nd_plasma_pedestal_greenwald}$ and $\texttt{f_nd_plasma_separatrix_greenwald}$ can be set as iteration variables respectively by using `ixc = 145`
 and `ixc = 152` respectively
 
 ------

--- a/documentation/source/physics-models/profiles/plasma_density_profile.md
+++ b/documentation/source/physics-models/profiles/plasma_density_profile.md
@@ -171,9 +171,8 @@ n_{\text{sep}} = \overbrace{f_{\text{GW,sep}}}^{\texttt{f_nd_plasma_separatrix_g
 $$
 
 
-$\texttt{f_nd_plasma_pedestal_greenwald}$ and $\texttt{f_nd_plasma_separatrix_greenwald}$ can be set as iteration variables respectively by using `ixc = 145`
+`f_nd_plasma_pedestal_greenwald` and `f_nd_plasma_separatrix_greenwald` can be set as iteration variables respectively by using `ixc = 145`
 and `ixc = 152` respectively
 
-------
 
 [^1]: Jean, J. (2011). *HELIOS: A Zero-Dimensional Tool for Next Step and Reactor Studies*. Fusion Science and Technology, 59(2), 308–349. <https://doi.org/10.13182/FST11-A11650>

--- a/documentation/source/physics-models/profiles/plasma_profiles.md
+++ b/documentation/source/physics-models/profiles/plasma_profiles.md
@@ -636,24 +636,6 @@ The same function is run from the `i_plasma_pedestal == 0 ` profile case, found 
 
 --------
 
-### Setting pedestal values as fractions of the Greenwald limit
-
-By default, the values of $n_{\text{ped}}$ and $n_{\text{sep}}$ are set as fractions of the [Greenwald](https://wiki.fusion.ciemat.es/wiki/Greenwald_limit) limit such as:
-
-$$
-n_{\text{ped}} = \overbrace{f_{\text{GW,ped}}}^{\texttt{f_nd_plasma_pedestal_greenwald}} \times \frac{I_p [\text{A}]}{\pi a^2 [\text{m}^2]} \times 10^{14}
-$$
-
-$$
-n_{\text{sep}} = \overbrace{f_{\text{GW,sep}}}^{\texttt{f_nd_plasma_separatrix_greenwald}} \times \frac{I_p [\text{A}]}{\pi a^2 [\text{m}^2]} \times 10^{14}
-$$
-
-To set the values of $n_{\text{ped}}$ and $n_{\text{sep}}$ directly, the user can input the value of $\texttt{f_nd_plasma_pedestal_greenwald}$ or $\texttt{f_nd_plasma_separatrix_greenwald}$ to be less than 0.0 (i.e negative) to prevent the Greenwald fraction value being set.
-
-$\texttt{f_nd_plasma_pedestal_greenwald}$ and $\texttt{f_nd_plasma_separatrix_greenwald}$ can be set as iteration variables respectively by using `ixc = 45`
-and `ixc = 152` respectively
-
-------
 
 ### Pedestal Density Upper limit
 

--- a/documentation/source/physics-models/profiles/plasma_profiles.md
+++ b/documentation/source/physics-models/profiles/plasma_profiles.md
@@ -277,10 +277,10 @@ $$
 
 --------
 
-The line averaged density is then calculated for the profile paramaters
+The line averaged density/temperature is then calculated for the profile paramaters
 
-###### Line averaged density derivation
-Line averaged electron density is calculated by integrating the profile across the normalised width of the profile and then dividing by the width of the integration bounds
+###### Line averaged density/temperature derivation
+Line averaged electron density/temperature is calculated by integrating the profile across the normalised width of the profile and then dividing by the width of the integration bounds. Using the density as an example:
 
 $$
 \overbrace{\bar{n_{\text{e}}}}^{\texttt{nd_plasma_electron_line}} = \frac{\int^1_0 n_0(1-\rho^2)^{\alpha_n} \ d\rho}{\rho}
@@ -612,10 +612,14 @@ $$
 \texttt{f_temp_plasma_electron_density_vol_avg} =\frac{\langle T_{\text{e}} \rangle_{\text{n}}}{\underbrace{\langle T_{\text{e}} \rangle_{\text{V}}}_{\texttt{temp_plasma_electrons_vol_avg}}}
 $$
 
-Calculate the line averaged electron density by integrating the normalised profile using the class [`integrate_profile_y()`](./plasma_profiles_abstract_class.md#calculate-the-profile-integral-value-integrate_profile_y) function
+Calculate the line averaged electron density and temperature by integrating the normalised profile using the class [`integrate_profile_y()`](./plasma_profiles_abstract_class.md#calculate-the-profile-integral-value-integrate_profile_y) function
 
 $$
  \overbrace{\bar{n_{\text{e}}}}^{\texttt{nd_plasma_electron_line}} = \int_0^1{n(\rho) \ d\rho}
+$$
+
+$$
+ \overbrace{\bar{T_{\text{e}}}}^{\texttt{temp_plasma_electron_line_avg_kev}} = \int_0^1{T(\rho) \ d\rho}
 $$
 
 A divertor variable `prn1` is set to be equal to the separatrix density over the mean density:

--- a/process/core/init.py
+++ b/process/core/init.py
@@ -60,6 +60,7 @@ from process.data_structure.superconducting_tf_coil_variables import (
 from process.data_structure.tfcoil_variables import init_tfcoil_variables
 from process.data_structure.times_variables import init_times_variables
 from process.data_structure.vacuum_variables import init_vacuum_variables
+from process.models.physics.profiles import DensityProfilePedestalType
 from process.models.stellarator.initialization import st_init
 from process.models.superconductors import (
     SuperconductorMaterial,
@@ -503,10 +504,10 @@ def check_process(inputs):  # noqa: ARG001
         # Density checks
         # Case where pedestal density is set manually
         if (
-            data_structure.physics_variables.f_nd_plasma_pedestal_greenwald < 0
-            or not (
-                data_structure.numerics.ixc[: data_structure.numerics.nvar] == 145
-            ).any()
+            DensityProfilePedestalType(
+                data_structure.physics_variables.i_nd_plasma_pedestal_separatrix
+            )
+            == DensityProfilePedestalType.USER_INPUT
         ):
             # Issue #589 Pedestal density is set manually using nd_plasma_pedestal_electron but it is less than nd_plasma_separatrix_electron.
             if (

--- a/process/core/init.py
+++ b/process/core/init.py
@@ -424,49 +424,45 @@ def check_process(inputs, data):  # noqa: ARG001
         # Density checks
         # Issue #589: Pedestal density is lower than separatrix density
         pedestal_type = DensityProfilePedestalType(
-            data_structure.physics_variables.i_nd_plasma_pedestal_separatrix
+            data.physics.i_nd_plasma_pedestal_separatrix
         )
         if (
             pedestal_type == DensityProfilePedestalType.USER_INPUT
-            and data_structure.physics_variables.nd_plasma_pedestal_electron
-            < data_structure.physics_variables.nd_plasma_separatrix_electron
+            and data.physics.nd_plasma_pedestal_electron
+            < data.physics.nd_plasma_separatrix_electron
         ) or (
             pedestal_type == DensityProfilePedestalType.GREENWALD_FRACTION
-            and data_structure.physics_variables.f_nd_plasma_pedestal_greenwald
-            < data_structure.physics_variables.f_nd_plasma_separatrix_greenwald
+            and data.physics.f_nd_plasma_pedestal_greenwald
+            < data.physics.f_nd_plasma_separatrix_greenwald
         ):
             raise ProcessValidationError(
                 "Density pedestal is lower than separatrix density",
                 **(
                     {
-                        "nd_plasma_pedestal_electron": data_structure.physics_variables.nd_plasma_pedestal_electron,
-                        "nd_plasma_separatrix_electron": data_structure.physics_variables.nd_plasma_separatrix_electron,
+                        "nd_plasma_pedestal_electron": data.physics.nd_plasma_pedestal_electron,
+                        "nd_plasma_separatrix_electron": data.physics.nd_plasma_separatrix_electron,
                     }
                     if pedestal_type == DensityProfilePedestalType.USER_INPUT
                     else {
-                        "f_nd_plasma_pedestal_greenwald": data_structure.physics_variables.f_nd_plasma_pedestal_greenwald,
-                        "f_nd_plasma_separatrix_greenwald": data_structure.physics_variables.f_nd_plasma_separatrix_greenwald,
+                        "f_nd_plasma_pedestal_greenwald": data.physics.f_nd_plasma_pedestal_greenwald,
+                        "f_nd_plasma_separatrix_greenwald": data.physics.f_nd_plasma_separatrix_greenwald,
                     }
                 ),
             )
 
         if (
-            abs(
-                data_structure.physics_variables.radius_plasma_pedestal_density_norm
-                - 1.0
-            )
-            <= 1e-7
+            abs(data.physics.radius_plasma_pedestal_density_norm - 1.0) <= 1e-7
             and (
-                data_structure.physics_variables.nd_plasma_pedestal_electron
-                - data_structure.physics_variables.nd_plasma_separatrix_electron
+                data.physics.nd_plasma_pedestal_electron
+                - data.physics.nd_plasma_separatrix_electron
             )
             >= 1e-7
         ):
             warn(
                 "Density pedestal is at plasma edge "
-                f"({data_structure.physics_variables.radius_plasma_pedestal_density_norm = }), but nd_plasma_pedestal_electron "
-                f"({data_structure.physics_variables.nd_plasma_pedestal_electron}) differs from "
-                f"nd_plasma_separatrix_electron ({data_structure.physics_variables.nd_plasma_separatrix_electron})",
+                f"({data.physics.radius_plasma_pedestal_density_norm = }), but nd_plasma_pedestal_electron "
+                f"({data.physics.nd_plasma_pedestal_electron}) differs from "
+                f"nd_plasma_separatrix_electron ({data.physics.nd_plasma_separatrix_electron})",
                 stacklevel=2,
             )
 

--- a/process/core/init.py
+++ b/process/core/init.py
@@ -428,17 +428,30 @@ def check_process(inputs, data):  # noqa: ARG001
                 data.physics.i_nd_plasma_pedestal_separatrix
             )
             == DensityProfilePedestalType.USER_INPUT
+            and data_structure.physics_variables.nd_plasma_pedestal_electron
+            < data_structure.physics_variables.nd_plasma_separatrix_electron
         ):
             # Issue #589 Pedestal density is set manually using nd_plasma_pedestal_electron but it is less than nd_plasma_separatrix_electron.
-            if (
-                data.physics.nd_plasma_pedestal_electron
-                < data.physics.nd_plasma_separatrix_electron
-            ):
-                raise ProcessValidationError(
-                    "Density pedestal is lower than separatrix density",
-                    nd_plasma_pedestal_electron=data.physics.nd_plasma_pedestal_electron,
-                    nd_plasma_separatrix_electron=data.physics.nd_plasma_separatrix_electron,
-                )
+            raise ProcessValidationError(
+                "Density pedestal is lower than separatrix density",
+                nd_plasma_pedestal_electron=data_structure.physics_variables.nd_plasma_pedestal_electron,
+                nd_plasma_separatrix_electron=data_structure.physics_variables.nd_plasma_separatrix_electron,
+            )
+
+        if (
+            DensityProfilePedestalType(
+                data_structure.physics_variables.i_nd_plasma_pedestal_separatrix
+            )
+            == DensityProfilePedestalType.GREENWALD_FRACTION
+            and data_structure.physics_variables.f_nd_plasma_pedestal_greenwald
+            < data_structure.physics_variables.f_nd_plasma_separatrix_greenwald
+        ):
+            # Issue #589 Pedestal density is set manually using nd_plasma_pedestal_electron but it is less than nd_plasma_separatrix_electron.
+            raise ProcessValidationError(
+                "Density pedestal is lower than separatrix density",
+                f_nd_plasma_pedestal_greenwald=data_structure.physics_variables.f_nd_plasma_pedestal_greenwald,
+                f_nd_plasma_separatrix_greenwald=data_structure.physics_variables.f_nd_plasma_separatrix_greenwald,
+            )
 
             # Issue #589 Pedestal density is set manually using nd_plasma_pedestal_electron,
             # but pedestal width = 0.

--- a/process/core/init.py
+++ b/process/core/init.py
@@ -21,6 +21,7 @@ from process.data_structure.impurity_radiation_variables import N_IMPURITIES
 from process.data_structure.numerics import FiguresOfMerit, PROCESSRunMode
 from process.data_structure.physics_variables import DivertorNumberModels
 from process.data_structure.scan_variables import init_scan_variables
+from process.models.physics.profiles import DensityProfilePedestalType
 from process.models.stellarator.initialization import st_init
 from process.models.superconductors import (
     SuperconductorMaterial,
@@ -423,10 +424,10 @@ def check_process(inputs, data):  # noqa: ARG001
         # Density checks
         # Case where pedestal density is set manually
         if (
-            data.physics.f_nd_plasma_pedestal_greenwald < 0
-            or not (
-                data_structure.numerics.ixc[: data_structure.numerics.nvar] == 145
-            ).any()
+            DensityProfilePedestalType(
+                data.physics.i_nd_plasma_pedestal_separatrix
+            )
+            == DensityProfilePedestalType.USER_INPUT
         ):
             # Issue #589 Pedestal density is set manually using nd_plasma_pedestal_electron but it is less than nd_plasma_separatrix_electron.
             if (

--- a/process/core/init.py
+++ b/process/core/init.py
@@ -422,54 +422,53 @@ def check_process(inputs, data):  # noqa: ARG001
             )
 
         # Density checks
-        # Case where pedestal density is set manually
+        # Issue #589: Pedestal density is lower than separatrix density
+        pedestal_type = DensityProfilePedestalType(
+            data_structure.physics_variables.i_nd_plasma_pedestal_separatrix
+        )
         if (
-            DensityProfilePedestalType(
-                data.physics.i_nd_plasma_pedestal_separatrix
-            )
-            == DensityProfilePedestalType.USER_INPUT
+            pedestal_type == DensityProfilePedestalType.USER_INPUT
             and data_structure.physics_variables.nd_plasma_pedestal_electron
             < data_structure.physics_variables.nd_plasma_separatrix_electron
-        ):
-            # Issue #589 Pedestal density is set manually using nd_plasma_pedestal_electron but it is less than nd_plasma_separatrix_electron.
-            raise ProcessValidationError(
-                "Density pedestal is lower than separatrix density",
-                nd_plasma_pedestal_electron=data_structure.physics_variables.nd_plasma_pedestal_electron,
-                nd_plasma_separatrix_electron=data_structure.physics_variables.nd_plasma_separatrix_electron,
-            )
-
-        if (
-            DensityProfilePedestalType(
-                data_structure.physics_variables.i_nd_plasma_pedestal_separatrix
-            )
-            == DensityProfilePedestalType.GREENWALD_FRACTION
+        ) or (
+            pedestal_type == DensityProfilePedestalType.GREENWALD_FRACTION
             and data_structure.physics_variables.f_nd_plasma_pedestal_greenwald
             < data_structure.physics_variables.f_nd_plasma_separatrix_greenwald
         ):
-            # Issue #589 Pedestal density is set manually using nd_plasma_pedestal_electron but it is less than nd_plasma_separatrix_electron.
             raise ProcessValidationError(
                 "Density pedestal is lower than separatrix density",
-                f_nd_plasma_pedestal_greenwald=data_structure.physics_variables.f_nd_plasma_pedestal_greenwald,
-                f_nd_plasma_separatrix_greenwald=data_structure.physics_variables.f_nd_plasma_separatrix_greenwald,
+                **(
+                    {
+                        "nd_plasma_pedestal_electron": data_structure.physics_variables.nd_plasma_pedestal_electron,
+                        "nd_plasma_separatrix_electron": data_structure.physics_variables.nd_plasma_separatrix_electron,
+                    }
+                    if pedestal_type == DensityProfilePedestalType.USER_INPUT
+                    else {
+                        "f_nd_plasma_pedestal_greenwald": data_structure.physics_variables.f_nd_plasma_pedestal_greenwald,
+                        "f_nd_plasma_separatrix_greenwald": data_structure.physics_variables.f_nd_plasma_separatrix_greenwald,
+                    }
+                ),
             )
 
-            # Issue #589 Pedestal density is set manually using nd_plasma_pedestal_electron,
-            # but pedestal width = 0.
-            if (
-                abs(data.physics.radius_plasma_pedestal_density_norm - 1.0) <= 1e-7
-                and (
-                    data.physics.nd_plasma_pedestal_electron
-                    - data.physics.nd_plasma_separatrix_electron
-                )
-                >= 1e-7
-            ):
-                warn(
-                    "Density pedestal is at plasma edge "
-                    f"({data.physics.radius_plasma_pedestal_density_norm = }), but nd_plasma_pedestal_electron "
-                    f"({data.physics.nd_plasma_pedestal_electron}) differs from "
-                    f"nd_plasma_separatrix_electron ({data.physics.nd_plasma_separatrix_electron})",
-                    stacklevel=2,
-                )
+        if (
+            abs(
+                data_structure.physics_variables.radius_plasma_pedestal_density_norm
+                - 1.0
+            )
+            <= 1e-7
+            and (
+                data_structure.physics_variables.nd_plasma_pedestal_electron
+                - data_structure.physics_variables.nd_plasma_separatrix_electron
+            )
+            >= 1e-7
+        ):
+            warn(
+                "Density pedestal is at plasma edge "
+                f"({data_structure.physics_variables.radius_plasma_pedestal_density_norm = }), but nd_plasma_pedestal_electron "
+                f"({data_structure.physics_variables.nd_plasma_pedestal_electron}) differs from "
+                f"nd_plasma_separatrix_electron ({data_structure.physics_variables.nd_plasma_separatrix_electron})",
+                stacklevel=2,
+            )
 
         # Issue #862 : Variable nd_plasma_electron_on_axis/nd_plasma_pedestal_electron ratio without constraint eq 81 (nd_plasma_electron_on_axis>nd_plasma_pedestal_electron)
         #  -> Potential hollowed density profile

--- a/process/core/input.py
+++ b/process/core/input.py
@@ -1083,6 +1083,9 @@ INPUT_VARIABLES = {
     "nd_plasma_separatrix_electron": InputVariable(
         data_structure.physics_variables, float, range=(0.0, 1e21)
     ),
+    "i_nd_plasma_pedestal_electron": InputVariable(
+        data_structure.physics_variables, int, choices=[0, 1]
+    ),
     "nflutfmax": InputVariable(
         data_structure.constraint_variables, float, range=(0.0, 1e24)
     ),

--- a/process/core/input.py
+++ b/process/core/input.py
@@ -171,10 +171,10 @@ INPUT_VARIABLES = {
     ),
     "ffwal": InputVariable(data_structure.physics_variables, float, range=(0.0, 10.0)),
     "f_nd_plasma_pedestal_greenwald": InputVariable(
-        data_structure.physics_variables, float, range=(-1.0, 5.0)
+        data_structure.physics_variables, float, range=(0.1, 1.5)
     ),
     "f_nd_plasma_separatrix_greenwald": InputVariable(
-        data_structure.physics_variables, float, range=(-1.0, 5.0)
+        data_structure.physics_variables, float, range=(0.01, 0.9)
     ),
     "f_plasma_fuel_helium3": InputVariable(
         data_structure.physics_variables, float, range=(-1.0, 5.0)

--- a/process/core/input.py
+++ b/process/core/input.py
@@ -149,9 +149,9 @@ INPUT_VARIABLES = {
     "f_p_div_lower": InputVariable("physics", float, range=(0.0, 1.0)),
     "f_plasma_fuel_deuterium": InputVariable("physics", float, range=(0.0, 1.0)),
     "ffwal": InputVariable("physics", float, range=(0.0, 10.0)),
-    "f_nd_plasma_pedestal_greenwald": InputVariable("physics", float, range=(-1.0, 5.0)),
+    "f_nd_plasma_pedestal_greenwald": InputVariable("physics", float, range=(0.1, 1.5)),
     "f_nd_plasma_separatrix_greenwald": InputVariable(
-        "physics", float, range=(-1.0, 5.0)
+        "physics", float, range=(0.01, 0.9)
     ),
     "f_plasma_fuel_helium3": InputVariable("physics", float, range=(-1.0, 5.0)),
     # TODO: does f_nd_impurity_electrons require an additional range?

--- a/process/core/input.py
+++ b/process/core/input.py
@@ -151,7 +151,7 @@ INPUT_VARIABLES = {
     "ffwal": InputVariable("physics", float, range=(0.0, 10.0)),
     "f_nd_plasma_pedestal_greenwald": InputVariable("physics", float, range=(0.1, 1.5)),
     "f_nd_plasma_separatrix_greenwald": InputVariable(
-        "physics", float, range=(0.01, 0.9)
+        "physics", float, range=(0.001, 0.9)
     ),
     "f_plasma_fuel_helium3": InputVariable("physics", float, range=(-1.0, 5.0)),
     # TODO: does f_nd_impurity_electrons require an additional range?

--- a/process/core/input.py
+++ b/process/core/input.py
@@ -578,6 +578,9 @@ INPUT_VARIABLES = {
     ),
     "nd_plasma_pedestal_electron": InputVariable("physics", float, range=(0.0, 1e21)),
     "nd_plasma_separatrix_electron": InputVariable("physics", float, range=(0.0, 1e21)),
+    "i_nd_plasma_pedestal_electron": InputVariable(
+        data_structure.physics_variables, int, choices=[0, 1]
+    ),
     "nflutfmax": InputVariable("constraints", float, range=(0.0, 1e24)),
     "j_tf_coil_full_area": InputVariable("tfcoil", float, range=(10000.0, 1000000000.0)),
     "f_a_cs_turn_steel": InputVariable("pf_coil", float, range=(0.001, 0.999)),

--- a/process/core/input.py
+++ b/process/core/input.py
@@ -578,7 +578,7 @@ INPUT_VARIABLES = {
     ),
     "nd_plasma_pedestal_electron": InputVariable("physics", float, range=(0.0, 1e21)),
     "nd_plasma_separatrix_electron": InputVariable("physics", float, range=(0.0, 1e21)),
-    "i_nd_plasma_pedestal_electron": InputVariable(
+    "i_nd_plasma_pedestal_separatrix": InputVariable(
         data_structure.physics_variables, int, choices=[0, 1]
     ),
     "nflutfmax": InputVariable("constraints", float, range=(0.0, 1e24)),

--- a/process/core/io/mfile/comparison.py
+++ b/process/core/io/mfile/comparison.py
@@ -117,7 +117,7 @@ BASELINE_LIST = [
     "temp_plasma_electron_on_axis_kev",
     "nd_plasma_electrons_vol_avg",
     "nd_plasma_electron_on_axis",
-    "dnla_gw",
+    "f_nd_plasma_greenwald",
     "temp_plasma_separatrix_kev",
     "nd_plasma_separatrix_electron",
     "temp_plasma_pedestal_kev",

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -4266,7 +4266,7 @@ def plot_t_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
         (
             rf"$\langle T_{{\text{{e}}}} \rangle_\text{{V}}$:  {mfile.get('temp_plasma_electron_vol_avg_kev', scan=scan):.3f} keV"
             rf"$\hspace{{2}} \langle T_{{\text{{e}}}} \rangle_\text{{n}}$: {mfile.get('temp_plasma_electron_density_weighted_kev', scan=scan):.3f} keV"
-            rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_average_kev', scan=scan):.3f} keV"
+            rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_avg_kev', scan=scan):.3f} keV"
         ),
         (
             rf"$T_{{\text{{e,0}}}}$:    {te0:.3f} keV"

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -4015,7 +4015,8 @@ def plot_n_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
 
     # Add text box with density profile parameters
     textstr_density = "\n".join((
-        rf"$\langle n_{{\text{{e}}}} \rangle$: {nd_plasma_electrons_vol_avg:.3e} m$^{{-3}}$",
+        rf"$\langle n_{{\text{{e}}}} \rangle$: {nd_plasma_electrons_vol_avg:.3e} m$^{{-3}}$"
+        rf"$\hspace{{4}} \overline{{n_{{e}}}}$: {mfile.get('nd_plasma_electron_line', scan=scan):.3e} m$^{{-3}}$",
         (
             rf"$n_{{\text{{e,0}}}}$: {ne0:.3e} m$^{{-3}}$"
             rf"$\hspace{{4}} \alpha_{{\text{{n}}}}$: {alphan:.3f}"

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -4015,8 +4015,10 @@ def plot_n_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
 
     # Add text box with density profile parameters
     textstr_density = "\n".join((
-        rf"$\langle n_{{\text{{e}}}} \rangle$: {nd_plasma_electrons_vol_avg:.3e} m$^{{-3}}$"
-        rf"$\hspace{{4}} \overline{{n_{{e}}}}$: {mfile.get('nd_plasma_electron_line', scan=scan):.3e} m$^{{-3}}$",
+        (
+            rf"$\langle n_{{\text{{e}}}} \rangle$: {nd_plasma_electrons_vol_avg:.3e} m$^{{-3}}$"
+            rf"$\hspace{{4}} \overline{{n_{{e}}}}$: {mfile.get('nd_plasma_electron_line', scan=scan):.3e} m$^{{-3}}$"
+        ),
         (
             rf"$n_{{\text{{e,0}}}}$: {ne0:.3e} m$^{{-3}}$"
             rf"$\hspace{{4}} \alpha_{{\text{{n}}}}$: {alphan:.3f}"
@@ -4264,7 +4266,7 @@ def plot_t_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
         (
             rf"$\langle T_{{\text{{e}}}} \rangle_\text{{V}}$:  {mfile.get('temp_plasma_electron_vol_avg_kev', scan=scan):.3f} keV"
             rf"$\hspace{{2}} \langle T_{{\text{{e}}}} \rangle_\text{{n}}$: {mfile.get('temp_plasma_electron_density_weighted_kev', scan=scan):.3f} keV"
-        rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_average_kev', scan=scan):.3f} keV"
+            rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_average_kev', scan=scan):.3f} keV"
         ),
         (
             rf"$T_{{\text{{e,0}}}}$:    {te0:.3f} keV"

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -4262,33 +4262,34 @@ def plot_t_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
     # Add text box with temperature profile parameters
     textstr_temperature = "\n".join((
         (
-            rf"$\langle T_{{\text{{e}}}} \rangle_\text{{V}}$: {mfile.get('temp_plasma_electron_vol_avg_kev', scan=scan):.3f} keV"
-            rf"$\hspace{{3}} \langle T_{{\text{{e}}}} \rangle_\text{{n}}$: {mfile.get('temp_plasma_electron_density_weighted_kev', scan=scan):.3f} keV"
+            rf"$\langle T_{{\text{{e}}}} \rangle_\text{{V}}$:  {mfile.get('temp_plasma_electron_vol_avg_kev', scan=scan):.3f} keV"
+            rf"$\hspace{{2}} \langle T_{{\text{{e}}}} \rangle_\text{{n}}$: {mfile.get('temp_plasma_electron_density_weighted_kev', scan=scan):.3f} keV"
+        rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_average_kev', scan=scan):.3f} keV"
         ),
         (
-            rf"$T_{{\text{{e,0}}}}$: {te0:.3f} keV"
-            rf"$\hspace{{4}} \alpha_{{\text{{T}}}}$: {alphat:.3f}"
+            rf"$T_{{\text{{e,0}}}}$:    {te0:.3f} keV"
+            rf"$\hspace{{2}} \alpha_{{\text{{T}}}}$:   {alphat:.3f}"
         ),
         (
             rf"$T_{{\text{{e,ped}}}}$: {temp_plasma_pedestal_kev:.3f} keV"
-            r"$ \hspace{4} \frac{\langle T_i \rangle}{\langle T_e \rangle}$: "
+            r"$ \hspace{3} \frac{\langle T_i \rangle}{\langle T_e \rangle}$: "
             f"{f_temp_plasma_ion_electron:.3f}"
         ),
         (
             rf"$\rho_{{\text{{ped,T}}}}$: {radius_plasma_pedestal_temp_norm:.3f}"
-            r"$ \hspace{6} \frac{T_{e,0}}{\langle T_e \rangle}$: "
+            r"$ \hspace{5} \frac{T_{e,0}}{\langle T_e \rangle}$: "
             f"{te0 / te:.3f}"
         ),
         (
             rf"$T_{{\text{{e,sep}}}}$: {temp_plasma_separatrix_kev:.3f} keV"
-            r"$ \hspace{4} \frac{{{\langle T_e \rangle_n}}}{{{\langle T_e \rangle_V}}}$: "
+            r"$ \hspace{3} \frac{{{\langle T_e \rangle_n}}}{{{\langle T_e \rangle_V}}}$: "
             f"{mfile.get('f_temp_plasma_electron_density_vol_avg', scan=scan):.3f}"
         ),
     ))
 
     props_temperature = {"boxstyle": "round", "facecolor": "wheat", "alpha": 0.5}
     prof.text(
-        0.0,
+        -0.1,
         -0.125,
         textstr_temperature,
         transform=prof.transAxes,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -3866,8 +3866,12 @@ def plot_n_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
     nd_ions_total = mfile.get("nd_plasma_ions_total_vol_avg", scan=scan)
     nd_fuel_ions = mfile.get("nd_plasma_fuel_ions_vol_avg", scan=scan)
     alphan = mfile.get("alphan", scan=scan)
-    fgwped_out = mfile.get("fgwped_out", scan=scan)
-    fgwsep_out = mfile.get("fgwsep_out", scan=scan)
+    f_nd_plasma_pedestal_greenwald = mfile.get(
+        "f_nd_plasma_pedestal_greenwald", scan=scan
+    )
+    f_nd_plasma_separatrix_greenwald = mfile.get(
+        "f_nd_plasma_separatrix_greenwald", scan=scan
+    )
     nd_plasma_electrons_vol_avg = mfile.get("nd_plasma_electrons_vol_avg", scan=scan)
     # find impurity densities
     imp_frac = np.array([
@@ -4071,7 +4075,7 @@ def plot_n_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
             f"{nd_fuel_ions / nd_plasma_electrons_vol_avg:.3f}"
         ),
         (
-            rf"$f_{{\text{{GW e,ped}}}}$: {fgwped_out:.3f}"
+            rf"$f_{{\text{{GW e,ped}}}}$: {f_nd_plasma_pedestal_greenwald:.3f}"
             r"$ \hspace{7} \frac{n_{e,0}}{\langle n_e \rangle}$: "
             f"{ne0 / nd_plasma_electrons_vol_avg:.3f}"
         ),
@@ -4081,12 +4085,12 @@ def plot_n_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
             f"{mfile.get('nd_plasma_electron_line', scan=scan) / mfile.get('nd_plasma_electron_max_array(7)', scan=scan):.3f}"
         ),
         rf"$n_{{\text{{e,sep}}}}$: {nd_plasma_separatrix_electron:.3e} m$^{{-3}}$",
-        rf"$f_{{\text{{GW e,sep}}}}$: {fgwsep_out:.3f}",
+        rf"$f_{{\text{{GW e,sep}}}}$: {f_nd_plasma_separatrix_greenwald:.3f}",
     ))
 
     props_density = {"boxstyle": "round", "facecolor": "wheat", "alpha": 0.5}
     ax_main.text(
-        0.0,
+        -0.05,
         -0.175,
         textstr_density,
         transform=ax_impurity.transAxes,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -3172,7 +3172,7 @@ def plot_main_plasma_information(
         f"$\\mathbf{{Density \\ limit:}}$\n"
         f"({DensityLimitModel(int(mfile.get('i_density_limit', scan=scan))).full_name})\n"
         f"$n_{{\\text{{e,limit}}}}: {mfile.get('nd_plasma_electrons_max', scan=scan):.3e} \\ m^{{-3}}$\n"
-        f"$f_{{\\text{{GW}}}}$: {mfile.get('dnla_gw', scan=scan):.4f}"
+        f"$f_{{\\text{{GW}}}}$: {mfile.get('f_nd_plasma_greenwald', scan=scan):.4f}"
     )
 
     axis.text(

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -4307,7 +4307,7 @@ def plot_t_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
         (
             rf"$\langle T_{{\text{{e}}}} \rangle_\text{{V}}$:  {mfile.get('temp_plasma_electron_vol_avg_kev', scan=scan):.3f} keV"
             rf"$\hspace{{2}} \langle T_{{\text{{e}}}} \rangle_\text{{n}}$: {mfile.get('temp_plasma_electron_density_weighted_kev', scan=scan):.3f} keV"
-            rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_average_kev', scan=scan):.3f} keV"
+            rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_avg_kev', scan=scan):.3f} keV"
         ),
         (
             rf"$T_{{\text{{e,0}}}}$:    {te0:.3f} keV"

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -4057,7 +4057,8 @@ def plot_n_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
 
     # Add text box with density profile parameters
     textstr_density = "\n".join((
-        rf"$\langle n_{{\text{{e}}}} \rangle$: {nd_plasma_electrons_vol_avg:.3e} m$^{{-3}}$",
+        rf"$\langle n_{{\text{{e}}}} \rangle$: {nd_plasma_electrons_vol_avg:.3e} m$^{{-3}}$"
+        rf"$\hspace{{4}} \overline{{n_{{e}}}}$: {mfile.get('nd_plasma_electron_line', scan=scan):.3e} m$^{{-3}}$",
         (
             rf"$n_{{\text{{e,0}}}}$: {ne0:.3e} m$^{{-3}}$"
             rf"$\hspace{{4}} \alpha_{{\text{{n}}}}$: {alphan:.3f}"

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -4303,33 +4303,34 @@ def plot_t_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
     # Add text box with temperature profile parameters
     textstr_temperature = "\n".join((
         (
-            rf"$\langle T_{{\text{{e}}}} \rangle_\text{{V}}$: {mfile.get('temp_plasma_electron_vol_avg_kev', scan=scan):.3f} keV"
-            rf"$\hspace{{3}} \langle T_{{\text{{e}}}} \rangle_\text{{n}}$: {mfile.get('temp_plasma_electron_density_weighted_kev', scan=scan):.3f} keV"
+            rf"$\langle T_{{\text{{e}}}} \rangle_\text{{V}}$:  {mfile.get('temp_plasma_electron_vol_avg_kev', scan=scan):.3f} keV"
+            rf"$\hspace{{2}} \langle T_{{\text{{e}}}} \rangle_\text{{n}}$: {mfile.get('temp_plasma_electron_density_weighted_kev', scan=scan):.3f} keV"
+        rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_average_kev', scan=scan):.3f} keV"
         ),
         (
-            rf"$T_{{\text{{e,0}}}}$: {te0:.3f} keV"
-            rf"$\hspace{{4}} \alpha_{{\text{{T}}}}$: {alphat:.3f}"
+            rf"$T_{{\text{{e,0}}}}$:    {te0:.3f} keV"
+            rf"$\hspace{{2}} \alpha_{{\text{{T}}}}$:   {alphat:.3f}"
         ),
         (
             rf"$T_{{\text{{e,ped}}}}$: {temp_plasma_pedestal_kev:.3f} keV"
-            r"$ \hspace{4} \frac{\langle T_i \rangle}{\langle T_e \rangle}$: "
+            r"$ \hspace{3} \frac{\langle T_i \rangle}{\langle T_e \rangle}$: "
             f"{f_temp_plasma_ion_electron:.3f}"
         ),
         (
             rf"$\rho_{{\text{{ped,T}}}}$: {radius_plasma_pedestal_temp_norm:.3f}"
-            r"$ \hspace{6} \frac{T_{e,0}}{\langle T_e \rangle}$: "
+            r"$ \hspace{5} \frac{T_{e,0}}{\langle T_e \rangle}$: "
             f"{te0 / te:.3f}"
         ),
         (
             rf"$T_{{\text{{e,sep}}}}$: {temp_plasma_separatrix_kev:.3f} keV"
-            r"$ \hspace{4} \frac{{{\langle T_e \rangle_n}}}{{{\langle T_e \rangle_V}}}$: "
+            r"$ \hspace{3} \frac{{{\langle T_e \rangle_n}}}{{{\langle T_e \rangle_V}}}$: "
             f"{mfile.get('f_temp_plasma_electron_density_vol_avg', scan=scan):.3f}"
         ),
     ))
 
     props_temperature = {"boxstyle": "round", "facecolor": "wheat", "alpha": 0.5}
     prof.text(
-        0.0,
+        -0.1,
         -0.125,
         textstr_temperature,
         transform=prof.transAxes,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -4057,8 +4057,10 @@ def plot_n_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
 
     # Add text box with density profile parameters
     textstr_density = "\n".join((
-        rf"$\langle n_{{\text{{e}}}} \rangle$: {nd_plasma_electrons_vol_avg:.3e} m$^{{-3}}$"
-        rf"$\hspace{{4}} \overline{{n_{{e}}}}$: {mfile.get('nd_plasma_electron_line', scan=scan):.3e} m$^{{-3}}$",
+        (
+            rf"$\langle n_{{\text{{e}}}} \rangle$: {nd_plasma_electrons_vol_avg:.3e} m$^{{-3}}$"
+            rf"$\hspace{{4}} \overline{{n_{{e}}}}$: {mfile.get('nd_plasma_electron_line', scan=scan):.3e} m$^{{-3}}$"
+        ),
         (
             rf"$n_{{\text{{e,0}}}}$: {ne0:.3e} m$^{{-3}}$"
             rf"$\hspace{{4}} \alpha_{{\text{{n}}}}$: {alphan:.3f}"
@@ -4305,7 +4307,7 @@ def plot_t_profiles(prof, demo_ranges: bool, mfile: MFile, scan: int):
         (
             rf"$\langle T_{{\text{{e}}}} \rangle_\text{{V}}$:  {mfile.get('temp_plasma_electron_vol_avg_kev', scan=scan):.3f} keV"
             rf"$\hspace{{2}} \langle T_{{\text{{e}}}} \rangle_\text{{n}}$: {mfile.get('temp_plasma_electron_density_weighted_kev', scan=scan):.3f} keV"
-        rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_average_kev', scan=scan):.3f} keV"
+            rf"$\hspace{{2}} \overline{{T_{{e}}}}$: {mfile.get('temp_plasma_electron_line_average_kev', scan=scan):.3f} keV"
         ),
         (
             rf"$T_{{\text{{e,0}}}}$:    {te0:.3f} keV"

--- a/process/core/io/variable_metadata.py
+++ b/process/core/io/variable_metadata.py
@@ -187,7 +187,7 @@ var_dicts = {
         description="Average electron density",
         units="m^{-3}",
     ),
-    "dnla_gw": VariableMetadata(
+    "f_nd_plasma_greenwald": VariableMetadata(
         latex=r"$f_{\mathrm{GW}}$", description="Greenwald fraction", units=""
     ),
     "normalised_toroidal_beta": VariableMetadata(

--- a/process/core/solver/iteration_variables.py
+++ b/process/core/solver/iteration_variables.py
@@ -260,10 +260,10 @@ ITERATION_VARIABLES = {
         1.0e20,
     ),
     145: IterationVariable(
-        "f_nd_plasma_pedestal_greenwald", data_structure.physics_variables, 0.1, 0.9
+        "f_nd_plasma_pedestal_greenwald", data_structure.physics_variables, 0.1, 1.5
     ),
     152: IterationVariable(
-        "f_nd_plasma_separatrix_greenwald", data_structure.physics_variables, 0.001, 0.5
+        "f_nd_plasma_separatrix_greenwald", data_structure.physics_variables, 0.001, 0.9
     ),
     155: IterationVariable("pfusife", data_structure.ife_variables, 5.0e2, 3.0e3),
     156: IterationVariable("rrin", data_structure.ife_variables, 1.0, 1.0e1),

--- a/process/core/solver/iteration_variables.py
+++ b/process/core/solver/iteration_variables.py
@@ -210,8 +210,8 @@ ITERATION_VARIABLES = {
         1.0e17,
         1.0e20,
     ),
-    145: IterationVariable("f_nd_plasma_pedestal_greenwald", "physics", 0.1, 0.9),
-    152: IterationVariable("f_nd_plasma_separatrix_greenwald", "physics", 0.001, 0.5),
+    145: IterationVariable("f_nd_plasma_pedestal_greenwald", "physics", 0.1, 1.5),
+    152: IterationVariable("f_nd_plasma_separatrix_greenwald", "physics", 0.001, 0.9),
     155: IterationVariable("pfusife", "ife", 5.0e2, 3.0e3),
     156: IterationVariable("rrin", "ife", 1.0, 1.0e1),
     158: IterationVariable(

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -1787,7 +1787,7 @@ def init_physics_variables():
     ffwal = 0.92
     f_nd_plasma_pedestal_greenwald = 0.85
     f_nd_plasma_separatrix_greenwald = 0.50
-    i_nd_plasma_pedestal_separatrix = 0
+    i_nd_plasma_pedestal_separatrix = 1
     f_plasma_fuel_helium3 = 0.0
     figmer = 0.0
     fkzohm = 1.0

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -422,16 +422,12 @@ load calculation (`i_pflux_fw_neutron=1`)
 
 
 f_nd_plasma_pedestal_greenwald: float = None
-"""fraction of Greenwald density to set as pedestal-top density. If `<0`, pedestal-top
-density set manually using nd_plasma_pedestal_electron (`i_plasma_pedestal==1`).
-(`iteration variable 145`)
+"""fraction of Greenwald density to set as pedestal-top density.
 """
 
 
 f_nd_plasma_separatrix_greenwald: float = None
-"""fraction of Greenwald density to set as separatrix density. If `<0`, separatrix
-density set manually using nd_plasma_separatrix_electron (`i_plasma_pedestal==1`).
-(`iteration variable 152`)
+"""fraction of Greenwald density to set as separatrix density.
 """
 
 

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -1213,6 +1213,8 @@ temp_plasma_electron_on_axis_kev: float = None
 temp_plasma_electron_density_weighted_kev: float = None
 """density weighted average electron temperature (keV)"""
 
+temp_plasma_electron_line_average_kev: float = None
+"""line averaged electron temperature (keV)"""
 
 temp_plasma_ion_vol_avg_kev: float = None
 """volume averaged ion temperature (keV). N.B. calculated from temp_plasma_electron_vol_avg_kev if `f_temp_plasma_ion_electron > 0.0`"""
@@ -1660,6 +1662,7 @@ def init_physics_variables():
         temp_plasma_electron_vol_avg_kev, \
         temp_plasma_electron_on_axis_kev, \
         temp_plasma_electron_density_weighted_kev, \
+        temp_plasma_electron_line_average_kev, \
         temp_plasma_ion_vol_avg_kev, \
         temp_plasma_ion_on_axis_kev, \
         temp_plasma_ion_density_weighted_kev, \
@@ -1952,6 +1955,7 @@ def init_physics_variables():
     temp_plasma_electron_vol_avg_kev = 12.9
     temp_plasma_electron_on_axis_kev = 0.0
     temp_plasma_electron_density_weighted_kev = 0.0
+    temp_plasma_electron_line_average_kev = 0.0
     temp_plasma_ion_vol_avg_kev = 12.9
     temp_plasma_ion_on_axis_kev = 0.0
     temp_plasma_ion_density_weighted_kev = 0.0

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -601,6 +601,12 @@ nd_plasma_pedestal_electron: float = None
 nd_plasma_separatrix_electron: float = None
 """electron density at separatrix [m-3] (`i_plasma_pedestal==1)"""
 
+i_nd_plasma_pedestal_separatrix: int = None
+"""switch for pedestal and separatrix density calculation:
+- =0 User input pedestal and separatrix density
+- =1 Calculate pedestal and separatrix density as fraction of Greenwald limit (see `f_nd_plasma_pedestal_greenwald` and `f_nd_plasma_separatrix_greenwald`)
+"""
+
 
 alpha_crit: float = None
 """critical ballooning parameter value"""
@@ -1488,6 +1494,7 @@ def init_physics_variables():
         ffwal, \
         f_nd_plasma_pedestal_greenwald, \
         f_nd_plasma_separatrix_greenwald, \
+        i_nd_plasma_pedestal_separatrix, \
         f_plasma_fuel_helium3, \
         figmer, \
         fkzohm, \
@@ -1777,6 +1784,7 @@ def init_physics_variables():
     ffwal = 0.92
     f_nd_plasma_pedestal_greenwald = 0.85
     f_nd_plasma_separatrix_greenwald = 0.50
+    i_nd_plasma_pedestal_separatrix = 0
     f_plasma_fuel_helium3 = 0.0
     figmer = 0.0
     fkzohm = 1.0

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -1213,7 +1213,7 @@ temp_plasma_electron_on_axis_kev: float = None
 temp_plasma_electron_density_weighted_kev: float = None
 """density weighted average electron temperature (keV)"""
 
-temp_plasma_electron_line_average_kev: float = None
+temp_plasma_electron_line_avg_kev: float = None
 """line averaged electron temperature (keV)"""
 
 temp_plasma_ion_vol_avg_kev: float = None
@@ -1662,7 +1662,7 @@ def init_physics_variables():
         temp_plasma_electron_vol_avg_kev, \
         temp_plasma_electron_on_axis_kev, \
         temp_plasma_electron_density_weighted_kev, \
-        temp_plasma_electron_line_average_kev, \
+        temp_plasma_electron_line_avg_kev, \
         temp_plasma_ion_vol_avg_kev, \
         temp_plasma_ion_on_axis_kev, \
         temp_plasma_ion_density_weighted_kev, \
@@ -1955,7 +1955,7 @@ def init_physics_variables():
     temp_plasma_electron_vol_avg_kev = 12.9
     temp_plasma_electron_on_axis_kev = 0.0
     temp_plasma_electron_density_weighted_kev = 0.0
-    temp_plasma_electron_line_average_kev = 0.0
+    temp_plasma_electron_line_avg_kev = 0.0
     temp_plasma_ion_vol_avg_kev = 12.9
     temp_plasma_ion_on_axis_kev = 0.0
     temp_plasma_ion_density_weighted_kev = 0.0

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -336,18 +336,17 @@ class PhysicsData:
     load calculation (`i_pflux_fw_neutron=1`)
     """
 
-f_nd_plasma_greenwald: float = None
-"""Greenwald fraction of the line averaged electron density. The classic Greenwald
-limit value"""
+    f_nd_plasma_greenwald: float = None
+    """Greenwald fraction of the line averaged electron density. The classic Greenwald
+    limit value"""
 
-f_nd_plasma_pedestal_greenwald: float = 0.85
-"""Greenwald fraction of the pedestal density
-"""
+    f_nd_plasma_pedestal_greenwald: float = 0.85
+    """Greenwald fraction of the pedestal density
+    """
 
-
-f_nd_plasma_separatrix_greenwald: float = 0.5
-"""Greenwald fraction of the separatrix density
-"""
+    f_nd_plasma_separatrix_greenwald: float = 0.5
+    """Greenwald fraction of the separatrix density
+    """
 
     f_plasma_fuel_helium3: float = 0.0
     """Plasma Helium-3 fuel fraction"""
@@ -489,22 +488,22 @@ f_nd_plasma_separatrix_greenwald: float = 0.5
     """
 
     nd_plasma_pedestal_electron: float = 4.0e19
-    """electron density of pedestal [m-3] (`i_plasma_pedestal==1)"""
+    """electron density of pedestal [m⁻³] (`i_plasma_pedestal==1)"""
 
     nd_plasma_separatrix_electron: float = 3.0e19
-    """electron density at separatrix [m-3] (`i_plasma_pedestal==1)"""
+    """electron density at separatrix [m⁻³] (`i_plasma_pedestal==1)"""
 
-i_nd_plasma_pedestal_separatrix: int = None
-"""switch for pedestal and separatrix density calculation:
-- =0 User input pedestal and separatrix density
-- =1 Calculate pedestal and separatrix density as fraction of Greenwald limit (see `f_nd_plasma_pedestal_greenwald` and `f_nd_plasma_separatrix_greenwald`)
-"""
+    i_nd_plasma_pedestal_separatrix: int = 1
+    """switch for pedestal and separatrix density calculation:
+    - =0 User input pedestal and separatrix density
+    - =1 Calculate pedestal and separatrix density as fraction of Greenwald limit (see `f_nd_plasma_pedestal_greenwald` and `f_nd_plasma_separatrix_greenwald`)
+    """
 
     alpha_crit: float = 0.0
     """critical ballooning parameter value"""
 
     nd_plasma_separatrix_electron_eich_max: float = 0.0
-    """Eich critical electron density at separatrix [m-3]"""
+    """Eich critical electron density at separatrix [m⁻³]"""
 
     plasma_res_factor: float = 1.0
     """plasma resistivity pre-factor"""
@@ -992,7 +991,7 @@ i_nd_plasma_pedestal_separatrix: int = None
 
     temp_plasma_electron_line_avg_kev: float = None
     """Line averaged electron temperature (keV)"""
-    
+
     temp_plasma_ion_vol_avg_kev: float = 12.9
     """volume averaged ion temperature (keV). N.B. calculated from temp_plasma_electron_vol_avg_kev if `f_temp_plasma_ion_electron > 0.0`"""
 

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -989,7 +989,7 @@ i_nd_plasma_pedestal_separatrix: int = None
     temp_plasma_electron_density_weighted_kev: float = 0.0
     """density weighted average electron temperature (keV)"""
 
-temp_plasma_electron_line_average_kev: float = None
+temp_plasma_electron_line_avg_kev: float = None
 """line averaged electron temperature (keV)"""
     temp_plasma_ion_vol_avg_kev: float = 12.9
     """volume averaged ion temperature (keV). N.B. calculated from temp_plasma_electron_vol_avg_kev if `f_temp_plasma_ion_electron > 0.0`"""

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -338,12 +338,12 @@ class PhysicsData:
 
 
 f_nd_plasma_pedestal_greenwald: float = 0.85
-"""fraction of Greenwald density to set as pedestal-top density.
+"""Greenwald fraction of the pedestal density
 """
 
 
 f_nd_plasma_separatrix_greenwald: float = 0.5
-"""fraction of Greenwald density to set as separatrix density.
+"""Greenwald fraction of the separatrix density
 """
 
     f_plasma_fuel_helium3: float = 0.0
@@ -987,8 +987,9 @@ i_nd_plasma_pedestal_separatrix: int = None
     temp_plasma_electron_density_weighted_kev: float = 0.0
     """density weighted average electron temperature (keV)"""
 
-temp_plasma_electron_line_avg_kev: float = None
-"""line averaged electron temperature (keV)"""
+    temp_plasma_electron_line_avg_kev: float = None
+    """Line averaged electron temperature (keV)"""
+    
     temp_plasma_ion_vol_avg_kev: float = 12.9
     """volume averaged ion temperature (keV). N.B. calculated from temp_plasma_electron_vol_avg_kev if `f_temp_plasma_ion_electron > 0.0`"""
 

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -493,6 +493,12 @@ class PhysicsData:
     nd_plasma_separatrix_electron: float = 3.0e19
     """electron density at separatrix [m-3] (`i_plasma_pedestal==1)"""
 
+i_nd_plasma_pedestal_separatrix: int = None
+"""switch for pedestal and separatrix density calculation:
+- =0 User input pedestal and separatrix density
+- =1 Calculate pedestal and separatrix density as fraction of Greenwald limit (see `f_nd_plasma_pedestal_greenwald` and `f_nd_plasma_separatrix_greenwald`)
+"""
+
     alpha_crit: float = 0.0
     """critical ballooning parameter value"""
 

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -336,17 +336,15 @@ class PhysicsData:
     load calculation (`i_pflux_fw_neutron=1`)
     """
 
-    f_nd_plasma_pedestal_greenwald: float = 0.85
-    """fraction of Greenwald density to set as pedestal-top density. If `<0`, pedestal-top
-    density set manually using nd_plasma_pedestal_electron (`i_plasma_pedestal==1`).
-    (`iteration variable 145`)
-    """
 
-    f_nd_plasma_separatrix_greenwald: float = 0.50
-    """fraction of Greenwald density to set as separatrix density. If `<0`, separatrix
-    density set manually using nd_plasma_separatrix_electron (`i_plasma_pedestal==1`).
-    (`iteration variable 152`)
-    """
+f_nd_plasma_pedestal_greenwald: float = 0.85
+"""fraction of Greenwald density to set as pedestal-top density.
+"""
+
+
+f_nd_plasma_separatrix_greenwald: float = 0.5
+"""fraction of Greenwald density to set as separatrix density.
+"""
 
     f_plasma_fuel_helium3: float = 0.0
     """Plasma Helium-3 fuel fraction"""

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -989,6 +989,8 @@ i_nd_plasma_pedestal_separatrix: int = None
     temp_plasma_electron_density_weighted_kev: float = 0.0
     """density weighted average electron temperature (keV)"""
 
+temp_plasma_electron_line_average_kev: float = None
+"""line averaged electron temperature (keV)"""
     temp_plasma_ion_vol_avg_kev: float = 12.9
     """volume averaged ion temperature (keV). N.B. calculated from temp_plasma_electron_vol_avg_kev if `f_temp_plasma_ion_electron > 0.0`"""
 

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -336,6 +336,9 @@ class PhysicsData:
     load calculation (`i_pflux_fw_neutron=1`)
     """
 
+f_nd_plasma_greenwald: float = None
+"""Greenwald fraction of the line averaged electron density. The classic Greenwald
+limit value"""
 
 f_nd_plasma_pedestal_greenwald: float = 0.85
 """Greenwald fraction of the pedestal density

--- a/process/models/physics/density_limit.py
+++ b/process/models/physics/density_limit.py
@@ -103,9 +103,9 @@ class PlasmaDensityLimit(Model):
             ) from None
 
         # Assign the Greenwald fraction for the rest of the code
-        physics_variables.f_nd_plasma_greenwald = (
-            physics_variables.nd_plasma_electron_line
-            / physics_variables.nd_plasma_electron_max_array[6]
+        self.data.physics.f_nd_plasma_greenwald = (
+            self.data.physics.nd_plasma_electron_line
+            / self.data.physics.nd_plasma_electron_max_array[6]
         )
 
     @staticmethod

--- a/process/models/physics/density_limit.py
+++ b/process/models/physics/density_limit.py
@@ -87,7 +87,9 @@ class PlasmaDensityLimit(Model):
             zeff=self.data.physics.n_charge_plasma_effective_vol_avg,
         )
 
-        # Calculate beta_norm_max based on i_beta_norm_max
+        # Convert the chosen density limit model to the actual density limit value and
+        # store in physics variables. This is the value that will be used for all
+        # comparisons to the plasma density in the rest of the code.
         try:
             model = DensityLimitModel(int(self.data.physics.i_density_limit))
             self.data.physics.nd_plasma_electrons_max = self.get_density_limit_value(
@@ -99,6 +101,12 @@ class PlasmaDensityLimit(Model):
                 "Illegal value of i_density_limit",
                 i_density_limit=self.data.physics.i_density_limit,
             ) from None
+
+        # Assign the Greenwald fraction for the rest of the code
+        physics_variables.f_nd_plasma_greenwald = (
+            physics_variables.nd_plasma_electron_line
+            / physics_variables.nd_plasma_electron_max_array[6]
+        )
 
     @staticmethod
     def get_density_limit_value(

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -340,24 +340,8 @@ class Physics(Model):
         if (
             PlasmaProfileShapeType(physics_variables.i_plasma_pedestal)
             == PlasmaProfileShapeType.PEDESTAL_PROFILE
-        ) and (physics_variables.f_nd_plasma_pedestal_greenwald >= 0e0):
-            physics_variables.nd_plasma_pedestal_electron = (
-                physics_variables.f_nd_plasma_pedestal_greenwald
-                * 1.0e14
-                * physics_variables.plasma_current
-                / (np.pi * physics_variables.rminor * physics_variables.rminor)
-            )
-
-        if (
-            PlasmaProfileShapeType(physics_variables.i_plasma_pedestal)
-            == PlasmaProfileShapeType.PEDESTAL_PROFILE
-        ) and (physics_variables.f_nd_plasma_separatrix_greenwald >= 0e0):
-            physics_variables.nd_plasma_separatrix_electron = (
-                physics_variables.f_nd_plasma_separatrix_greenwald
-                * 1.0e14
-                * physics_variables.plasma_current
-                / (np.pi * physics_variables.rminor * physics_variables.rminor)
-            )
+        ):
+            self.plasma_profile.neprofile.set_pedestal_and_separatrix_values()
 
         self.plasma_profile.run()
 

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2071,6 +2071,12 @@ class Physics(Model):
         )
         po.ovarrf(
             self.outfile,
+            "Line averaged electron temperature (keV)",
+            "(temp_plasma_electron_line_average_kev)",
+            physics_variables.temp_plasma_electron_line_average_kev,
+        )
+        po.ovarrf(
+            self.outfile,
             "Ratio of ion to electron volume-averaged temperature",
             "(f_temp_plasma_ion_electron)",
             physics_variables.f_temp_plasma_ion_electron,

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -35,7 +35,10 @@ from process.models.physics.confinement_time import (
 from process.models.physics.density_limit import PlasmaDensityLimit
 from process.models.physics.exhaust import PlasmaExhaust
 from process.models.physics.l_h_transition import PlasmaConfinementTransition
-from process.models.physics.profiles import PlasmaProfileShapeType
+from process.models.physics.profiles import (
+    DensityProfilePedestalType,
+    PlasmaProfileShapeType,
+)
 
 if TYPE_CHECKING:
     from process.models.physics.plasma_current import (
@@ -2404,7 +2407,12 @@ class Physics(Model):
                 "(radius_plasma_pedestal_density_norm)",
                 physics_variables.radius_plasma_pedestal_density_norm,
             )
-            if physics_variables.f_nd_plasma_pedestal_greenwald >= 0e0:
+            if (
+                DensityProfilePedestalType(
+                    physics_variables.i_nd_plasma_pedestal_separatrix
+                )
+                == DensityProfilePedestalType.GREENWALD_FRACTION
+            ):
                 po.ovarre(
                     self.outfile,
                     "Electron density pedestal height (/m3)",

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2056,8 +2056,8 @@ class Physics(Model):
         po.ovarrf(
             self.outfile,
             "Line averaged electron temperature (keV)",
-            "(temp_plasma_electron_line_average_kev)",
-            physics_variables.temp_plasma_electron_line_average_kev,
+            "(temp_plasma_electron_line_avg_kev)",
+            physics_variables.temp_plasma_electron_line_avg_kev,
         )
         po.ovarrf(
             self.outfile,

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -19,13 +19,12 @@ from process.core.exceptions import ProcessValueError
 from process.core.model import Model
 from process.data_structure import numerics
 from process.data_structure.impurity_radiation_variables import N_IMPURITIES
+from process.models.physics import impurity_radiation
+from process.models.physics.plasma_geometry import PlasmaGeom
 from process.models.physics.profiles import (
     DensityProfilePedestalType,
     PlasmaProfileShapeType,
 )
-from process.models.physics import impurity_radiation
-from process.models.physics.plasma_geometry import PlasmaGeom
-from process.models.physics.profiles import PlasmaProfileShapeType
 
 if TYPE_CHECKING:
     from process.data_structure.physics_variables import PhysicsData
@@ -2503,68 +2502,90 @@ class Physics(Model):
         )
         po.oblnkl(self.outfile)
         if (
-            PlasmaProfileShapeType(self.data.physics.i_plasma_pedestal)
+            self.data.physics.i_plasma_pedestal
             == PlasmaProfileShapeType.PEDESTAL_PROFILE
         ):
+            po.ovarin(
+                self.outfile,
+                "Pedestal and separatrix density model selected",
+                "(i_nd_plasma_pedestal_separatrix)",
+                physics_variables.i_nd_plasma_pedestal_separatrix,
+            )
+            po.ocmmnt(
+                self.outfile,
+                f"Pedestal and separatrix values set by: "
+                f"{DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix).description}",
+            )
+            po.oblnkl(self.outfile)
+
             po.ovarrf(
                 self.outfile,
                 "Density pedestal r/a location (ρₙ,pedestal)",
                 "(radius_plasma_pedestal_density_norm)",
                 self.data.physics.radius_plasma_pedestal_density_norm,
             )
-            if self.data.physics.f_nd_plasma_pedestal_greenwald >= 0e0:
-                po.ovarre(
+            if (
+                self.data.physics.i_nd_plasma_pedestal_separatrix
+                == DensityProfilePedestalType.USER_INPUT
+            ):
+                po.ovarin(
                     self.outfile,
                     "Electron density pedestal height (nₑ_pedestal) (/m³)",
                     "(nd_plasma_pedestal_electron)",
                     self.data.physics.nd_plasma_pedestal_electron,
+                )
+                po.ovarin(
+                    self.outfile,
+                    "Electron separatrix density (nₑ,ₛₑₚ) (/m³)",
+                    "(nd_plasma_separatrix_electron)",
+                    physics_variables.nd_plasma_separatrix_electron,
+                )
+                po.ovarre(
+                    self.outfile,
+                    "Pedestal Greenwald fraction",
+                    "(f_nd_plasma_pedestal_greenwald)",
+                    physics_variables.f_nd_plasma_pedestal_greenwald,
                     "OP ",
                 )
-            else:
+                po.ovarre(
+                    self.outfile,
+                    "Separatrix Greenwald fraction",
+                    "(f_nd_plasma_separatrix_greenwald)",
+                    physics_variables.f_nd_plasma_separatrix_greenwald,
+                    "OP ",
+                )
+
+            elif (
+                physics_variables.i_nd_plasma_pedestal_separatrix
+                == DensityProfilePedestalType.GREENWALD_FRACTION
+            ):
                 po.ovarre(
                     self.outfile,
                     "Electron density pedestal height (nₑ_pedestal) (/m³)",
                     "(nd_plasma_pedestal_electron)",
-                    self.data.physics.nd_plasma_pedestal_electron,
+                    physics_variables.nd_plasma_pedestal_electron,
+                    "OP ",
                 )
-            # must be assigned to their exisiting values#
-            fgwped_out = (
-                self.data.physics.nd_plasma_pedestal_electron
-                / self.data.physics.nd_plasma_electron_max_array[6]
-            )
-            fgwsep_out = (
-                self.data.physics.nd_plasma_separatrix_electron
-                / self.data.physics.nd_plasma_electron_max_array[6]
-            )
-            if self.data.physics.f_nd_plasma_pedestal_greenwald >= 0e0:
-                self.data.physics.f_nd_plasma_pedestal_greenwald = (
-                    self.data.physics.nd_plasma_pedestal_electron
-                    / self.data.physics.nd_plasma_electron_max_array[6]
+                po.ovarre(
+                    self.outfile,
+                    "Electron separatrix density (nₑ,ₛₑₚ) (/m³)",
+                    "(nd_plasma_separatrix_electron)",
+                    physics_variables.nd_plasma_separatrix_electron,
+                    "OP ",
                 )
-            if self.data.physics.f_nd_plasma_separatrix_greenwald >= 0e0:
-                self.data.physics.f_nd_plasma_separatrix_greenwald = (
-                    self.data.physics.nd_plasma_separatrix_electron
-                    / self.data.physics.nd_plasma_electron_max_array[6]
+                po.ovarin(
+                    self.outfile,
+                    "Pedestal Greenwald fraction",
+                    "(f_nd_plasma_pedestal_greenwald)",
+                    physics_variables.f_nd_plasma_pedestal_greenwald,
+                )
+                po.ovarin(
+                    self.outfile,
+                    "Separatrix Greenwald fraction",
+                    "(f_nd_plasma_separatrix_greenwald)",
+                    physics_variables.f_nd_plasma_separatrix_greenwald,
                 )
 
-            po.ovarre(
-                self.outfile,
-                "Pedestal Greenwald fraction",
-                "(fgwped_out)",
-                fgwped_out,
-            )
-            po.ovarre(
-                self.outfile,
-                "Electron density at separatrix (nₑ,ₛₑₚ) (/m³)",
-                "(nd_plasma_separatrix_electron)",
-                self.data.physics.nd_plasma_separatrix_electron,
-            )
-            po.ovarre(
-                self.outfile,
-                "Separatrix Greenwald fraction",
-                "(fgwsep_out)",
-                fgwsep_out,
-            )
             po.oblnkl(self.outfile)
 
         po.ovarre(

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2612,9 +2612,8 @@ class Physics(Model):
             po.ovarre(
                 self.outfile,
                 "Greenwald fraction (f_GW)",
-                "(dnla_gw)",
-                self.data.physics.nd_plasma_electron_line
-                / self.data.physics.nd_plasma_electron_max_array[6],
+                "(f_nd_plasma_greenwald)",
+                physics_variables.f_nd_plasma_greenwald,
                 "OP ",
             )
         po.oblnkl(self.outfile)

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -356,24 +356,8 @@ class Physics(Model):
         if (
             PlasmaProfileShapeType(self.data.physics.i_plasma_pedestal)
             == PlasmaProfileShapeType.PEDESTAL_PROFILE
-        ) and (self.data.physics.f_nd_plasma_pedestal_greenwald >= 0e0):
-            self.data.physics.nd_plasma_pedestal_electron = (
-                self.data.physics.f_nd_plasma_pedestal_greenwald
-                * 1.0e14
-                * self.data.physics.plasma_current
-                / (np.pi * self.data.physics.rminor * self.data.physics.rminor)
-            )
-
-        if (
-            PlasmaProfileShapeType(self.data.physics.i_plasma_pedestal)
-            == PlasmaProfileShapeType.PEDESTAL_PROFILE
-        ) and (self.data.physics.f_nd_plasma_separatrix_greenwald >= 0e0):
-            self.data.physics.nd_plasma_separatrix_electron = (
-                self.data.physics.f_nd_plasma_separatrix_greenwald
-                * 1.0e14
-                * self.data.physics.plasma_current
-                / (np.pi * self.data.physics.rminor * self.data.physics.rminor)
-            )
+        ):
+            self.plasma_profile.neprofile.set_pedestal_and_separatrix_values()
 
         self.plasma_profile.run()
 

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -19,6 +19,10 @@ from process.core.exceptions import ProcessValueError
 from process.core.model import Model
 from process.data_structure import numerics
 from process.data_structure.impurity_radiation_variables import N_IMPURITIES
+from process.models.physics.profiles import (
+    DensityProfilePedestalType,
+    PlasmaProfileShapeType,
+)
 from process.models.physics import impurity_radiation
 from process.models.physics.plasma_geometry import PlasmaGeom
 from process.models.physics.profiles import PlasmaProfileShapeType

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2463,6 +2463,12 @@ class Physics(Model):
         )
         po.ovarrf(
             self.outfile,
+            "Line averaged electron temperature (keV)",
+            "(temp_plasma_electron_line_average_kev)",
+            physics_variables.temp_plasma_electron_line_average_kev,
+        )
+        po.ovarrf(
+            self.outfile,
             "Volume averaged density weighted electron temperature (⟨Tₑ⟩ₙ) (keV)",
             "(temp_plasma_electron_density_weighted_kev)",
             self.data.physics.temp_plasma_electron_density_weighted_kev,

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2448,8 +2448,8 @@ class Physics(Model):
         po.ovarrf(
             self.outfile,
             "Line averaged electron temperature (keV)",
-            "(temp_plasma_electron_line_average_kev)",
-            physics_variables.temp_plasma_electron_line_average_kev,
+            "(temp_plasma_electron_line_avg_kev)",
+            physics_variables.temp_plasma_electron_line_avg_kev,
         )
         po.ovarrf(
             self.outfile,

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2452,7 +2452,7 @@ class Physics(Model):
             self.outfile,
             "Line averaged electron temperature (keV)",
             "(temp_plasma_electron_line_avg_kev)",
-            physics_variables.temp_plasma_electron_line_avg_kev,
+            self.data.physics.temp_plasma_electron_line_avg_kev,
         )
         po.ovarrf(
             self.outfile,
@@ -2509,12 +2509,12 @@ class Physics(Model):
                 self.outfile,
                 "Pedestal and separatrix density model selected",
                 "(i_nd_plasma_pedestal_separatrix)",
-                physics_variables.i_nd_plasma_pedestal_separatrix,
+                self.data.physics.i_nd_plasma_pedestal_separatrix,
             )
             po.ocmmnt(
                 self.outfile,
                 f"Pedestal and separatrix values set by: "
-                f"{DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix).description}",
+                f"{DensityProfilePedestalType(self.data.physics.i_nd_plasma_pedestal_separatrix).description}",
             )
             po.oblnkl(self.outfile)
 
@@ -2538,52 +2538,52 @@ class Physics(Model):
                     self.outfile,
                     "Electron separatrix density (nₑ,ₛₑₚ) (/m³)",
                     "(nd_plasma_separatrix_electron)",
-                    physics_variables.nd_plasma_separatrix_electron,
+                    self.data.physics.nd_plasma_separatrix_electron,
                 )
                 po.ovarre(
                     self.outfile,
                     "Pedestal Greenwald fraction",
                     "(f_nd_plasma_pedestal_greenwald)",
-                    physics_variables.f_nd_plasma_pedestal_greenwald,
+                    self.data.physics.f_nd_plasma_pedestal_greenwald,
                     "OP ",
                 )
                 po.ovarre(
                     self.outfile,
                     "Separatrix Greenwald fraction",
                     "(f_nd_plasma_separatrix_greenwald)",
-                    physics_variables.f_nd_plasma_separatrix_greenwald,
+                    self.data.physics.f_nd_plasma_separatrix_greenwald,
                     "OP ",
                 )
 
             elif (
-                physics_variables.i_nd_plasma_pedestal_separatrix
+                self.data.physics.i_nd_plasma_pedestal_separatrix
                 == DensityProfilePedestalType.GREENWALD_FRACTION
             ):
                 po.ovarre(
                     self.outfile,
                     "Electron density pedestal height (nₑ_pedestal) (/m³)",
                     "(nd_plasma_pedestal_electron)",
-                    physics_variables.nd_plasma_pedestal_electron,
+                    self.data.physics.nd_plasma_pedestal_electron,
                     "OP ",
                 )
                 po.ovarre(
                     self.outfile,
                     "Electron separatrix density (nₑ,ₛₑₚ) (/m³)",
                     "(nd_plasma_separatrix_electron)",
-                    physics_variables.nd_plasma_separatrix_electron,
+                    self.data.physics.nd_plasma_separatrix_electron,
                     "OP ",
                 )
                 po.ovarin(
                     self.outfile,
                     "Pedestal Greenwald fraction",
                     "(f_nd_plasma_pedestal_greenwald)",
-                    physics_variables.f_nd_plasma_pedestal_greenwald,
+                    self.data.physics.f_nd_plasma_pedestal_greenwald,
                 )
                 po.ovarin(
                     self.outfile,
                     "Separatrix Greenwald fraction",
                     "(f_nd_plasma_separatrix_greenwald)",
-                    physics_variables.f_nd_plasma_separatrix_greenwald,
+                    self.data.physics.f_nd_plasma_separatrix_greenwald,
                 )
 
             po.oblnkl(self.outfile)
@@ -2613,7 +2613,7 @@ class Physics(Model):
                 self.outfile,
                 "Greenwald fraction (f_GW)",
                 "(f_nd_plasma_greenwald)",
-                physics_variables.f_nd_plasma_greenwald,
+                self.data.physics.f_nd_plasma_greenwald,
                 "OP ",
             )
         po.oblnkl(self.outfile)

--- a/process/models/physics/plasma_profiles.py
+++ b/process/models/physics/plasma_profiles.py
@@ -127,6 +127,14 @@ class PlasmaProfile:
             / sp.special.gamma(physics_variables.alphan + 1.5)
         )
 
+        physics_variables.temp_plasma_electron_line_average_kev = (
+            physics_variables.temp_plasma_electron_vol_avg_kev
+            * (1.0 + physics_variables.alphat)
+            * (sp.special.gamma(0.5) / 2.0)
+            * sp.special.gamma(physics_variables.alphat + 1.0)
+            / sp.special.gamma(physics_variables.alphat + 1.5)
+        )
+
         #  Density-weighted temperatures
 
         physics_variables.temp_plasma_electron_density_weighted_kev = (
@@ -203,10 +211,14 @@ class PlasmaProfile:
             / physics_variables.temp_plasma_electron_vol_avg_kev
         )
 
-        #  Line-averaged electron density
+        #  Line-averaged electron density and temperature
         #  = integral(n(rho).drho)
 
         physics_variables.nd_plasma_electron_line = self.neprofile.profile_integ
+
+        physics_variables.temp_plasma_electron_line_average_kev = (
+            self.teprofile.profile_integ
+        )
 
         #  Scrape-off density / volume averaged density
         #  (Input value is used if i_plasma_pedestal = 0)

--- a/process/models/physics/plasma_profiles.py
+++ b/process/models/physics/plasma_profiles.py
@@ -127,7 +127,7 @@ class PlasmaProfile:
             / sp.special.gamma(physics_variables.alphan + 1.5)
         )
 
-        physics_variables.temp_plasma_electron_line_average_kev = (
+        physics_variables.temp_plasma_electron_line_avg_kev = (
             physics_variables.temp_plasma_electron_vol_avg_kev
             * (1.0 + physics_variables.alphat)
             * (sp.special.gamma(0.5) / 2.0)
@@ -216,7 +216,7 @@ class PlasmaProfile:
 
         physics_variables.nd_plasma_electron_line = self.neprofile.profile_integ
 
-        physics_variables.temp_plasma_electron_line_average_kev = (
+        physics_variables.temp_plasma_electron_line_avg_kev = (
             self.teprofile.profile_integ
         )
 

--- a/process/models/physics/plasma_profiles.py
+++ b/process/models/physics/plasma_profiles.py
@@ -159,7 +159,7 @@ class PlasmaProfile(Model):
             * self.data.physics.f_temp_plasma_electron_density_vol_avg
         )
 
-        #  Central values for temperature (keV) and density (m**-3)
+        #  Central values for temperature (keV) and density (m^-3)
 
         self.data.physics.temp_plasma_electron_on_axis_kev = (
             self.data.physics.temp_plasma_electron_vol_avg_kev
@@ -197,9 +197,9 @@ class PlasmaProfile(Model):
 
         #  Perform integrations to calculate ratio of density-weighted
         #  to volume-averaged temperature, etc.
-        #  Density-weighted temperature = integral(n.T dV) / integral(n dV)
+        #  Density-weighted temperature = ∫(n.T dV) / ∫(n dV)
         #  which is approximately equal to the ratio
-        #  integral(rho.n(rho).T(rho) drho) / integral(rho.n(rho) drho)
+        #  ∫(ρ.n(ρ).T(ρ) dρ) / ∫(ρ.n(ρ) dρ) # noqa: RUF003
 
         drho = self.neprofile.profile_dx
         dens = self.neprofile.profile_y
@@ -228,7 +228,7 @@ class PlasmaProfile(Model):
         )
 
         #  Line-averaged electron density and temperature
-        #  = integral(n(rho).drho)
+        #  = ∫(n(ρ).dρ) # noqa: RUF003
 
         self.data.physics.nd_plasma_electron_line = self.neprofile.profile_integ
 
@@ -295,7 +295,7 @@ class PlasmaProfile(Model):
 
         #  Pressure profile index (only true for a parabolic profile)
         #  N.B. pres_plasma_thermal_on_axis is NOT equal to <p> * (1 + alphap),
-        #  but p(rho) = n(rho)*T(rho)
+        #  but p(ρ) = n(ρ)*T(ρ) # noqa: RUF003
         #  and <p> = <n>.T_n where <...> denotes volume-averages and T_n is the
         #  density-weighted temperature
 
@@ -311,7 +311,7 @@ class PlasmaProfile(Model):
             * self.data.physics.temp_plasma_ion_density_weighted_kev
         ) * constants.KILOELECTRON_VOLT
 
-        # Central plasma current density (A/m^2)
+        # Central plasma current density (A/m²)
         # Assumes a parabolic profile for the current density
         self.data.physics.j_plasma_on_axis = (
             (self.data.physics.plasma_current)

--- a/process/models/physics/plasma_profiles.py
+++ b/process/models/physics/plasma_profiles.py
@@ -140,12 +140,12 @@ class PlasmaProfile(Model):
             / sp.special.gamma(self.data.physics.alphan + 1.5)
         )
 
-        physics_variables.temp_plasma_electron_line_avg_kev = (
-            physics_variables.temp_plasma_electron_vol_avg_kev
-            * (1.0 + physics_variables.alphat)
+        self.data.physics.temp_plasma_electron_line_avg_kev = (
+            self.data.physics.temp_plasma_electron_vol_avg_kev
+            * (1.0 + self.data.physics.alphat)
             * (sp.special.gamma(0.5) / 2.0)
-            * sp.special.gamma(physics_variables.alphat + 1.0)
-            / sp.special.gamma(physics_variables.alphat + 1.5)
+            * sp.special.gamma(self.data.physics.alphat + 1.0)
+            / sp.special.gamma(self.data.physics.alphat + 1.5)
         )
 
         #  Density-weighted temperatures
@@ -232,7 +232,7 @@ class PlasmaProfile(Model):
 
         self.data.physics.nd_plasma_electron_line = self.neprofile.profile_integ
 
-        physics_variables.temp_plasma_electron_line_avg_kev = (
+        self.data.physics.temp_plasma_electron_line_avg_kev = (
             self.teprofile.profile_integ
         )
 

--- a/process/models/physics/plasma_profiles.py
+++ b/process/models/physics/plasma_profiles.py
@@ -140,6 +140,14 @@ class PlasmaProfile(Model):
             / sp.special.gamma(self.data.physics.alphan + 1.5)
         )
 
+        physics_variables.temp_plasma_electron_line_average_kev = (
+            physics_variables.temp_plasma_electron_vol_avg_kev
+            * (1.0 + physics_variables.alphat)
+            * (sp.special.gamma(0.5) / 2.0)
+            * sp.special.gamma(physics_variables.alphat + 1.0)
+            / sp.special.gamma(physics_variables.alphat + 1.5)
+        )
+
         #  Density-weighted temperatures
 
         self.data.physics.temp_plasma_electron_density_weighted_kev = (
@@ -219,10 +227,14 @@ class PlasmaProfile(Model):
             / self.data.physics.temp_plasma_electron_vol_avg_kev
         )
 
-        #  Line-averaged electron density
+        #  Line-averaged electron density and temperature
         #  = integral(n(rho).drho)
 
         self.data.physics.nd_plasma_electron_line = self.neprofile.profile_integ
+
+        physics_variables.temp_plasma_electron_line_average_kev = (
+            self.teprofile.profile_integ
+        )
 
         #  Scrape-off density / volume averaged density
         #  (Input value is used if i_plasma_pedestal = 0)

--- a/process/models/physics/plasma_profiles.py
+++ b/process/models/physics/plasma_profiles.py
@@ -140,7 +140,7 @@ class PlasmaProfile(Model):
             / sp.special.gamma(self.data.physics.alphan + 1.5)
         )
 
-        physics_variables.temp_plasma_electron_line_average_kev = (
+        physics_variables.temp_plasma_electron_line_avg_kev = (
             physics_variables.temp_plasma_electron_vol_avg_kev
             * (1.0 + physics_variables.alphat)
             * (sp.special.gamma(0.5) / 2.0)
@@ -232,7 +232,7 @@ class PlasmaProfile(Model):
 
         self.data.physics.nd_plasma_electron_line = self.neprofile.profile_integ
 
-        physics_variables.temp_plasma_electron_line_average_kev = (
+        physics_variables.temp_plasma_electron_line_avg_kev = (
             self.teprofile.profile_integ
         )
 

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy as sp
 
 from process.data_structure import physics_variables
+from process.models.physics.density_limit import PlasmaDensityLimit
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,13 @@ class Profile(ABC):
         self.profile_integ = sp.integrate.simpson(
             self.profile_y, x=self.profile_x, dx=self.profile_dx
         )
+
+
+class DensityProfilePedestalType(IntEnum):
+    """Enum for i_nd_plasma_pedestal_separatrix types"""
+
+    USER_INPUT = 0
+    GREENWALD_FRACTION = 1
 
 
 class NeProfile(Profile):
@@ -219,6 +227,33 @@ class NeProfile(Profile):
             )
             ncore = 1.0e-6
         return ncore
+
+    def set_pedestal_and_separatrix_values(self):
+        """Sets the pedestal and separatrix density values based on the user input or greenwald fraction method."""
+
+        if (
+            DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix)
+            == DensityProfilePedestalType.USER_INPUT
+        ):
+            pass
+        elif (
+            DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix)
+            == DensityProfilePedestalType.GREENWALD_FRACTION
+        ):
+            physics_variables.nd_plasma_pedestal_electron = (
+                physics_variables.f_nd_plasma_pedestal_greenwald
+                * 1.0e14
+                * PlasmaDensityLimit.calculate_greenwald_density_limit(
+                    c_plasma=physics_variables.c_plasma, rminor=physics_variables.rminor
+                )
+            )
+            physics_variables.nd_plasma_separatrix_electron = (
+                physics_variables.f_nd_plasma_separatrix_greenwald
+                * 1.0e14
+                * PlasmaDensityLimit.calculate_greenwald_density_limit(
+                    c_plasma=physics_variables.c_plasma, rminor=physics_variables.rminor
+                )
+            )
 
     def set_physics_variables(self):
         """Calculates and sets physics variables required for the profile."""

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -242,16 +242,16 @@ class NeProfile(Profile):
         ):
             physics_variables.nd_plasma_pedestal_electron = (
                 physics_variables.f_nd_plasma_pedestal_greenwald
-                * 1.0e14
                 * PlasmaDensityLimit.calculate_greenwald_density_limit(
-                    c_plasma=physics_variables.c_plasma, rminor=physics_variables.rminor
+                    c_plasma=physics_variables.plasma_current,
+                    rminor=physics_variables.rminor,
                 )
             )
             physics_variables.nd_plasma_separatrix_electron = (
                 physics_variables.f_nd_plasma_separatrix_greenwald
-                * 1.0e14
                 * PlasmaDensityLimit.calculate_greenwald_density_limit(
-                    c_plasma=physics_variables.c_plasma, rminor=physics_variables.rminor
+                    c_plasma=physics_variables.plasma_current,
+                    rminor=physics_variables.rminor,
                 )
             )
 

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -277,16 +277,16 @@ class NeProfile(Profile):
         ):
             physics_variables.nd_plasma_pedestal_electron = (
                 physics_variables.f_nd_plasma_pedestal_greenwald
-                * 1.0e14
                 * PlasmaDensityLimit.calculate_greenwald_density_limit(
-                    c_plasma=physics_variables.c_plasma, rminor=physics_variables.rminor
+                    c_plasma=physics_variables.plasma_current,
+                    rminor=physics_variables.rminor,
                 )
             )
             physics_variables.nd_plasma_separatrix_electron = (
                 physics_variables.f_nd_plasma_separatrix_greenwald
-                * 1.0e14
                 * PlasmaDensityLimit.calculate_greenwald_density_limit(
-                    c_plasma=physics_variables.c_plasma, rminor=physics_variables.rminor
+                    c_plasma=physics_variables.plasma_current,
+                    rminor=physics_variables.rminor,
                 )
             )
 

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -284,26 +284,26 @@ class NeProfile(Profile):
     def set_pedestal_and_separatrix_values(self):
         """Sets the pedestal and separatrix density values based on the user input or greenwald fraction method."""
         i_nd_plasma_pedestal_separatrix = DensityProfilePedestalType(
-            physics_variables.i_nd_plasma_pedestal_separatrix
+            self.data.physics.i_nd_plasma_pedestal_separatrix
         )
 
         if i_nd_plasma_pedestal_separatrix == DensityProfilePedestalType.USER_INPUT:
-            physics_variables.f_nd_plasma_pedestal_greenwald = (
-                physics_variables.nd_plasma_pedestal_electron
+            self.data.physics.f_nd_plasma_pedestal_greenwald = (
+                self.data.physics.nd_plasma_pedestal_electron
                 / (
                     PlasmaDensityLimit.calculate_greenwald_density_limit(
-                        c_plasma=physics_variables.plasma_current,
-                        rminor=physics_variables.rminor,
+                        c_plasma=self.data.physics.plasma_current,
+                        rminor=self.data.physics.rminor,
                     )
                 )
             )
 
-            physics_variables.f_nd_plasma_separatrix_greenwald = (
-                physics_variables.nd_plasma_separatrix_electron
+            self.data.physics.f_nd_plasma_separatrix_greenwald = (
+                self.data.physics.nd_plasma_separatrix_electron
                 / (
                     PlasmaDensityLimit.calculate_greenwald_density_limit(
-                        c_plasma=physics_variables.plasma_current,
-                        rminor=physics_variables.rminor,
+                        c_plasma=self.data.physics.plasma_current,
+                        rminor=self.data.physics.rminor,
                     )
                 )
             )
@@ -311,18 +311,18 @@ class NeProfile(Profile):
             i_nd_plasma_pedestal_separatrix
             == DensityProfilePedestalType.GREENWALD_FRACTION
         ):
-            physics_variables.nd_plasma_pedestal_electron = (
-                physics_variables.f_nd_plasma_pedestal_greenwald
+            self.data.physics.nd_plasma_pedestal_electron = (
+                self.data.physics.f_nd_plasma_pedestal_greenwald
                 * PlasmaDensityLimit.calculate_greenwald_density_limit(
-                    c_plasma=physics_variables.plasma_current,
-                    rminor=physics_variables.rminor,
+                    c_plasma=self.data.physics.plasma_current,
+                    rminor=self.data.physics.rminor,
                 )
             )
-            physics_variables.nd_plasma_separatrix_electron = (
-                physics_variables.f_nd_plasma_separatrix_greenwald
+            self.data.physics.nd_plasma_separatrix_electron = (
+                self.data.physics.f_nd_plasma_separatrix_greenwald
                 * PlasmaDensityLimit.calculate_greenwald_density_limit(
-                    c_plasma=physics_variables.plasma_current,
-                    rminor=physics_variables.rminor,
+                    c_plasma=self.data.physics.plasma_current,
+                    rminor=self.data.physics.rminor,
                 )
             )
 

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -277,10 +277,11 @@ class NeProfile(Profile):
 
     def set_pedestal_and_separatrix_values(self):
         """Sets the pedestal and separatrix density values based on the user input or greenwald fraction method."""
-        if (
-            DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix)
-            == DensityProfilePedestalType.USER_INPUT
-        ):
+        i_nd_plasma_pedestal_separatrix = DensityProfilePedestalType(
+            physics_variables.i_nd_plasma_pedestal_separatrix
+        )
+
+        if i_nd_plasma_pedestal_separatrix == DensityProfilePedestalType.USER_INPUT:
             physics_variables.f_nd_plasma_pedestal_greenwald = (
                 physics_variables.nd_plasma_pedestal_electron
                 / (
@@ -301,7 +302,7 @@ class NeProfile(Profile):
                 )
             )
         elif (
-            DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix)
+            i_nd_plasma_pedestal_separatrix
             == DensityProfilePedestalType.GREENWALD_FRACTION
         ):
             physics_variables.nd_plasma_pedestal_electron = (

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -113,8 +113,20 @@ class Profile(Model, ABC):
 class DensityProfilePedestalType(IntEnum):
     """Enum for i_nd_plasma_pedestal_separatrix types"""
 
-    USER_INPUT = 0
-    GREENWALD_FRACTION = 1
+    USER_INPUT = (0, "User input direct values")
+    GREENWALD_FRACTION = (1, "Fractions of the Greenwald limit")
+
+    def __new__(cls, value: int, description: str):
+        """Create a new PlasmaProfileShapeType instance."""
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj._description_ = description
+        return obj
+
+    @DynamicClassAttribute
+    def description(self):
+        """Get the description of the plasma profile shape."""
+        return self._description_
 
 
 class NeProfile(Profile):
@@ -265,12 +277,29 @@ class NeProfile(Profile):
 
     def set_pedestal_and_separatrix_values(self):
         """Sets the pedestal and separatrix density values based on the user input or greenwald fraction method."""
-
         if (
             DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix)
             == DensityProfilePedestalType.USER_INPUT
         ):
-            pass
+            physics_variables.f_nd_plasma_pedestal_greenwald = (
+                physics_variables.nd_plasma_pedestal_electron
+                / (
+                    PlasmaDensityLimit.calculate_greenwald_density_limit(
+                        c_plasma=physics_variables.plasma_current,
+                        rminor=physics_variables.rminor,
+                    )
+                )
+            )
+
+            physics_variables.f_nd_plasma_separatrix_greenwald = (
+                physics_variables.nd_plasma_separatrix_electron
+                / (
+                    PlasmaDensityLimit.calculate_greenwald_density_limit(
+                        c_plasma=physics_variables.plasma_current,
+                        rminor=physics_variables.rminor,
+                    )
+                )
+            )
         elif (
             DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix)
             == DensityProfilePedestalType.GREENWALD_FRACTION

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -13,6 +13,7 @@ import numpy as np
 import scipy as sp
 
 from process.core.model import Model
+from process.models.physics.density_limit import PlasmaDensityLimit
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +108,13 @@ class Profile(Model, ABC):
         self.profile_integ = sp.integrate.simpson(
             self.profile_y, x=self.profile_x, dx=self.profile_dx
         )
+
+
+class DensityProfilePedestalType(IntEnum):
+    """Enum for i_nd_plasma_pedestal_separatrix types"""
+
+    USER_INPUT = 0
+    GREENWALD_FRACTION = 1
 
 
 class NeProfile(Profile):
@@ -254,6 +262,33 @@ class NeProfile(Profile):
             )
             ncore = 1.0e-6
         return ncore
+
+    def set_pedestal_and_separatrix_values(self):
+        """Sets the pedestal and separatrix density values based on the user input or greenwald fraction method."""
+
+        if (
+            DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix)
+            == DensityProfilePedestalType.USER_INPUT
+        ):
+            pass
+        elif (
+            DensityProfilePedestalType(physics_variables.i_nd_plasma_pedestal_separatrix)
+            == DensityProfilePedestalType.GREENWALD_FRACTION
+        ):
+            physics_variables.nd_plasma_pedestal_electron = (
+                physics_variables.f_nd_plasma_pedestal_greenwald
+                * 1.0e14
+                * PlasmaDensityLimit.calculate_greenwald_density_limit(
+                    c_plasma=physics_variables.c_plasma, rminor=physics_variables.rminor
+                )
+            )
+            physics_variables.nd_plasma_separatrix_electron = (
+                physics_variables.f_nd_plasma_separatrix_greenwald
+                * 1.0e14
+                * PlasmaDensityLimit.calculate_greenwald_density_limit(
+                    c_plasma=physics_variables.c_plasma, rminor=physics_variables.rminor
+                )
+            )
 
     def set_physics_variables(self):
         """Calculates and sets physics variables required for the profile."""

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -117,7 +117,12 @@ class DensityProfilePedestalType(IntEnum):
     GREENWALD_FRACTION = (1, "Fractions of the Greenwald limit")
 
     def __new__(cls, value: int, description: str):
-        """Create a new PlasmaProfileShapeType instance."""
+        """Create a new DensityProfilePedestalType instance.
+
+        Parameters:
+            value: Integer value for the enum member.
+            description: Human-readable description for the enum member.
+        """
         obj = int.__new__(cls, value)
         obj._value_ = value
         obj._description_ = description

--- a/process/models/physics/profiles.py
+++ b/process/models/physics/profiles.py
@@ -119,7 +119,8 @@ class DensityProfilePedestalType(IntEnum):
     def __new__(cls, value: int, description: str):
         """Create a new DensityProfilePedestalType instance.
 
-        Parameters:
+        Parameters
+        ----------
             value: Integer value for the enum member.
             description: Human-readable description for the enum member.
         """

--- a/tests/unit/models/physics/test_plasma_profiles.py
+++ b/tests/unit/models/physics/test_plasma_profiles.py
@@ -552,11 +552,11 @@ def test_plasma_profiles(plasmaprofilesparam, monkeypatch, plasmaprofile):
         plasmaprofilesparam.expected_nd_electron_line
     )
 
-    assert physics_variables.temp_plasma_electron_line_avg_kev == pytest.approx(
+    assert plasmaprofile.data.physics.temp_plasma_electron_line_avg_kev == pytest.approx(
         plasmaprofilesparam.expected_temp_plasma_electron_line_avg_kev
     )
 
-    assert physics_variables.temp_plasma_electron_line_avg_kev == pytest.approx(
+    assert plasmaprofile.data.physics.temp_plasma_electron_line_avg_kev == pytest.approx(
         plasmaprofilesparam.expected_temp_plasma_electron_line_avg_kev
     )
 

--- a/tests/unit/models/physics/test_plasma_profiles.py
+++ b/tests/unit/models/physics/test_plasma_profiles.py
@@ -228,6 +228,8 @@ class PlasmaProfilesParam(NamedTuple):
 
     expected_nd_electron_line: float = 0.0
 
+    expected_temp_plasma_electron_line_avg_kev: float = 0.0
+
     expected_ti: float = 0.0
 
 
@@ -277,6 +279,7 @@ class PlasmaProfilesParam(NamedTuple):
             expected_ne0=1.0585658890823703e20,
             expected_ti0=27.370104119511087,
             expected_nd_electron_line=8.8687354645836431e19,
+            expected_temp_plasma_electron_line_avg_kev=17.582796426026842,
             expected_ti=13.07,
         ),
         PlasmaProfilesParam(
@@ -322,6 +325,7 @@ class PlasmaProfilesParam(NamedTuple):
             expected_ne0=1.0585658890823703e20,
             expected_ti0=27.370104119511087,
             expected_nd_electron_line=8.8687354645836431e19,
+            expected_temp_plasma_electron_line_avg_kev=17.582796426026842,
             expected_ti=13.07,
         ),
     ],
@@ -546,6 +550,14 @@ def test_plasma_profiles(plasmaprofilesparam, monkeypatch, plasmaprofile):
 
     assert plasmaprofile.data.physics.nd_plasma_electron_line == pytest.approx(
         plasmaprofilesparam.expected_nd_electron_line
+    )
+
+    assert physics_variables.temp_plasma_electron_line_avg_kev == pytest.approx(
+        plasmaprofilesparam.expected_temp_plasma_electron_line_avg_kev
+    )
+
+    assert physics_variables.temp_plasma_electron_line_avg_kev == pytest.approx(
+        plasmaprofilesparam.expected_temp_plasma_electron_line_avg_kev
     )
 
     assert plasmaprofile.data.physics.temp_plasma_ion_vol_avg_kev == pytest.approx(


### PR DESCRIPTION
This pull request introduces significant improvements to how plasma density pedestal and separatrix values are set, validated, and documented throughout the codebase and user documentation. The changes standardize the handling of Greenwald limit fractions, clarify user input options, and enhance plotting and metadata consistency. The most important changes are grouped below:

**Plasma Density Profile Calculation and Validation:**

* Introduced a new switch variable `i_nd_plasma_pedestal_separatrix` to control whether pedestal and separatrix densities are set by user input or as fractions of the Greenwald limit, with corresponding updates to documentation and input handling. 
* Refactored validation logic in `check_process` to use the new pedestal/separatrix mode, ensuring correct relationships between densities and their Greenwald fractions depending on the selected method.
* Updated input variable ranges and iteration variable definitions for `f_nd_plasma_pedestal_greenwald` and `f_nd_plasma_separatrix_greenwald` to reflect physically meaningful limits. 

**Greenwald Limit Fraction Handling and Metadata:**

* Added `f_nd_plasma_greenwald` as a new physics variable representing the Greenwald fraction of the line-averaged electron density, with initialization, metadata, and I/O updates. 
* Updated the density limit model to compute and assign `f_nd_plasma_greenwald` for use in plots and further calculations. 

**Plotting and Output Improvements:**

* Standardized plot labels and text boxes to use the new Greenwald fraction variable names and added more detailed density and temperature profile information (including line-averaged values). 
* Added new output variables such as `temp_plasma_electron_line_avg_kev` to enhance result reporting. 
**Documentation Updates:**

* Updated and clarified documentation in `plasma_density_profile.md` and `plasma_profiles.md` to reflect the new switch-based approach for setting pedestal and separatrix densities, and removed outdated instructions about negative Greenwald fractions. 

**Codebase Consistency:**

* Updated all relevant files and function signatures to consistently use the new variables and logic for plasma density profile handling.

These changes together improve the clarity, robustness, and usability of the plasma density profile modeling in the codebase.

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
