### PR TITLE
Pf coils accounting pr

### DIFF
--- a/documentation/source/eng-models/power-requirements.md
+++ b/documentation/source/eng-models/power-requirements.md
@@ -34,7 +34,7 @@ All PF circuits (and plasma current) are coupled through the mutual inductance m
 Magnetic energy in an inductive system is given by:
 
 $$
-E_{PF}(t_n) = \frac{1}{2} \sum_i I_i(t_n)\sum_j M_{ij} I_j(t_n)
+E_{\text{PF}}(t_n) = \frac{1}{2} \sum_i I_i(t_n)\sum_j M_{ij} I_j(t_n)
 $$
 
 This is the standard inductive energy expression:
@@ -50,7 +50,7 @@ $$
 The change in stored magnetic energy between time points is:
 
 $$
-\Delta E_n = E_{PF}(t_{n+1}) - E_{PF}(t_n)
+\Delta E_n = E_{\text{PF}}(t_{n+1}) - E_{\text{PF}}(t_n)
 $$
 
 This represents how much energy is charged into or discharged from the PF magnetic field.
@@ -59,10 +59,10 @@ This represents how much energy is charged into or discharged from the PF magnet
 
 ##### 3. Storage system losses | `_pf_loss_storage_j()`
 
-Assuming a fractional inefficiency $k_s$ in the energy storage system:
+Assuming a fractional inefficiency $k_\text{s}$ in the energy storage system:
 
 $$
-ELoss_{s,n} = k_s \, \left| \Delta E_n \right|
+E_{\text{loss},\text{s},n} = k_\text{s} \, \left| \Delta E_n \right|
 $$
 
 A fixed fraction of energy moved is lost each time energy flows in or out of storage.
@@ -104,8 +104,8 @@ $$
 The resulting energy loss in the power supplies over the interval is:
 
 $$
-ELoss_{ps,n} =
-\frac{k_{ps}}{2}
+E_{\text{loss},\text{ps},n} =
+\frac{k_{\text{ps}}}{2}
 \left|
 \left[I_i(t_{n+1}) + I_i(t_n)\right]
 \sum_j M_{ij}
@@ -134,7 +134,7 @@ $$
 Energy dissipated in the busbars is:
 
 $$
-ELoss_{bus,n} = \Delta t \sum_i \bar{I}_i^2 R_i
+E_{\text{loss}, \text{bus},n} = \Delta t \sum_i \bar{I}_i^2 R_i
 $$
 
 ---
@@ -144,7 +144,7 @@ $$
 Summing losses over all pulse phases:
 
 $$
-EnergyLoss = \sum_n \left( ELoss_{s,n} + ELoss_{ps,n} + ELoss_{bus,n} \right)
+EnergyLoss = \sum_n \left( E_{\text{loss},\text{s},n} + E_{\text{loss},\text{ps},n} + E_{\text{loss},\text{bus},n} \right)
 $$
 
 The mean PF electrical power demand is obtained by dividing the total pulse energy loss by the flat-top duration.

--- a/process/data_structure/pf_power_variables.py
+++ b/process/data_structure/pf_power_variables.py
@@ -42,6 +42,12 @@ maxpoloidalpower: float = None
 poloidalpower: list[float] = None
 """Poloidal power usage at time t (MW)"""
 
+f_p_pf_energy_store_loss: float = None
+"""Fraction of PF magnetic energy moved into/out of storage that is lost each time"""
+
+f_p_pf_psu_loss: float = None
+"""Fraction of inductive power flow lost in the PF power supplies/converters."""
+
 
 def init_pf_power_variables():
     """Initialise PF coil power variables"""
@@ -56,7 +62,9 @@ def init_pf_power_variables():
         vpfskv, \
         peakpoloidalpower, \
         maxpoloidalpower, \
-        poloidalpower
+        poloidalpower, \
+        f_p_pf_energy_store_loss, \
+        f_p_pf_psu_loss
 
     acptmax = 0.0
     ensxpfm = 0.0
@@ -69,3 +77,5 @@ def init_pf_power_variables():
     peakpoloidalpower = 0.0
     maxpoloidalpower = 1000.0
     poloidalpower = np.zeros(5)
+    f_p_pf_energy_store_loss = 0.1
+    f_p_pf_psu_loss = 0.1

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -80,18 +80,18 @@ class Power(Model):
 
     def _pf_loss_power_supply_j(
         self,
-        ii: int,
+        idx_time_interval: int,
         n_pf_cs_plasma_circuits: int,
         c_pf_coil_turn: np.ndarray,
         ind_pf_cs_plasma_mutual: np.ndarray,
     ) -> float:
         """
-        Power supply conversion loss over interval ii -> ii+1 [J]
+        Power supply conversion loss over interval idx_time_interval -> idx_time_interval+1 [J]
         Implements: sum_i (k_ps/2) * | (I_i[n+1] + I_i[n]) * sum_j M_ij (I_j[n+1] - I_j[n]) |
         Ref: M. Kovari, "PF power supplies accounting 2, Issue #972"
 
-        :param ii: index of time interval (ii -> ii+1)
-        :type ii: int
+        :param idx_time_interval: index of time interval (n -> n+1)
+        :type idx_time_interval: int
         :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
         :type c_pf_coil_turn: np.ndarray
         :param ind_pf_cs_plasma_mutual: mutual inductance matrix between PF circuits [H]
@@ -100,27 +100,34 @@ class Power(Model):
         :rtype: float
         """
         e_loss_pf_psu_j = 0.0e0
-        for jj in range(n_pf_cs_plasma_circuits - 1):
-            c_pf_sum_a = c_pf_coil_turn[jj, ii + 1] + c_pf_coil_turn[jj, ii]
 
-            web_pf_delta_wb = 0.0e0
-            for kk in range(n_pf_cs_plasma_circuits):
-                web_pf_delta_wb = web_pf_delta_wb + ind_pf_cs_plasma_mutual[jj, kk] * (
-                    c_pf_coil_turn[kk, ii + 1] - c_pf_coil_turn[kk, ii]
+        # Exclude plasma circuit from power supply sum: circuits 0..(n-2)
+        for idx_circuit in range(n_pf_cs_plasma_circuits - 1):
+            c_pf_sum_a = (
+                c_pf_coil_turn[idx_circuit, idx_time_interval + 1]
+                + c_pf_coil_turn[idx_circuit, idx_time_interval]
+            )
+
+            delta_flux_linkage_wb = 0.0e0
+            for idx_coupled_circuit in range(n_pf_cs_plasma_circuits):
+                delta_flux_linkage_wb += ind_pf_cs_plasma_mutual[
+                    idx_circuit, idx_coupled_circuit
+                ] * (
+                    c_pf_coil_turn[idx_coupled_circuit, idx_time_interval + 1]
+                    - c_pf_coil_turn[idx_coupled_circuit, idx_time_interval]
                 )
 
-            e_loss_pf_psu_j = (
-                e_loss_pf_psu_j
-                + 0.5e0
+            e_loss_pf_psu_j += (
+                0.5e0
                 * pf_power_variables.f_p_pf_psu_loss
-                * abs(c_pf_sum_a * web_pf_delta_wb)
+                * abs(c_pf_sum_a * delta_flux_linkage_wb)
             )
 
         return e_loss_pf_psu_j
 
     def _pf_loss_busbar_j(
         self,
-        ii: int,
+        idx_time_interval: int,
         dt_pulse_phase_s: float,
         n_pf_coil_groups: int,
         pf_group_circuit_index: np.ndarray,
@@ -128,17 +135,17 @@ class Power(Model):
         pfbusr: np.ndarray,
     ) -> float:
         """
-        Busbar resistive loss over interval ii -> ii+1 [J]
+        Busbar resistive loss over interval idx_time_interval -> idx_time_interval+1 [J]
         Loss = Δt * sum_groups (I_mean^2 * R_bus)
         Ref: M. Kovari, "PF power supplies accounting 2, Issue #972"
 
-        :param ii: index of time interval (ii -> ii+1)
-        :type ii: int
+        :param idx_time_interval: index of time interval (n -> n+1)
+        :type idx_time_interval: int
         :param dt_pulse_phase_s: duration of pulse interval [s]
         :type dt_pulse_phase_s: float
         :param n_pf_coil_groups: number of PF coil groups/circuits
         :type n_pf_coil_groups: int
-        :param pf_group_circuit_index: mapping from PF group to circuit index
+        :param pf_group_circuit_index: mapping from PF group to representative circuit index
         :type pf_group_circuit_index: np.ndarray
         :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
         :type c_pf_coil_turn: np.ndarray
@@ -148,17 +155,20 @@ class Power(Model):
         :rtype: float
         """
         e_loss_pf_bus_j = 0.0e0
-        for jj in range(n_pf_coil_groups):
-            kk = pf_group_circuit_index[jj]
-            c_pf_mean_a = 0.5e0 * (c_pf_coil_turn[kk, ii + 1] + c_pf_coil_turn[kk, ii])
-            e_loss_pf_bus_j = (
-                e_loss_pf_bus_j + dt_pulse_phase_s * (c_pf_mean_a**2) * pfbusr[jj]
+
+        for idx_group in range(n_pf_coil_groups):
+            idx_group_circuit = pf_group_circuit_index[idx_group]
+            c_pf_mean_a = 0.5e0 * (
+                c_pf_coil_turn[idx_group_circuit, idx_time_interval + 1]
+                + c_pf_coil_turn[idx_group_circuit, idx_time_interval]
             )
+            e_loss_pf_bus_j += dt_pulse_phase_s * (c_pf_mean_a**2) * pfbusr[idx_group]
+
         return e_loss_pf_bus_j
 
     def _pf_loss_interval_total_j(
         self,
-        ii: int,
+        idx_time_interval: int,
         f_p_pf_energy_store_loss: float,
         dt_pulse_phase_s: float,
         poloidalenergy: np.ndarray,
@@ -170,19 +180,19 @@ class Power(Model):
         pfbusr: np.ndarray,
     ) -> float:
         """
-        Total PF electrical energy dissipated over interval ii -> ii+1 [J]
+        Total PF electrical energy dissipated over interval idx_time_interval -> idx_time_interval+1 [J]
         = storage + power supply + busbar
         Ref: M. Kovari, "PF power supplies accounting 2, Issue #972".
 
-        :param ii: index of time interval (ii -> ii+1)
-        :type ii: int
+        :param idx_time_interval: index of time interval (n -> n+1)
+        :type idx_time_interval: int
         :param dt_pulse_phase_s: duration of pulse interval [s]
         :type dt_pulse_phase_s: float
         :param poloidalenergy: stored poloidal magnetic energy at pulse times [J]
         :type poloidalenergy: np.ndarray
         :param n_pf_coil_groups: number of PF coil groups/circuits
         :type n_pf_coil_groups: int
-        :param pf_group_circuit_index: mapping from PF group to circuit index
+        :param pf_group_circuit_index: mapping from PF group to representative circuit index
         :type pf_group_circuit_index: np.ndarray
         :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
         :type c_pf_coil_turn: np.ndarray
@@ -196,20 +206,23 @@ class Power(Model):
         if dt_pulse_phase_s <= 0.0e0:
             return 0.0e0
 
-        e_pf_delta_j = poloidalenergy[ii + 1] - poloidalenergy[ii]
+        e_pf_delta_j = (
+            poloidalenergy[idx_time_interval + 1] - poloidalenergy[idx_time_interval]
+        )
         e_loss_pf_store_j = self._pf_loss_storage_j(
-            e_pf_delta_j, f_p_pf_energy_store_loss
+            e_pf_delta_j=e_pf_delta_j,
+            f_p_pf_energy_store_loss=f_p_pf_energy_store_loss,
         )
 
         e_loss_pf_psu_j = self._pf_loss_power_supply_j(
-            ii=ii,
+            idx_time_interval=idx_time_interval,
             n_pf_cs_plasma_circuits=n_pf_cs_plasma_circuits,
             c_pf_coil_turn=c_pf_coil_turn,
             ind_pf_cs_plasma_mutual=ind_pf_cs_plasma_mutual,
         )
 
         e_loss_pf_bus_j = self._pf_loss_busbar_j(
-            ii=ii,
+            idx_time_interval=idx_time_interval,
             dt_pulse_phase_s=dt_pulse_phase_s,
             n_pf_coil_groups=n_pf_coil_groups,
             pf_group_circuit_index=pf_group_circuit_index,
@@ -444,7 +457,7 @@ class Power(Model):
 
             # Electrical energy dissipated in PFC power supplies as they increase or decrease the poloidal field energy
             pfdissipation[idx_time_interval] = self._pf_loss_interval_total_j(
-                ii=idx_time_interval,
+                idx_time_interval=idx_time_interval,
                 f_p_pf_energy_store_loss=f_p_pf_energy_store_loss,
                 dt_pulse_phase_s=dt_pulse_phase_s,
                 poloidalenergy=poloidalenergy,

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -381,19 +381,21 @@ class Power(Model):
                     )
 
                     # Term used for calculating stored energy at each time
-                    for kk in range(6):
-                        inductxcurrent[kk] = (
-                            inductxcurrent[kk]
+                    for idx_time in range(6):
+                        inductxcurrent[idx_time] = (
+                            inductxcurrent[idx_time]
                             + ind_pf_cs_plasma_mutual[idx_pf_coil, idx_circuit]
-                            * c_pf_coil_turn[idx_circuit, kk]
+                            * c_pf_coil_turn[idx_circuit, idx_time]
                         )
 
                 #  Stored magnetic energy of the poloidal field at each time
-                # kk is the time INDEX. 't_pulse_cumulative' is the time.
-                for kk in range(6):
-                    poloidalenergy[kk] = (
-                        poloidalenergy[kk]
-                        + 0.5e0 * inductxcurrent[kk] * c_pf_coil_turn[idx_pf_coil, kk]
+                # idx_time is the time INDEX. 't_pulse_cumulative' is the time.
+                for idx_time in range(6):
+                    poloidalenergy[idx_time] = (
+                        poloidalenergy[idx_time]
+                        + 0.5e0
+                        * inductxcurrent[idx_time]
+                        * c_pf_coil_turn[idx_pf_coil, idx_time]
                     )
 
                 # Resistive power in circuits at times times_variables.t_pulse_cumulative(3) and times_variables.t_pulse_cumulative(5) respectively (MW)

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -415,23 +415,36 @@ class Power(Model):
                 )
                 powpfi = powpfi + powpfii[idx_pf_coil]
 
-        for ii in range(5):
+        for idx_time_interval in range(5):
             # Stored magnetic energy of the poloidal field at each time
-            # ii is the time index. 't_pulse_cumulative' is the time.
+            # idx_time_interval is the time index. 't_pulse_cumulative' is the time.
             # Mean rate of change of stored energy between time and time+1
-            if abs(t_pulse_cumulative[ii + 1] - t_pulse_cumulative[ii]) > 1.0e0:
-                pf_power_variables.poloidalpower[ii] = (
-                    poloidalenergy[ii + 1] - poloidalenergy[ii]
-                ) / (t_pulse_cumulative[ii + 1] - t_pulse_cumulative[ii])
+            if (
+                abs(
+                    t_pulse_cumulative[idx_time_interval + 1]
+                    - t_pulse_cumulative[idx_time_interval]
+                )
+                > 1.0e0
+            ):
+                pf_power_variables.poloidalpower[idx_time_interval] = (
+                    poloidalenergy[idx_time_interval + 1]
+                    - poloidalenergy[idx_time_interval]
+                ) / (
+                    t_pulse_cumulative[idx_time_interval + 1]
+                    - t_pulse_cumulative[idx_time_interval]
+                )
             else:
                 # Flag when an interval is small or zero MDK 30/11/16
-                pf_power_variables.poloidalpower[ii] = 9.9e9
+                pf_power_variables.poloidalpower[idx_time_interval] = 9.9e9
 
-            dt_pulse_phase_s = t_pulse_cumulative[ii + 1] - t_pulse_cumulative[ii]
+            dt_pulse_phase_s = (
+                t_pulse_cumulative[idx_time_interval + 1]
+                - t_pulse_cumulative[idx_time_interval]
+            )
 
             # Electrical energy dissipated in PFC power supplies as they increase or decrease the poloidal field energy
-            pfdissipation[ii] = self._pf_loss_interval_total_j(
-                ii=ii,
+            pfdissipation[idx_time_interval] = self._pf_loss_interval_total_j(
+                ii=idx_time_interval,
                 f_p_pf_energy_store_loss=f_p_pf_energy_store_loss,
                 dt_pulse_phase_s=dt_pulse_phase_s,
                 poloidalenergy=poloidalenergy,

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -97,14 +97,20 @@ class Power(Model):
         Implements: sum_i (k_ps/2) * | (I_i[n+1] + I_i[n]) * sum_j M_ij (I_j[n+1] - I_j[n]) |
         Ref: M. Kovari, "PF power supplies accounting 2, Issue #972"
 
-        :param idx_time_interval: index of time interval (n -> n+1)
-        :type idx_time_interval: int
-        :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
-        :type c_pf_coil_turn: np.ndarray
-        :param ind_pf_cs_plasma_mutual: mutual inductance matrix between PF circuits [H]
-        :type ind_pf_cs_plasma_mutual: np.ndarray
-        :return: power supply electrical energy loss over interval [J]
-        :rtype: float
+        Parameters
+        ----------
+        idx_time_interval : int
+            index of time interval (n -> n+1)
+        n_pf_cs_plasma_circuits : int
+        c_pf_coil_turn : np.ndarray
+            PF circuit current per turn at pulse times [A]
+        ind_pf_cs_plasma_mutual : np.ndarray
+            mutual inductance matrix between PF circuits [H]
+
+        Returns
+        -------
+        float
+            power supply electrical energy loss over interval [J]
         """
         e_loss_pf_psu_j = 0.0e0
 

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -348,9 +348,9 @@ class Power(Model):
         #  pfcoil_variables.n_pf_cs_plasma_circuits : total number of PF coils (including Central Solenoid and plasma)
         #  plasma is #n_pf_cs_plasma_circuits, and Central Solenoid is #(pfcoil_variables.n_pf_cs_plasma_circuits-1)
         #  pfcoil_variables.ind_pf_cs_plasma_mutual(i,j) : mutual inductance between coil i and j
-        for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits):
-            powpfii[ii] = 0.0e0
-            vpfi[ii] = 0.0e0
+        for idx_circuit in range(pfcoil_variables.n_pf_cs_plasma_circuits):
+            powpfii[idx_circuit] = 0.0e0
+            vpfi[idx_circuit] = 0.0e0
 
         jpf = -1
         poloidalenergy[:] = 0.0e0
@@ -360,11 +360,14 @@ class Power(Model):
             ):  # Loop over all coils in each group
                 jpf = jpf + 1
                 inductxcurrent[:] = 0.0e0
-                for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits):
-                    #  Voltage in circuit jpf due to change in current from circuit ii
+                for idx_circuit in range(pfcoil_variables.n_pf_cs_plasma_circuits):
+                    #  Voltage in circuit jpf due to change in current from circuit idx_circuit
                     vpfij = (
-                        ind_pf_cs_plasma_mutual[jpf, ii]
-                        * (c_pf_coil_turn[ii, 2] - c_pf_coil_turn[ii, 1])
+                        ind_pf_cs_plasma_mutual[jpf, idx_circuit]
+                        * (
+                            c_pf_coil_turn[idx_circuit, 2]
+                            - c_pf_coil_turn[idx_circuit, 1]
+                        )
                         / delktim
                     )
 
@@ -378,7 +381,8 @@ class Power(Model):
                     for kk in range(6):
                         inductxcurrent[kk] = (
                             inductxcurrent[kk]
-                            + ind_pf_cs_plasma_mutual[jpf, ii] * c_pf_coil_turn[ii, kk]
+                            + ind_pf_cs_plasma_mutual[jpf, idx_circuit]
+                            * c_pf_coil_turn[idx_circuit, kk]
                         )
 
                 #  Stored magnetic energy of the poloidal field at each time

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -81,6 +81,11 @@ class Power(Model):
         output: bool
 
         """
+        # Local aliases for readability (no functional change)
+        t_pulse_cumulative = times_variables.t_pulse_cumulative  # [s]
+        c_pf_coil_turn = pfcoil_variables.c_pf_coil_turn  # [A]
+        ind_pf_cs_plasma_mutual = pfcoil_variables.ind_pf_cs_plasma_mutual  # [H]
+
         powpfii = np.zeros((pfcoil_variables.NGC2,))
         cktr = np.zeros((pfcoil_variables.NGC2,))
         pfcr = np.zeros((pfcoil_variables.NGC2,))
@@ -168,26 +173,23 @@ class Power(Model):
         #  pfcoil_variables.n_pf_cs_plasma_circuits : total number of PF coils (including Central Solenoid and plasma)
         #          plasma is #n_pf_cs_plasma_circuits, and Central Solenoid is #(pfcoil_variables.n_pf_cs_plasma_circuits-1)
         #  pfcoil_variables.ind_pf_cs_plasma_mutual(i,j) : mutual inductance between coil i and j
-        for i in range(pfcoil_variables.n_pf_cs_plasma_circuits):
-            powpfii[i] = 0.0e0
-            vpfi[i] = 0.0e0
+        for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits):
+            powpfii[ii] = 0.0e0
+            vpfi[ii] = 0.0e0
 
         jpf = -1
         poloidalenergy[:] = 0.0e0
-        for jjpf in range(ngrpt):  # Loop over all groups of PF coils.
+        for jj in range(ngrpt):  # Loop over all groups of PF coils.
             for _jjpf2 in range(
-                pfcoil_variables.n_pf_coils_in_group[jjpf]
+                pfcoil_variables.n_pf_coils_in_group[jj]
             ):  # Loop over all coils in each group
                 jpf = jpf + 1
                 inductxcurrent[:] = 0.0e0
-                for ipf in range(pfcoil_variables.n_pf_cs_plasma_circuits):
+                for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits):
                     #  Voltage in circuit jpf due to change in current from circuit ipf
                     vpfij = (
-                        pfcoil_variables.ind_pf_cs_plasma_mutual[jpf, ipf]
-                        * (
-                            pfcoil_variables.c_pf_coil_turn[ipf, 2]
-                            - pfcoil_variables.c_pf_coil_turn[ipf, 1]
-                        )
+                        ind_pf_cs_plasma_mutual[jpf, ii]
+                        * (c_pf_coil_turn[ii, 2] - c_pf_coil_turn[ii, 1])
                         / delktim
                     )
 
@@ -195,100 +197,66 @@ class Power(Model):
                     vpfi[jpf] = vpfi[jpf] + vpfij
 
                     #  MVA in circuit jpf at time, times_variables.t_pulse_cumulative(3) due to changes in current
-                    powpfii[jpf] = (
-                        powpfii[jpf]
-                        + vpfij * pfcoil_variables.c_pf_coil_turn[jpf, 2] / 1.0e6
-                    )
+                    powpfii[jpf] = powpfii[jpf] + vpfij * c_pf_coil_turn[jpf, 2] / 1.0e6
 
                     # Term used for calculating stored energy at each time
-                    for time in range(6):
-                        inductxcurrent[time] = (
-                            inductxcurrent[time]
-                            + pfcoil_variables.ind_pf_cs_plasma_mutual[jpf, ipf]
-                            * pfcoil_variables.c_pf_coil_turn[ipf, time]
+                    for kk in range(6):
+                        inductxcurrent[kk] = (
+                            inductxcurrent[kk]
+                            + ind_pf_cs_plasma_mutual[jpf, ii] * c_pf_coil_turn[ii, kk]
                         )
-
-                    # engx = engx + pfcoil_variables.ind_pf_cs_plasma_mutual(jpf,ipf)*pfcoil_variables.c_pf_coil_turn(ipf,5)
 
                 #  Stored magnetic energy of the poloidal field at each time
                 # 'time' is the time INDEX.  't_pulse_cumulative' is the time.
-                for time in range(6):
-                    poloidalenergy[time] = (
-                        poloidalenergy[time]
-                        + 0.5e0
-                        * inductxcurrent[time]
-                        * pfcoil_variables.c_pf_coil_turn[jpf, time]
+                for kk in range(6):
+                    poloidalenergy[kk] = (
+                        poloidalenergy[kk]
+                        + 0.5e0 * inductxcurrent[kk] * c_pf_coil_turn[jpf, kk]
                     )
-
-                #   do time = 1,5
-                #     # Mean rate of change of stored energy between time and time+1
-                #     if(abs(times_variables.t_pulse_cumulative(time+1)-times_variables.t_pulse_cumulative(time)).gt.1.0e0) :
-                #         pf_power_variables.poloidalpower(time) = (poloidalenergy(time+1)-poloidalenergy(time)) / (times_variables.t_pulse_cumulative(time+1)-times_variables.t_pulse_cumulative(time))
-                #     else:
-                #         # Flag when an interval is small or zero MDK 30/11/16
-                #         pf_power_variables.poloidalpower(time) = 9.9e9
-                #
-
-                #   end do
-                #   #engxpc = 0.5e0 * engx * pfcoil_variables.c_pf_coil_turn(jpf,5)
-                #   #ensxpf = ensxpf + engxpc
 
                 #  Resistive power in circuits at times times_variables.t_pulse_cumulative(3) and times_variables.t_pulse_cumulative(5) respectively (MW)
                 powpfr = (
                     powpfr
                     + pfcoil_variables.n_pf_coil_turns[jpf]
-                    * pfcoil_variables.c_pf_coil_turn[jpf, 2]
-                    * cktr[jjpf]
+                    * c_pf_coil_turn[jpf, 2]
+                    * cktr[jj]
                     / 1.0e6
                 )
                 powpfr2 = (
                     powpfr2
                     + pfcoil_variables.n_pf_coil_turns[jpf]
-                    * pfcoil_variables.c_pf_coil_turn[jpf, 4]
-                    * cktr[jjpf]
+                    * c_pf_coil_turn[jpf, 4]
+                    * cktr[jj]
                     / 1.0e6
                 )
                 powpfi = powpfi + powpfii[jpf]
 
-        for time in range(5):
+        for ii in range(5):
             # Stored magnetic energy of the poloidal field at each time
             # 'time' is the time INDEX.  't_pulse_cumulative' is the time.
             # Mean rate of change of stored energy between time and time+1
-            if (
-                abs(
-                    times_variables.t_pulse_cumulative[time + 1]
-                    - times_variables.t_pulse_cumulative[time]
-                )
-                > 1.0e0
-            ):
-                pf_power_variables.poloidalpower[time] = (
-                    poloidalenergy[time + 1] - poloidalenergy[time]
-                ) / (
-                    times_variables.t_pulse_cumulative[time + 1]
-                    - times_variables.t_pulse_cumulative[time]
-                )
+            if abs(t_pulse_cumulative[ii + 1] - t_pulse_cumulative[ii]) > 1.0e0:
+                pf_power_variables.poloidalpower[ii] = (
+                    poloidalenergy[ii + 1] - poloidalenergy[ii]
+                ) / (t_pulse_cumulative[ii + 1] - t_pulse_cumulative[ii])
             else:
                 # Flag when an interval is small or zero MDK 30/11/16
-                pf_power_variables.poloidalpower[time] = 9.9e9
+                pf_power_variables.poloidalpower[ii] = 9.9e9
 
             # Electrical energy dissipated in PFC power supplies as they increase or decrease the poloidal field energy
             # This assumes that the energy storage in the PFC power supply is lossless and that currents
             # in the coils can be varied without loss when there is no change in the energy in the poloidal field.
             # Energy is dissipated only when energy moves into or out of the store in the power supply.
             # Issue #713
-            pfdissipation[time] = abs(
-                poloidalenergy[time + 1] - poloidalenergy[time]
-            ) * (1.0e0 / pfcoil_variables.etapsu - 1.0e0)
+            pfdissipation[ii] = abs(poloidalenergy[ii + 1] - poloidalenergy[ii]) * (
+                1.0e0 / pfcoil_variables.etapsu - 1.0e0
+            )
 
         # Mean power dissipated
         # The flat top duration (time 4 to 5) is the denominator, as this is the time when electricity is generated.
-        if (
-            times_variables.t_pulse_cumulative[4] - times_variables.t_pulse_cumulative[3]
-            > 1.0e0
-        ):
+        if t_pulse_cumulative[4] - t_pulse_cumulative[3] > 1.0e0:
             pfpower = sum(pfdissipation[:]) / (
-                times_variables.t_pulse_cumulative[4]
-                - times_variables.t_pulse_cumulative[3]
+                t_pulse_cumulative[4] - t_pulse_cumulative[3]
             )
         else:
             # Give up when an interval is small or zero.
@@ -316,20 +284,20 @@ class Power(Model):
         pf_power_variables.acptmax = 0.0e0
         pf_power_variables.spsmva = 0.0e0
 
-        for jpf in range(pfcoil_variables.n_pf_cs_plasma_circuits - 1):
+        for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits - 1):
             #  Power supply MVA for each PF circuit
-            psmva[jpf] = 1.0e-6 * abs(
-                vpfi[jpf] * pfcoil_variables.c_pf_coil_turn_peak_input[jpf]
+            psmva[ii] = 1.0e-6 * abs(
+                vpfi[ii] * pfcoil_variables.c_pf_coil_turn_peak_input[ii]
             )
 
             #  Sum of the power supply MVA of the PF circuits
-            pf_power_variables.spsmva = pf_power_variables.spsmva + psmva[jpf]
+            pf_power_variables.spsmva = pf_power_variables.spsmva + psmva[ii]
 
             #  Average of the maximum currents in the PF circuits, kA
             pf_power_variables.acptmax = (
                 pf_power_variables.acptmax
                 + 1.0e-3
-                * abs(pfcoil_variables.c_pf_coil_turn_peak_input[jpf])
+                * abs(pfcoil_variables.c_pf_coil_turn_peak_input[ii])
                 / pf_power_variables.pfckts
             )
 

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -354,9 +354,9 @@ class Power(Model):
 
         jpf = -1
         poloidalenergy[:] = 0.0e0
-        for jj in range(n_pf_coil_groups):  # Loop over all groups of PF coils.
+        for idx_group in range(n_pf_coil_groups):  # Loop over all groups of PF coils.
             for _jjpf2 in range(
-                pfcoil_variables.n_pf_coils_in_group[jj]
+                pfcoil_variables.n_pf_coils_in_group[idx_group]
             ):  # Loop over all coils in each group
                 jpf = jpf + 1
                 inductxcurrent[:] = 0.0e0
@@ -398,14 +398,14 @@ class Power(Model):
                     powpfr
                     + pfcoil_variables.n_pf_coil_turns[jpf]
                     * c_pf_coil_turn[jpf, 2]
-                    * cktr[jj]
+                    * cktr[idx_group]
                     / 1.0e6
                 )
                 powpfr2 = (
                     powpfr2
                     + pfcoil_variables.n_pf_coil_turns[jpf]
                     * c_pf_coil_turn[jpf, 4]
-                    * cktr[jj]
+                    * cktr[idx_group]
                     / 1.0e6
                 )
                 powpfi = powpfi + powpfii[jpf]

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -267,6 +267,13 @@ class Power(Model):
         peak MVA, and at the end of flattop for the peak stored energy.
         The reactive (inductive) components use waves to calculate the
         <I>dI/dt</I> at the time periods.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
         None
 
         Parameters

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -716,9 +716,7 @@ class Power(Model):
         # po.oheadr(self.outfile,'AC Power')
         po.oheadr(self.outfile, "Electric Power Requirements")
         po.ovarre(self.outfile, "Divertor coil power supplies (MW)", "(bdvmw)", bdvmw)
-        po.ovarre(
-            self.outfile, "Cryoplant electric power (MW)", "(crymw)", crymw, "OP "
-        )
+        po.ovarre(self.outfile, "Cryoplant electric power (MW)", "(crymw)", crymw, "OP ")
         # po.ovarre(self.outfile,'Heat removed from cryogenic coils (MWth)','(helpow/1.0e6)',helpow/1.0e6)
         # po.ovarre(self.outfile,'MGF (motor-generator flywheel) units (MW)', '(fmgdmw)',fmgdmw)
         # po.ovarin(self.outfile,'Primary coolant pumps (MW)', '(i_blkt_coolant_type)',i_blkt_coolant_type)
@@ -1042,10 +1040,7 @@ class Power(Model):
             p_tf_cryoal_cryo = (
                 1.0e-6
                 * (constants.TEMP_ROOM - tfcoil_variables.temp_cp_coolant_inlet)
-                / (
-                    tfcoil_variables.eff_tf_cryo
-                    * tfcoil_variables.temp_cp_coolant_inlet
-                )
+                / (tfcoil_variables.eff_tf_cryo * tfcoil_variables.temp_cp_coolant_inlet)
                 * heat_transport_variables.helpow_cryal
             )
 
@@ -2611,17 +2606,15 @@ class Power(Model):
         - Negative values indicate power consumption (loads).
         """
 
-        t_steps = np.cumsum(
-            [
-                0,
-                t_precharge,
-                t_current_ramp_up,
-                t_fusion_ramp,
-                t_burn,
-                t_ramp_down,
-                t_between_pulse,
-            ]
-        )
+        t_steps = np.cumsum([
+            0,
+            t_precharge,
+            t_current_ramp_up,
+            t_fusion_ramp,
+            t_burn,
+            t_ramp_down,
+            t_between_pulse,
+        ])
 
         # Number of time steps
         n_steps = len(t_steps)
@@ -2700,9 +2693,7 @@ class Power(Model):
 
         # Integrate net electric power over the pulse to get total energy produced (MJ)
         # Assume t_steps in seconds, power in MW, so energy in MJ
-        energy_made_mj = sp.integrate.trapezoid(
-            p_plant_electric_net_profile_mw, t_steps
-        )
+        energy_made_mj = sp.integrate.trapezoid(p_plant_electric_net_profile_mw, t_steps)
         energy_made_kwh = energy_made_mj / 3.6
 
         return (

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -487,20 +487,21 @@ class Power(Model):
         pf_power_variables.acptmax = 0.0e0
         pf_power_variables.spsmva = 0.0e0
 
-        for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits - 1):
+        for idx_circuit in range(pfcoil_variables.n_pf_cs_plasma_circuits - 1):
             #  Power supply MVA for each PF circuit
-            psmva[ii] = 1.0e-6 * abs(
-                vpfi[ii] * pfcoil_variables.c_pf_coil_turn_peak_input[ii]
+            psmva[idx_circuit] = 1.0e-6 * abs(
+                vpfi[idx_circuit]
+                * pfcoil_variables.c_pf_coil_turn_peak_input[idx_circuit]
             )
 
             #  Sum of the power supply MVA of the PF circuits
-            pf_power_variables.spsmva = pf_power_variables.spsmva + psmva[ii]
+            pf_power_variables.spsmva = pf_power_variables.spsmva + psmva[idx_circuit]
 
             #  Average of the maximum currents in the PF circuits, kA
             pf_power_variables.acptmax = (
                 pf_power_variables.acptmax
                 + 1.0e-3
-                * abs(pfcoil_variables.c_pf_coil_turn_peak_input[ii])
+                * abs(pfcoil_variables.c_pf_coil_turn_peak_input[idx_circuit])
                 / pf_power_variables.pfckts
             )
 

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -122,7 +122,7 @@ class Power(Model):
         self,
         ii: int,
         dt_pulse_phase_s: float,
-        ngrpt: int,
+        n_pf_coil_groups: int,
         pf_group_circuit_index: np.ndarray,
         c_pf_coil_turn: np.ndarray,
         pfbusr: np.ndarray,
@@ -136,8 +136,8 @@ class Power(Model):
         :type ii: int
         :param dt_pulse_phase_s: duration of pulse interval [s]
         :type dt_pulse_phase_s: float
-        :param ngrpt: number of PF coil groups/circuits
-        :type ngrpt: int
+        :param n_pf_coil_groups: number of PF coil groups/circuits
+        :type n_pf_coil_groups: int
         :param pf_group_circuit_index: mapping from PF group to circuit index
         :type pf_group_circuit_index: np.ndarray
         :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
@@ -148,7 +148,7 @@ class Power(Model):
         :rtype: float
         """
         e_loss_pf_bus_j = 0.0e0
-        for jj in range(ngrpt):
+        for jj in range(n_pf_coil_groups):
             kk = pf_group_circuit_index[jj]
             c_pf_mean_a = 0.5e0 * (c_pf_coil_turn[kk, ii + 1] + c_pf_coil_turn[kk, ii])
             e_loss_pf_bus_j = (
@@ -162,7 +162,7 @@ class Power(Model):
         f_p_pf_energy_store_loss: float,
         dt_pulse_phase_s: float,
         poloidalenergy: np.ndarray,
-        ngrpt: int,
+        n_pf_coil_groups: int,
         pf_group_circuit_index: np.ndarray,
         n_pf_cs_plasma_circuits: int,
         c_pf_coil_turn: np.ndarray,
@@ -180,8 +180,8 @@ class Power(Model):
         :type dt_pulse_phase_s: float
         :param poloidalenergy: stored poloidal magnetic energy at pulse times [J]
         :type poloidalenergy: np.ndarray
-        :param ngrpt: number of PF coil groups/circuits
-        :type ngrpt: int
+        :param n_pf_coil_groups: number of PF coil groups/circuits
+        :type n_pf_coil_groups: int
         :param pf_group_circuit_index: mapping from PF group to circuit index
         :type pf_group_circuit_index: np.ndarray
         :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
@@ -211,7 +211,7 @@ class Power(Model):
         e_loss_pf_bus_j = self._pf_loss_busbar_j(
             ii=ii,
             dt_pulse_phase_s=dt_pulse_phase_s,
-            ngrpt=ngrpt,
+            n_pf_coil_groups=n_pf_coil_groups,
             pf_group_circuit_index=pf_group_circuit_index,
             c_pf_coil_turn=c_pf_coil_turn,
             pfbusr=pfbusr,
@@ -268,17 +268,17 @@ class Power(Model):
         #  PF coil resistive power requirements
         #  Bussing losses assume aluminium bussing with 100 A/cm**2
         ic = -1
-        ngrpt = pfcoil_variables.n_pf_coil_groups
+        n_pf_coil_groups = pfcoil_variables.n_pf_coil_groups
         if build_variables.iohcl != 0:
-            ngrpt = ngrpt + 1
+            n_pf_coil_groups = n_pf_coil_groups + 1
 
         # Map PF group to representative circuit index (used for busbar I^2R per circuit)
-        pf_group_circuit_index = np.zeros((ngrpt,), dtype=int)
+        pf_group_circuit_index = np.zeros((n_pf_coil_groups,), dtype=int)
 
         pf_power_variables.srcktpm = 0.0e0
         pfbuspwr = 0.0e0
 
-        for ig in range(ngrpt):
+        for ig in range(n_pf_coil_groups):
             ic = ic + pfcoil_variables.n_pf_coils_in_group[ig]
             pf_group_circuit_index[ig] = ic
 
@@ -333,13 +333,16 @@ class Power(Model):
         powpfr = 0.0e0
         powpfr2 = 0.0e0
 
+        #  pfcoil_variables.n_pf_cs_plasma_circuits : total number of PF coils (including Central Solenoid and plasma)
+        #  plasma is #n_pf_cs_plasma_circuits, and Central Solenoid is #(pfcoil_variables.n_pf_cs_plasma_circuits-1)
+        #  pfcoil_variables.ind_pf_cs_plasma_mutual(i,j) : mutual inductance between coil i and j
         for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits):
             powpfii[ii] = 0.0e0
             vpfi[ii] = 0.0e0
 
         jpf = -1
         poloidalenergy[:] = 0.0e0
-        for jj in range(ngrpt):  # Loop over all groups of PF coils.
+        for jj in range(n_pf_coil_groups):  # Loop over all groups of PF coils.
             for _jjpf2 in range(
                 pfcoil_variables.n_pf_coils_in_group[jj]
             ):  # Loop over all coils in each group
@@ -411,7 +414,7 @@ class Power(Model):
                 f_p_pf_energy_store_loss=f_p_pf_energy_store_loss,
                 dt_pulse_phase_s=dt_pulse_phase_s,
                 poloidalenergy=poloidalenergy,
-                ngrpt=ngrpt,
+                n_pf_coil_groups=n_pf_coil_groups,
                 pf_group_circuit_index=pf_group_circuit_index,
                 n_pf_cs_plasma_circuits=n_pf_cs_plasma_circuits,
                 c_pf_coil_turn=c_pf_coil_turn,

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -63,7 +63,9 @@ class Power(Model):
         # Cryoplant loads
         self.calculate_cryo_loads()
 
-    def _pf_loss_storage_j(self, e_pf_delta_j: float) -> float:
+    def _pf_loss_storage_j(
+        self, e_pf_delta_j: float, f_p_pf_energy_store_loss: float
+    ) -> float:
         """
         Energy storage loss over an interval [J]
         Loss = f_p_pf_energy_store_loss * |ΔE_PF|
@@ -74,11 +76,12 @@ class Power(Model):
         :return: energy storage electrical loss over interval [J]
         :rtype: float
         """
-        return pf_power_variables.f_p_pf_energy_store_loss * abs(e_pf_delta_j)
+        return f_p_pf_energy_store_loss * abs(e_pf_delta_j)
 
     def _pf_loss_power_supply_j(
         self,
         ii: int,
+        n_pf_cs_plasma_circuits: int,
         c_pf_coil_turn: np.ndarray,
         ind_pf_cs_plasma_mutual: np.ndarray,
     ) -> float:
@@ -97,11 +100,11 @@ class Power(Model):
         :rtype: float
         """
         e_loss_pf_psu_j = 0.0e0
-        for jj in range(pfcoil_variables.n_pf_cs_plasma_circuits - 1):
+        for jj in range(n_pf_cs_plasma_circuits - 1):
             c_pf_sum_a = c_pf_coil_turn[jj, ii + 1] + c_pf_coil_turn[jj, ii]
 
             web_pf_delta_wb = 0.0e0
-            for kk in range(pfcoil_variables.n_pf_cs_plasma_circuits):
+            for kk in range(n_pf_cs_plasma_circuits):
                 web_pf_delta_wb = web_pf_delta_wb + ind_pf_cs_plasma_mutual[jj, kk] * (
                     c_pf_coil_turn[kk, ii + 1] - c_pf_coil_turn[kk, ii]
                 )
@@ -156,10 +159,12 @@ class Power(Model):
     def _pf_loss_interval_total_j(
         self,
         ii: int,
+        f_p_pf_energy_store_loss: float,
         dt_pulse_phase_s: float,
         poloidalenergy: np.ndarray,
         ngrpt: int,
         pf_group_circuit_index: np.ndarray,
+        n_pf_cs_plasma_circuits: int,
         c_pf_coil_turn: np.ndarray,
         ind_pf_cs_plasma_mutual: np.ndarray,
         pfbusr: np.ndarray,
@@ -192,10 +197,13 @@ class Power(Model):
             return 0.0e0
 
         e_pf_delta_j = poloidalenergy[ii + 1] - poloidalenergy[ii]
-        e_loss_pf_store_j = self._pf_loss_storage_j(e_pf_delta_j)
+        e_loss_pf_store_j = self._pf_loss_storage_j(
+            e_pf_delta_j, f_p_pf_energy_store_loss
+        )
 
         e_loss_pf_psu_j = self._pf_loss_power_supply_j(
             ii=ii,
+            n_pf_cs_plasma_circuits=n_pf_cs_plasma_circuits,
             c_pf_coil_turn=c_pf_coil_turn,
             ind_pf_cs_plasma_mutual=ind_pf_cs_plasma_mutual,
         )
@@ -232,6 +240,10 @@ class Power(Model):
         t_pulse_cumulative = times_variables.t_pulse_cumulative  # [s]
         c_pf_coil_turn = pfcoil_variables.c_pf_coil_turn  # [A]
         ind_pf_cs_plasma_mutual = pfcoil_variables.ind_pf_cs_plasma_mutual  # [H]
+        f_p_pf_energy_store_loss = (
+            pf_power_variables.f_p_pf_energy_store_loss
+        )  # [unitless]
+        n_pf_cs_plasma_circuits = pfcoil_variables.n_pf_cs_plasma_circuits  # [unitless]
 
         powpfii = np.zeros((pfcoil_variables.NGC2,))
         cktr = np.zeros((pfcoil_variables.NGC2,))
@@ -399,10 +411,12 @@ class Power(Model):
             # Electrical energy dissipated in PFC power supplies as they increase or decrease the poloidal field energy
             pfdissipation[ii] = self._pf_loss_interval_total_j(
                 ii=ii,
+                f_p_pf_energy_store_loss=f_p_pf_energy_store_loss,
                 dt_pulse_phase_s=dt_pulse_phase_s,
                 poloidalenergy=poloidalenergy,
                 ngrpt=ngrpt,
                 pf_group_circuit_index=pf_group_circuit_index,
+                n_pf_cs_plasma_circuits=n_pf_cs_plasma_circuits,
                 c_pf_coil_turn=c_pf_coil_turn,
                 ind_pf_cs_plasma_mutual=ind_pf_cs_plasma_mutual,
                 pfbusr=pfbusr,

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -333,9 +333,6 @@ class Power(Model):
         powpfr = 0.0e0
         powpfr2 = 0.0e0
 
-        #  pfcoil_variables.n_pf_cs_plasma_circuits : total number of PF coils (including Central Solenoid and plasma)
-        #  plasma is #n_pf_cs_plasma_circuits, and Central Solenoid is #(pfcoil_variables.n_pf_cs_plasma_circuits-1)
-        #  pfcoil_variables.ind_pf_cs_plasma_mutual(i,j) : mutual inductance between coil i and j
         for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits):
             powpfii[ii] = 0.0e0
             vpfi[ii] = 0.0e0

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -63,11 +63,158 @@ class Power(Model):
         # Cryoplant loads
         self.calculate_cryo_loads()
 
+    def _pf_loss_storage_j(self, e_pf_delta_j: float) -> float:
+        """
+        Energy storage loss over an interval [J]
+        Loss = f_p_pf_energy_store_loss * |ΔE_PF|
+        Ref: M. Kovari, "PF power supplies accounting 2, Issue #972"
+
+        :param e_pf_delta_j: change in stored poloidal magnetic energy over interval [J]
+        :type e_pf_delta_j: float
+        :return: energy storage electrical loss over interval [J]
+        :rtype: float
+        """
+        return pf_power_variables.f_p_pf_energy_store_loss * abs(e_pf_delta_j)
+
+    def _pf_loss_power_supply_j(
+        self,
+        ii: int,
+        c_pf_coil_turn: np.ndarray,
+        ind_pf_cs_plasma_mutual: np.ndarray,
+    ) -> float:
+        """
+        Power supply conversion loss over interval ii -> ii+1 [J]
+        Implements: sum_i (k_ps/2) * | (I_i[n+1] + I_i[n]) * sum_j M_ij (I_j[n+1] - I_j[n]) |
+        Ref: M. Kovari, "PF power supplies accounting 2, Issue #972"
+
+        :param ii: index of time interval (ii -> ii+1)
+        :type ii: int
+        :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
+        :type c_pf_coil_turn: np.ndarray
+        :param ind_pf_cs_plasma_mutual: mutual inductance matrix between PF circuits [H]
+        :type ind_pf_cs_plasma_mutual: np.ndarray
+        :return: power supply electrical energy loss over interval [J]
+        :rtype: float
+        """
+        e_loss_pf_psu_j = 0.0e0
+        for jj in range(pfcoil_variables.n_pf_cs_plasma_circuits - 1):
+            c_pf_sum_a = c_pf_coil_turn[jj, ii + 1] + c_pf_coil_turn[jj, ii]
+
+            web_pf_delta_wb = 0.0e0
+            for kk in range(pfcoil_variables.n_pf_cs_plasma_circuits):
+                web_pf_delta_wb = web_pf_delta_wb + ind_pf_cs_plasma_mutual[jj, kk] * (
+                    c_pf_coil_turn[kk, ii + 1] - c_pf_coil_turn[kk, ii]
+                )
+
+            e_loss_pf_psu_j = (
+                e_loss_pf_psu_j
+                + 0.5e0
+                * pf_power_variables.f_p_pf_psu_loss
+                * abs(c_pf_sum_a * web_pf_delta_wb)
+            )
+
+        return e_loss_pf_psu_j
+
+    def _pf_loss_busbar_j(
+        self,
+        ii: int,
+        dt_pulse_phase_s: float,
+        ngrpt: int,
+        pf_group_circuit_index: np.ndarray,
+        c_pf_coil_turn: np.ndarray,
+        pfbusr: np.ndarray,
+    ) -> float:
+        """
+        Busbar resistive loss over interval ii -> ii+1 [J]
+        Loss = Δt * sum_groups (I_mean^2 * R_bus)
+        Ref: M. Kovari, "PF power supplies accounting 2, Issue #972"
+
+        :param ii: index of time interval (ii -> ii+1)
+        :type ii: int
+        :param dt_pulse_phase_s: duration of pulse interval [s]
+        :type dt_pulse_phase_s: float
+        :param ngrpt: number of PF coil groups/circuits
+        :type ngrpt: int
+        :param pf_group_circuit_index: mapping from PF group to circuit index
+        :type pf_group_circuit_index: np.ndarray
+        :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
+        :type c_pf_coil_turn: np.ndarray
+        :param pfbusr: PF busbar resistance for each circuit/group [ohm]
+        :type pfbusr: np.ndarray
+        :return: busbar electrical energy loss over interval [J]
+        :rtype: float
+        """
+        e_loss_pf_bus_j = 0.0e0
+        for jj in range(ngrpt):
+            kk = pf_group_circuit_index[jj]
+            c_pf_mean_a = 0.5e0 * (c_pf_coil_turn[kk, ii + 1] + c_pf_coil_turn[kk, ii])
+            e_loss_pf_bus_j = (
+                e_loss_pf_bus_j + dt_pulse_phase_s * (c_pf_mean_a**2) * pfbusr[jj]
+            )
+        return e_loss_pf_bus_j
+
+    def _pf_loss_interval_total_j(
+        self,
+        ii: int,
+        dt_pulse_phase_s: float,
+        poloidalenergy: np.ndarray,
+        ngrpt: int,
+        pf_group_circuit_index: np.ndarray,
+        c_pf_coil_turn: np.ndarray,
+        ind_pf_cs_plasma_mutual: np.ndarray,
+        pfbusr: np.ndarray,
+    ) -> float:
+        """
+        Total PF electrical energy dissipated over interval ii -> ii+1 [J]
+        = storage + power supply + busbar
+        Ref: M. Kovari, "PF power supplies accounting 2, Issue #972".
+
+        :param ii: index of time interval (ii -> ii+1)
+        :type ii: int
+        :param dt_pulse_phase_s: duration of pulse interval [s]
+        :type dt_pulse_phase_s: float
+        :param poloidalenergy: stored poloidal magnetic energy at pulse times [J]
+        :type poloidalenergy: np.ndarray
+        :param ngrpt: number of PF coil groups/circuits
+        :type ngrpt: int
+        :param pf_group_circuit_index: mapping from PF group to circuit index
+        :type pf_group_circuit_index: np.ndarray
+        :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
+        :type c_pf_coil_turn: np.ndarray
+        :param ind_pf_cs_plasma_mutual: mutual inductance matrix between PF circuits [H]
+        :type ind_pf_cs_plasma_mutual: np.ndarray
+        :param pfbusr: PF busbar resistance for each circuit/group [ohm]
+        :type pfbusr: np.ndarray
+        :return: total PF electrical energy dissipated over interval [J]
+        :rtype: float
+        """
+        if dt_pulse_phase_s <= 0.0e0:
+            return 0.0e0
+
+        e_pf_delta_j = poloidalenergy[ii + 1] - poloidalenergy[ii]
+        e_loss_pf_store_j = self._pf_loss_storage_j(e_pf_delta_j)
+
+        e_loss_pf_psu_j = self._pf_loss_power_supply_j(
+            ii=ii,
+            c_pf_coil_turn=c_pf_coil_turn,
+            ind_pf_cs_plasma_mutual=ind_pf_cs_plasma_mutual,
+        )
+
+        e_loss_pf_bus_j = self._pf_loss_busbar_j(
+            ii=ii,
+            dt_pulse_phase_s=dt_pulse_phase_s,
+            ngrpt=ngrpt,
+            pf_group_circuit_index=pf_group_circuit_index,
+            c_pf_coil_turn=c_pf_coil_turn,
+            pfbusr=pfbusr,
+        )
+
+        return e_loss_pf_store_j + e_loss_pf_psu_j + e_loss_pf_bus_j
+
     def pfpwr(self, output: bool):
         """PF coil power supply requirements
 
         outfile : input integer : output file unit
-        iprint : input integer : switch for writing to output (1=yes)
         This routine calculates the MVA, power and energy requirements
         for the PF coil systems.  Units are MW and MVA for power terms.
         The routine checks at the beginning of the flattop for the
@@ -113,11 +260,15 @@ class Power(Model):
         if build_variables.iohcl != 0:
             ngrpt = ngrpt + 1
 
+        # Map PF group to representative circuit index (used for busbar I^2R per circuit)
+        pf_group_circuit_index = np.zeros((ngrpt,), dtype=int)
+
         pf_power_variables.srcktpm = 0.0e0
         pfbuspwr = 0.0e0
 
         for ig in range(ngrpt):
             ic = ic + pfcoil_variables.n_pf_coils_in_group[ig]
+            pf_group_circuit_index[ig] = ic
 
             #  Section area of aluminium bussing for circuit (cm**2)
             #  pfcoil_variables.c_pf_coil_turn_peak_input : max current per turn of coil (A)
@@ -171,7 +322,7 @@ class Power(Model):
         powpfr2 = 0.0e0
 
         #  pfcoil_variables.n_pf_cs_plasma_circuits : total number of PF coils (including Central Solenoid and plasma)
-        #          plasma is #n_pf_cs_plasma_circuits, and Central Solenoid is #(pfcoil_variables.n_pf_cs_plasma_circuits-1)
+        #  plasma is #n_pf_cs_plasma_circuits, and Central Solenoid is #(pfcoil_variables.n_pf_cs_plasma_circuits-1)
         #  pfcoil_variables.ind_pf_cs_plasma_mutual(i,j) : mutual inductance between coil i and j
         for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits):
             powpfii[ii] = 0.0e0
@@ -186,7 +337,7 @@ class Power(Model):
                 jpf = jpf + 1
                 inductxcurrent[:] = 0.0e0
                 for ii in range(pfcoil_variables.n_pf_cs_plasma_circuits):
-                    #  Voltage in circuit jpf due to change in current from circuit ipf
+                    #  Voltage in circuit jpf due to change in current from circuit ii
                     vpfij = (
                         ind_pf_cs_plasma_mutual[jpf, ii]
                         * (c_pf_coil_turn[ii, 2] - c_pf_coil_turn[ii, 1])
@@ -207,14 +358,14 @@ class Power(Model):
                         )
 
                 #  Stored magnetic energy of the poloidal field at each time
-                # 'time' is the time INDEX.  't_pulse_cumulative' is the time.
+                # kk is the time INDEX. 't_pulse_cumulative' is the time.
                 for kk in range(6):
                     poloidalenergy[kk] = (
                         poloidalenergy[kk]
                         + 0.5e0 * inductxcurrent[kk] * c_pf_coil_turn[jpf, kk]
                     )
 
-                #  Resistive power in circuits at times times_variables.t_pulse_cumulative(3) and times_variables.t_pulse_cumulative(5) respectively (MW)
+                # Resistive power in circuits at times times_variables.t_pulse_cumulative(3) and times_variables.t_pulse_cumulative(5) respectively (MW)
                 powpfr = (
                     powpfr
                     + pfcoil_variables.n_pf_coil_turns[jpf]
@@ -233,7 +384,7 @@ class Power(Model):
 
         for ii in range(5):
             # Stored magnetic energy of the poloidal field at each time
-            # 'time' is the time INDEX.  't_pulse_cumulative' is the time.
+            # ii is the time index. 't_pulse_cumulative' is the time.
             # Mean rate of change of stored energy between time and time+1
             if abs(t_pulse_cumulative[ii + 1] - t_pulse_cumulative[ii]) > 1.0e0:
                 pf_power_variables.poloidalpower[ii] = (
@@ -243,15 +394,19 @@ class Power(Model):
                 # Flag when an interval is small or zero MDK 30/11/16
                 pf_power_variables.poloidalpower[ii] = 9.9e9
 
-            # Electrical energy dissipated in PFC power supplies as they increase or decrease the poloidal field energy
-            # This assumes that the energy storage in the PFC power supply is lossless and that currents
-            # in the coils can be varied without loss when there is no change in the energy in the poloidal field.
-            # Energy is dissipated only when energy moves into or out of the store in the power supply.
-            # Issue #713
-            pfdissipation[ii] = abs(poloidalenergy[ii + 1] - poloidalenergy[ii]) * (
-                1.0e0 / pfcoil_variables.etapsu - 1.0e0
-            )
+            dt_pulse_phase_s = t_pulse_cumulative[ii + 1] - t_pulse_cumulative[ii]
 
+            # Electrical energy dissipated in PFC power supplies as they increase or decrease the poloidal field energy
+            pfdissipation[ii] = self._pf_loss_interval_total_j(
+                ii=ii,
+                dt_pulse_phase_s=dt_pulse_phase_s,
+                poloidalenergy=poloidalenergy,
+                ngrpt=ngrpt,
+                pf_group_circuit_index=pf_group_circuit_index,
+                c_pf_coil_turn=c_pf_coil_turn,
+                ind_pf_cs_plasma_mutual=ind_pf_cs_plasma_mutual,
+                pfbusr=pfbusr,
+            )
         # Mean power dissipated
         # The flat top duration (time 4 to 5) is the denominator, as this is the time when electricity is generated.
         if t_pulse_cumulative[4] - t_pulse_cumulative[3] > 1.0e0:
@@ -403,7 +558,6 @@ class Power(Model):
 
 
         outfile : input integer : output file unit
-        iprint : input integer : switch for writing to output (1=yes)
         The routine was drastically shortened on 23/01/90 (ORNL) from the
         original TETRA routine to provide only the total power needs for
         the plant. Included in STORAC in January 1992 by P.C. Shipe.
@@ -1774,7 +1928,6 @@ class Power(Model):
         """TF coil power supply requirements for resistive coils
 
         outfile : input integer : output file unit
-        iprint : input integer : switch for writing to output (1=yes)
         This routine calculates the power conversion requirements for
         resistive TF coils, or calls <CODE>tfpwcall</CODE> if the TF
         coils are superconducting.
@@ -1948,7 +2101,6 @@ class Power(Model):
 
 
         outfile : input integer : output file unit
-        iprint : input integer : switch for writing to output (1=yes)
         This routine calls routine <CODE>tfcpwr</CODE> to calculate
         the power conversion requirements for superconducting TF coils.
         None

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -68,13 +68,20 @@ class Power(Model):
     ) -> float:
         """
         Energy storage loss over an interval [J]
+
         Loss = f_p_pf_energy_store_loss * |ΔE_PF|
         Ref: M. Kovari, "PF power supplies accounting 2, Issue #972"
 
-        :param e_pf_delta_j: change in stored poloidal magnetic energy over interval [J]
-        :type e_pf_delta_j: float
-        :return: energy storage electrical loss over interval [J]
-        :rtype: float
+        Parameters
+        ----------
+        e_pf_delta_j : float
+            change in stored poloidal magnetic energy over interval [J]
+        f_p_pf_energy_store_loss : float
+
+        Returns
+        -------
+        float
+            energy storage electrical loss over interval [J]
         """
         return f_p_pf_energy_store_loss * abs(e_pf_delta_j)
 

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -152,20 +152,25 @@ class Power(Model):
         Loss = Δt * sum_groups (I_mean^2 * R_bus)
         Ref: M. Kovari, "PF power supplies accounting 2, Issue #972"
 
-        :param idx_time_interval: index of time interval (n -> n+1)
-        :type idx_time_interval: int
-        :param dt_pulse_phase_s: duration of pulse interval [s]
-        :type dt_pulse_phase_s: float
-        :param n_pf_coil_groups: number of PF coil groups/circuits
-        :type n_pf_coil_groups: int
-        :param pf_group_circuit_index: mapping from PF group to representative circuit index
-        :type pf_group_circuit_index: np.ndarray
-        :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
-        :type c_pf_coil_turn: np.ndarray
-        :param pfbusr: PF busbar resistance for each circuit/group [ohm]
-        :type pfbusr: np.ndarray
-        :return: busbar electrical energy loss over interval [J]
-        :rtype: float
+        Parameters
+        ----------
+        idx_time_interval : int
+            index of time interval (n -> n+1)
+        dt_pulse_phase_s : float
+            duration of pulse interval [s]
+        n_pf_coil_groups : int
+            number of PF coil groups/circuits
+        pf_group_circuit_index : np.ndarray
+            mapping from PF group to representative circuit index
+        c_pf_coil_turn : np.ndarray
+            PF circuit current per turn at pulse times [A]
+        pfbusr : np.ndarray
+            PF busbar resistance for each circuit/group [ohm]
+
+        Returns
+        -------
+        float
+            busbar electrical energy loss over interval [J]
         """
         e_loss_pf_bus_j = 0.0e0
 

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -202,24 +202,31 @@ class Power(Model):
         = storage + power supply + busbar
         Ref: M. Kovari, "PF power supplies accounting 2, Issue #972".
 
-        :param idx_time_interval: index of time interval (n -> n+1)
-        :type idx_time_interval: int
-        :param dt_pulse_phase_s: duration of pulse interval [s]
-        :type dt_pulse_phase_s: float
-        :param poloidalenergy: stored poloidal magnetic energy at pulse times [J]
-        :type poloidalenergy: np.ndarray
-        :param n_pf_coil_groups: number of PF coil groups/circuits
-        :type n_pf_coil_groups: int
-        :param pf_group_circuit_index: mapping from PF group to representative circuit index
-        :type pf_group_circuit_index: np.ndarray
-        :param c_pf_coil_turn: PF circuit current per turn at pulse times [A]
-        :type c_pf_coil_turn: np.ndarray
-        :param ind_pf_cs_plasma_mutual: mutual inductance matrix between PF circuits [H]
-        :type ind_pf_cs_plasma_mutual: np.ndarray
-        :param pfbusr: PF busbar resistance for each circuit/group [ohm]
-        :type pfbusr: np.ndarray
-        :return: total PF electrical energy dissipated over interval [J]
-        :rtype: float
+        Parameters
+        ----------
+        idx_time_interval : int
+            index of time interval (n -> n+1)
+        f_p_pf_energy_store_loss : float
+        dt_pulse_phase_s : float
+            duration of pulse interval [s]
+        poloidalenergy : np.ndarray
+            stored poloidal magnetic energy at pulse times [J]
+        n_pf_coil_groups : int
+            number of PF coil groups/circuits
+        pf_group_circuit_index : np.ndarray
+            mapping from PF group to representative circuit index
+        n_pf_cs_plasma_circuits : int
+        c_pf_coil_turn : np.ndarray
+            PF circuit current per turn at pulse times [A]
+        ind_pf_cs_plasma_mutual : np.ndarray
+            mutual inductance matrix between PF circuits [H]
+        pfbusr : np.ndarray
+            PF busbar resistance for each circuit/group [ohm]
+
+        Returns
+        -------
+        float
+            total PF electrical energy dissipated over interval [J]
         """
         if dt_pulse_phase_s <= 0.0e0:
             return 0.0e0

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -278,23 +278,27 @@ class Power(Model):
         pf_power_variables.srcktpm = 0.0e0
         pfbuspwr = 0.0e0
 
-        for ig in range(n_pf_coil_groups):
-            ic = ic + pfcoil_variables.n_pf_coils_in_group[ig]
-            pf_group_circuit_index[ig] = ic
+        for idx_n_pf in range(n_pf_coil_groups):
+            ic = ic + pfcoil_variables.n_pf_coils_in_group[idx_n_pf]
+            pf_group_circuit_index[idx_n_pf] = ic
 
             #  Section area of aluminium bussing for circuit (cm**2)
             #  pfcoil_variables.c_pf_coil_turn_peak_input : max current per turn of coil (A)
-            albusa[ig] = abs(pfcoil_variables.c_pf_coil_turn_peak_input[ic]) / 100.0e0
+            albusa[idx_n_pf] = (
+                abs(pfcoil_variables.c_pf_coil_turn_peak_input[ic]) / 100.0e0
+            )
 
             #  Resistance of bussing for circuit (ohm)
             #  pfbusl : bus length for each PF circuit (m)
-            #  pfbusr[ig] = 1.5e0 * 2.62e-4 * pfbusl / albusa[ig]
+            #  pfbusr[idx_n_pf] = 1.5e0 * 2.62e-4 * pfbusl / albusa[idx_n_pf]
             #  I have removed the fudge factor of 1.5 but included it in the value of rhopfbus
-            pfbusr[ig] = pfcoil_variables.rhopfbus * pfbusl / (albusa[ig] / 10000)
+            pfbusr[idx_n_pf] = (
+                pfcoil_variables.rhopfbus * pfbusl / (albusa[idx_n_pf] / 10000)
+            )
 
             #  Total PF coil resistance (during burn)
             #  pfcoil_variables.c_pf_cs_coils_peak_ma : maximum current in coil (A)
-            pfcr[ig] = (
+            pfcr[idx_n_pf] = (
                 pfcoil_variables.rho_pf_coil
                 * 2.0e0
                 * np.pi
@@ -308,21 +312,29 @@ class Power(Model):
                     )
                 )
                 * pfcoil_variables.n_pf_coil_turns[ic] ** 2
-                * pfcoil_variables.n_pf_coils_in_group[ig]
+                * pfcoil_variables.n_pf_coils_in_group[idx_n_pf]
             )
 
-            cktr[ig] = pfcr[ig] + pfbusr[ig]  # total resistance of circuit (ohms)
+            cktr[idx_n_pf] = (
+                pfcr[idx_n_pf] + pfbusr[idx_n_pf]
+            )  # total resistance of circuit (ohms)
             cptburn = (
                 pfcoil_variables.c_pf_coil_turn_peak_input[ic]
                 * pfcoil_variables.c_pf_cs_coil_pulse_end_ma[ic]
                 / pfcoil_variables.c_pf_cs_coils_peak_ma[ic]
             )
-            rcktvm[ig] = abs(cptburn) * cktr[ig]  # peak resistive voltage (V)
-            rcktpm[ig] = 1.0e-6 * rcktvm[ig] * abs(cptburn)  # peak resistive power (MW)
+            rcktvm[idx_n_pf] = (
+                abs(cptburn) * cktr[idx_n_pf]
+            )  # peak resistive voltage (V)
+            rcktpm[idx_n_pf] = (
+                1.0e-6 * rcktvm[idx_n_pf] * abs(cptburn)
+            )  # peak resistive power (MW)
 
             #  Compute the sum of resistive power in the PF circuits, kW
-            pfbuspwr = pfbuspwr + 1.0e-3 * pfbusr[ig] * cptburn**2
-            pf_power_variables.srcktpm = pf_power_variables.srcktpm + 1.0e3 * rcktpm[ig]
+            pfbuspwr = pfbuspwr + 1.0e-3 * pfbusr[idx_n_pf] * cptburn**2
+            pf_power_variables.srcktpm = (
+                pf_power_variables.srcktpm + 1.0e3 * rcktpm[idx_n_pf]
+            )
 
         #  Inductive MVA requirements, and stored energy
         delktim = times_variables.t_plant_pulse_plasma_current_ramp_up

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -323,27 +323,27 @@ class Power(Model):
         pf_power_variables.srcktpm = 0.0e0
         pfbuspwr = 0.0e0
 
-        for idx_n_pf in range(n_pf_coil_groups):
-            ic = ic + pfcoil_variables.n_pf_coils_in_group[idx_n_pf]
-            pf_group_circuit_index[idx_n_pf] = ic
+        for a_pf_bus_cm in range(n_pf_coil_groups):
+            ic = ic + pfcoil_variables.n_pf_coils_in_group[a_pf_bus_cm]
+            pf_group_circuit_index[a_pf_bus_cm] = ic
 
             #  Section area of aluminium bussing for circuit (cm**2)
             #  pfcoil_variables.c_pf_coil_turn_peak_input : max current per turn of coil (A)
-            albusa[idx_n_pf] = (
+            albusa[a_pf_bus_cm] = (
                 abs(pfcoil_variables.c_pf_coil_turn_peak_input[ic]) / 100.0e0
             )
 
             #  Resistance of bussing for circuit (ohm)
             #  pfbusl : bus length for each PF circuit (m)
-            #  res_pf_bus[idx_n_pf] = 1.5e0 * 2.62e-4 * pfbusl / albusa[idx_n_pf]
+            #  res_pf_bus[a_pf_bus_cm] = 1.5e0 * 2.62e-4 * pfbusl / albusa[a_pf_bus_cm]
             #  I have removed the fudge factor of 1.5 but included it in the value of rhopfbus
-            res_pf_bus[idx_n_pf] = (
-                pfcoil_variables.rhopfbus * pfbusl / (albusa[idx_n_pf] / 10000)
+            res_pf_bus[a_pf_bus_cm] = (
+                pfcoil_variables.rhopfbus * pfbusl / (albusa[a_pf_bus_cm] / 10000)
             )
 
             #  Total PF coil resistance (during burn)
             #  pfcoil_variables.c_pf_cs_coils_peak_ma : maximum current in coil (A)
-            res_pf_coil[idx_n_pf] = (
+            res_pf_coil[a_pf_bus_cm] = (
                 pfcoil_variables.rho_pf_coil
                 * 2.0e0
                 * np.pi
@@ -357,29 +357,29 @@ class Power(Model):
                     )
                 )
                 * pfcoil_variables.n_pf_coil_turns[ic] ** 2
-                * pfcoil_variables.n_pf_coils_in_group[idx_n_pf]
+                * pfcoil_variables.n_pf_coils_in_group[a_pf_bus_cm]
             )
 
-            res_pf_circuit_total[idx_n_pf] = (
-                res_pf_coil[idx_n_pf] + res_pf_bus[idx_n_pf]
+            res_pf_circuit_total[a_pf_bus_cm] = (
+                res_pf_coil[a_pf_bus_cm] + res_pf_bus[a_pf_bus_cm]
             )  # total resistance of circuit (ohms)
             cptburn = (
                 pfcoil_variables.c_pf_coil_turn_peak_input[ic]
                 * pfcoil_variables.c_pf_cs_coil_pulse_end_ma[ic]
                 / pfcoil_variables.c_pf_cs_coils_peak_ma[ic]
             )
-            v_pf_circuit_peak[idx_n_pf] = (
-                abs(cptburn) * res_pf_circuit_total[idx_n_pf]
+            v_pf_circuit_peak[a_pf_bus_cm] = (
+                abs(cptburn) * res_pf_circuit_total[a_pf_bus_cm]
             )  # peak resistive voltage (V)
-            p_pf_circuit_resistive_peak[idx_n_pf] = (
-                1.0e-6 * v_pf_circuit_peak[idx_n_pf] * abs(cptburn)
+            p_pf_circuit_resistive_peak[a_pf_bus_cm] = (
+                1.0e-6 * v_pf_circuit_peak[a_pf_bus_cm] * abs(cptburn)
             )  # peak resistive power (MW)
 
             #  Compute the sum of resistive power in the PF circuits, kW
-            pfbuspwr = pfbuspwr + 1.0e-3 * res_pf_bus[idx_n_pf] * cptburn**2
+            pfbuspwr = pfbuspwr + 1.0e-3 * res_pf_bus[a_pf_bus_cm] * cptburn**2
             pf_power_variables.srcktpm = (
                 pf_power_variables.srcktpm
-                + 1.0e3 * p_pf_circuit_resistive_peak[idx_n_pf]
+                + 1.0e3 * p_pf_circuit_resistive_peak[a_pf_bus_cm]
             )
 
         #  Inductive MVA requirements, and stored energy

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -291,14 +291,12 @@ class Power(Model):
         n_pf_cs_plasma_circuits = pfcoil_variables.n_pf_cs_plasma_circuits  # [unitless]
 
         powpfii = np.zeros((pfcoil_variables.NGC2,))
-        cktr = np.zeros((pfcoil_variables.NGC2,))
-        pfcr = np.zeros((pfcoil_variables.NGC2,))
+        res_pf_coil = np.zeros((pfcoil_variables.NGC2,))
+        res_pf_circuit_total = np.zeros((pfcoil_variables.NGC2,))
         albusa = np.zeros((pfcoil_variables.NGC2,))
         pfbusr = np.zeros((pfcoil_variables.NGC2,))
-        pfcr = np.zeros((pfcoil_variables.NGC2,))
-        cktr = np.zeros((pfcoil_variables.NGC2,))
-        rcktvm = np.zeros((pfcoil_variables.NGC2,))
-        rcktpm = np.zeros((pfcoil_variables.NGC2,))
+        v_pf_circuit_peak = np.zeros((pfcoil_variables.NGC2,))
+        p_pf_circuit_resistive_peak = np.zeros((pfcoil_variables.NGC2,))
         vpfi = np.zeros((pfcoil_variables.NGC2,))
         psmva = np.zeros((pfcoil_variables.NGC2,))
         poloidalenergy = np.zeros((6,))
@@ -343,7 +341,7 @@ class Power(Model):
 
             #  Total PF coil resistance (during burn)
             #  pfcoil_variables.c_pf_cs_coils_peak_ma : maximum current in coil (A)
-            pfcr[idx_n_pf] = (
+            res_pf_coil[idx_n_pf] = (
                 pfcoil_variables.rho_pf_coil
                 * 2.0e0
                 * np.pi
@@ -360,25 +358,26 @@ class Power(Model):
                 * pfcoil_variables.n_pf_coils_in_group[idx_n_pf]
             )
 
-            cktr[idx_n_pf] = (
-                pfcr[idx_n_pf] + pfbusr[idx_n_pf]
+            res_pf_circuit_total[idx_n_pf] = (
+                res_pf_coil[idx_n_pf] + pfbusr[idx_n_pf]
             )  # total resistance of circuit (ohms)
             cptburn = (
                 pfcoil_variables.c_pf_coil_turn_peak_input[ic]
                 * pfcoil_variables.c_pf_cs_coil_pulse_end_ma[ic]
                 / pfcoil_variables.c_pf_cs_coils_peak_ma[ic]
             )
-            rcktvm[idx_n_pf] = (
-                abs(cptburn) * cktr[idx_n_pf]
+            v_pf_circuit_peak[idx_n_pf] = (
+                abs(cptburn) * res_pf_circuit_total[idx_n_pf]
             )  # peak resistive voltage (V)
-            rcktpm[idx_n_pf] = (
-                1.0e-6 * rcktvm[idx_n_pf] * abs(cptburn)
+            p_pf_circuit_resistive_peak[idx_n_pf] = (
+                1.0e-6 * v_pf_circuit_peak[idx_n_pf] * abs(cptburn)
             )  # peak resistive power (MW)
 
             #  Compute the sum of resistive power in the PF circuits, kW
             pfbuspwr = pfbuspwr + 1.0e-3 * pfbusr[idx_n_pf] * cptburn**2
             pf_power_variables.srcktpm = (
-                pf_power_variables.srcktpm + 1.0e3 * rcktpm[idx_n_pf]
+                pf_power_variables.srcktpm
+                + 1.0e3 * p_pf_circuit_resistive_peak[idx_n_pf]
             )
 
         #  Inductive MVA requirements, and stored energy
@@ -448,14 +447,14 @@ class Power(Model):
                     powpfr
                     + pfcoil_variables.n_pf_coil_turns[idx_pf_coil]
                     * c_pf_coil_turn[idx_pf_coil, 2]
-                    * cktr[idx_group]
+                    * res_pf_circuit_total[idx_group]
                     / 1.0e6
                 )
                 powpfr2 = (
                     powpfr2
                     + pfcoil_variables.n_pf_coil_turns[idx_pf_coil]
                     * c_pf_coil_turn[idx_pf_coil, 4]
-                    * cktr[idx_group]
+                    * res_pf_circuit_total[idx_group]
                     / 1.0e6
                 )
                 powpfi = powpfi + powpfii[idx_pf_coil]

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -145,7 +145,7 @@ class Power(Model):
         n_pf_coil_groups: int,
         pf_group_circuit_index: np.ndarray,
         c_pf_coil_turn: np.ndarray,
-        pfbusr: np.ndarray,
+        res_pf_bus: np.ndarray,
     ) -> float:
         """
         Busbar resistive loss over interval idx_time_interval -> idx_time_interval+1 [J]
@@ -164,7 +164,7 @@ class Power(Model):
             mapping from PF group to representative circuit index
         c_pf_coil_turn : np.ndarray
             PF circuit current per turn at pulse times [A]
-        pfbusr : np.ndarray
+        res_pf_bus : np.ndarray
             PF busbar resistance for each circuit/group [ohm]
 
         Returns
@@ -180,7 +180,9 @@ class Power(Model):
                 c_pf_coil_turn[idx_group_circuit, idx_time_interval + 1]
                 + c_pf_coil_turn[idx_group_circuit, idx_time_interval]
             )
-            e_loss_pf_bus_j += dt_pulse_phase_s * (c_pf_mean_a**2) * pfbusr[idx_group]
+            e_loss_pf_bus_j += (
+                dt_pulse_phase_s * (c_pf_mean_a**2) * res_pf_bus[idx_group]
+            )
 
         return e_loss_pf_bus_j
 
@@ -195,7 +197,7 @@ class Power(Model):
         n_pf_cs_plasma_circuits: int,
         c_pf_coil_turn: np.ndarray,
         ind_pf_cs_plasma_mutual: np.ndarray,
-        pfbusr: np.ndarray,
+        res_pf_bus: np.ndarray,
     ) -> float:
         """
         Total PF electrical energy dissipated over interval idx_time_interval -> idx_time_interval+1 [J]
@@ -220,7 +222,7 @@ class Power(Model):
             PF circuit current per turn at pulse times [A]
         ind_pf_cs_plasma_mutual : np.ndarray
             mutual inductance matrix between PF circuits [H]
-        pfbusr : np.ndarray
+        res_pf_bus : np.ndarray
             PF busbar resistance for each circuit/group [ohm]
 
         Returns
@@ -252,7 +254,7 @@ class Power(Model):
             n_pf_coil_groups=n_pf_coil_groups,
             pf_group_circuit_index=pf_group_circuit_index,
             c_pf_coil_turn=c_pf_coil_turn,
-            pfbusr=pfbusr,
+            res_pf_bus=res_pf_bus,
         )
 
         return e_loss_pf_store_j + e_loss_pf_psu_j + e_loss_pf_bus_j
@@ -294,7 +296,7 @@ class Power(Model):
         res_pf_coil = np.zeros((pfcoil_variables.NGC2,))
         res_pf_circuit_total = np.zeros((pfcoil_variables.NGC2,))
         albusa = np.zeros((pfcoil_variables.NGC2,))
-        pfbusr = np.zeros((pfcoil_variables.NGC2,))
+        res_pf_bus = np.zeros((pfcoil_variables.NGC2,))
         v_pf_circuit_peak = np.zeros((pfcoil_variables.NGC2,))
         p_pf_circuit_resistive_peak = np.zeros((pfcoil_variables.NGC2,))
         vpfi = np.zeros((pfcoil_variables.NGC2,))
@@ -333,9 +335,9 @@ class Power(Model):
 
             #  Resistance of bussing for circuit (ohm)
             #  pfbusl : bus length for each PF circuit (m)
-            #  pfbusr[idx_n_pf] = 1.5e0 * 2.62e-4 * pfbusl / albusa[idx_n_pf]
+            #  res_pf_bus[idx_n_pf] = 1.5e0 * 2.62e-4 * pfbusl / albusa[idx_n_pf]
             #  I have removed the fudge factor of 1.5 but included it in the value of rhopfbus
-            pfbusr[idx_n_pf] = (
+            res_pf_bus[idx_n_pf] = (
                 pfcoil_variables.rhopfbus * pfbusl / (albusa[idx_n_pf] / 10000)
             )
 
@@ -359,7 +361,7 @@ class Power(Model):
             )
 
             res_pf_circuit_total[idx_n_pf] = (
-                res_pf_coil[idx_n_pf] + pfbusr[idx_n_pf]
+                res_pf_coil[idx_n_pf] + res_pf_bus[idx_n_pf]
             )  # total resistance of circuit (ohms)
             cptburn = (
                 pfcoil_variables.c_pf_coil_turn_peak_input[ic]
@@ -374,7 +376,7 @@ class Power(Model):
             )  # peak resistive power (MW)
 
             #  Compute the sum of resistive power in the PF circuits, kW
-            pfbuspwr = pfbuspwr + 1.0e-3 * pfbusr[idx_n_pf] * cptburn**2
+            pfbuspwr = pfbuspwr + 1.0e-3 * res_pf_bus[idx_n_pf] * cptburn**2
             pf_power_variables.srcktpm = (
                 pf_power_variables.srcktpm
                 + 1.0e3 * p_pf_circuit_resistive_peak[idx_n_pf]
@@ -497,7 +499,7 @@ class Power(Model):
                 n_pf_cs_plasma_circuits=n_pf_cs_plasma_circuits,
                 c_pf_coil_turn=c_pf_coil_turn,
                 ind_pf_cs_plasma_mutual=ind_pf_cs_plasma_mutual,
-                pfbusr=pfbusr,
+                res_pf_bus=res_pf_bus,
             )
         # Mean power dissipated
         # The flat top duration (time 4 to 5) is the denominator, as this is the time when electricity is generated.

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -716,7 +716,9 @@ class Power(Model):
         # po.oheadr(self.outfile,'AC Power')
         po.oheadr(self.outfile, "Electric Power Requirements")
         po.ovarre(self.outfile, "Divertor coil power supplies (MW)", "(bdvmw)", bdvmw)
-        po.ovarre(self.outfile, "Cryoplant electric power (MW)", "(crymw)", crymw, "OP ")
+        po.ovarre(
+            self.outfile, "Cryoplant electric power (MW)", "(crymw)", crymw, "OP "
+        )
         # po.ovarre(self.outfile,'Heat removed from cryogenic coils (MWth)','(helpow/1.0e6)',helpow/1.0e6)
         # po.ovarre(self.outfile,'MGF (motor-generator flywheel) units (MW)', '(fmgdmw)',fmgdmw)
         # po.ovarin(self.outfile,'Primary coolant pumps (MW)', '(i_blkt_coolant_type)',i_blkt_coolant_type)
@@ -1040,7 +1042,10 @@ class Power(Model):
             p_tf_cryoal_cryo = (
                 1.0e-6
                 * (constants.TEMP_ROOM - tfcoil_variables.temp_cp_coolant_inlet)
-                / (tfcoil_variables.eff_tf_cryo * tfcoil_variables.temp_cp_coolant_inlet)
+                / (
+                    tfcoil_variables.eff_tf_cryo
+                    * tfcoil_variables.temp_cp_coolant_inlet
+                )
                 * heat_transport_variables.helpow_cryal
             )
 
@@ -2606,15 +2611,17 @@ class Power(Model):
         - Negative values indicate power consumption (loads).
         """
 
-        t_steps = np.cumsum([
-            0,
-            t_precharge,
-            t_current_ramp_up,
-            t_fusion_ramp,
-            t_burn,
-            t_ramp_down,
-            t_between_pulse,
-        ])
+        t_steps = np.cumsum(
+            [
+                0,
+                t_precharge,
+                t_current_ramp_up,
+                t_fusion_ramp,
+                t_burn,
+                t_ramp_down,
+                t_between_pulse,
+            ]
+        )
 
         # Number of time steps
         n_steps = len(t_steps)
@@ -2693,7 +2700,9 @@ class Power(Model):
 
         # Integrate net electric power over the pulse to get total energy produced (MJ)
         # Assume t_steps in seconds, power in MW, so energy in MJ
-        energy_made_mj = sp.integrate.trapezoid(p_plant_electric_net_profile_mw, t_steps)
+        energy_made_mj = sp.integrate.trapezoid(
+            p_plant_electric_net_profile_mw, t_steps
+        )
         energy_made_kwh = energy_made_mj / 3.6
 
         return (

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -352,18 +352,18 @@ class Power(Model):
             powpfii[idx_circuit] = 0.0e0
             vpfi[idx_circuit] = 0.0e0
 
-        jpf = -1
+        idx_pf_coil = -1
         poloidalenergy[:] = 0.0e0
         for idx_group in range(n_pf_coil_groups):  # Loop over all groups of PF coils.
-            for _jjpf2 in range(
+            for _ in range(
                 pfcoil_variables.n_pf_coils_in_group[idx_group]
             ):  # Loop over all coils in each group
-                jpf = jpf + 1
+                idx_pf_coil = idx_pf_coil + 1
                 inductxcurrent[:] = 0.0e0
                 for idx_circuit in range(pfcoil_variables.n_pf_cs_plasma_circuits):
-                    #  Voltage in circuit jpf due to change in current from circuit idx_circuit
+                    #  Voltage in circuit idx_pf_coil due to change in current from circuit idx_circuit
                     vpfij = (
-                        ind_pf_cs_plasma_mutual[jpf, idx_circuit]
+                        ind_pf_cs_plasma_mutual[idx_pf_coil, idx_circuit]
                         * (
                             c_pf_coil_turn[idx_circuit, 2]
                             - c_pf_coil_turn[idx_circuit, 1]
@@ -371,17 +371,20 @@ class Power(Model):
                         / delktim
                     )
 
-                    #  Voltage in circuit jpf at time, times_variables.t_pulse_cumulative(3), due to changes in coil currents
-                    vpfi[jpf] = vpfi[jpf] + vpfij
+                    #  Voltage in circuit idx_pf_coil at time, times_variables.t_pulse_cumulative(3), due to changes in coil currents
+                    vpfi[idx_pf_coil] = vpfi[idx_pf_coil] + vpfij
 
-                    #  MVA in circuit jpf at time, times_variables.t_pulse_cumulative(3) due to changes in current
-                    powpfii[jpf] = powpfii[jpf] + vpfij * c_pf_coil_turn[jpf, 2] / 1.0e6
+                    #  MVA in circuit idx_pf_coil at time, times_variables.t_pulse_cumulative(3) due to changes in current
+                    powpfii[idx_pf_coil] = (
+                        powpfii[idx_pf_coil]
+                        + vpfij * c_pf_coil_turn[idx_pf_coil, 2] / 1.0e6
+                    )
 
                     # Term used for calculating stored energy at each time
                     for kk in range(6):
                         inductxcurrent[kk] = (
                             inductxcurrent[kk]
-                            + ind_pf_cs_plasma_mutual[jpf, idx_circuit]
+                            + ind_pf_cs_plasma_mutual[idx_pf_coil, idx_circuit]
                             * c_pf_coil_turn[idx_circuit, kk]
                         )
 
@@ -390,25 +393,25 @@ class Power(Model):
                 for kk in range(6):
                     poloidalenergy[kk] = (
                         poloidalenergy[kk]
-                        + 0.5e0 * inductxcurrent[kk] * c_pf_coil_turn[jpf, kk]
+                        + 0.5e0 * inductxcurrent[kk] * c_pf_coil_turn[idx_pf_coil, kk]
                     )
 
                 # Resistive power in circuits at times times_variables.t_pulse_cumulative(3) and times_variables.t_pulse_cumulative(5) respectively (MW)
                 powpfr = (
                     powpfr
-                    + pfcoil_variables.n_pf_coil_turns[jpf]
-                    * c_pf_coil_turn[jpf, 2]
+                    + pfcoil_variables.n_pf_coil_turns[idx_pf_coil]
+                    * c_pf_coil_turn[idx_pf_coil, 2]
                     * cktr[idx_group]
                     / 1.0e6
                 )
                 powpfr2 = (
                     powpfr2
-                    + pfcoil_variables.n_pf_coil_turns[jpf]
-                    * c_pf_coil_turn[jpf, 4]
+                    + pfcoil_variables.n_pf_coil_turns[idx_pf_coil]
+                    * c_pf_coil_turn[idx_pf_coil, 4]
                     * cktr[idx_group]
                     / 1.0e6
                 )
-                powpfi = powpfi + powpfii[jpf]
+                powpfi = powpfi + powpfii[idx_pf_coil]
 
         for ii in range(5):
             # Stored magnetic energy of the poloidal field at each time


### PR DESCRIPTION
## Description
Closes #972 #4089 

pdates pfpwr equation to account for additional components in pf power management: busbar, power supply and storage system.

    We have added separate functions to calculate the power loss for each component.
    pfpwr has been adapted to use these new functions to account for the pf power supply - previously they were lumped into one value.
    A mild refactor of pfpwr function (modularising it a bit, renaming some variables)


from #972 and #4089
## Checklist

I confirm that I have completed the following checks:

- [x ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ x] I have added new tests where appropriate for the changes I have made.
- [ x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x ] If I have made documentation changes, I have checked they render correctly.
- [x ] I have added documentation for my change, if appropriate.
