### PR TITLE
4193 revamp beam fusion calculations

### DIFF
--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -2,7 +2,7 @@
 
 This page describes the neutral beam fusion model currently implemented in `beam_fusion()`.
 
-The model is a reduced beam-target treatment for neutral beam ions that have been injected into the plasma. PROCESS builds a steady population of fast ions from a beam source, then calculates how many of those ions fuse with the background plasma. It does not model neutral beam attenuation, shine-through, or orbit effects explicitly. Instead, it starts from the total beam current available to the beam-fusion model and then:
+The model is a reduced beam–target treatment for neutral beam ions injected into the plasma. PROCESS first determines an effective beam current that already accounts for beam transport effects such as shine-through losses. The beam-fusion model then uses this net beam current to build a steady population of fast ions and estimates how many of those ions fuse with the background plasma. `beam_fusion()` does not explicitly model beam attenuation, orbit effects, or spatial beam evolution, and instead treats the fast-ion population in a volume-averaged (0D) sense.
 
 1. computes a beam slowing-down time and a critical energy for deuterium and tritium beam ions,
 2. estimates the steady-state hot beam ion densities from the beam source rate and slowing-down residence time,

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -2,7 +2,7 @@
 
 This page describes the neutral beam fusion model currently implemented in `beam_fusion()`.
 
-The model is a reduced beam-target treatment for neutral beam ions injected into the plasma. PROCESS first determines an effective beam current that already accounts for beam transport effects such as shine-through losses. The beam-fusion model then uses this net beam current to build a steady population of fast ions and estimates how many of those ions fuse with the background plasma. `beam_fusion()` does not explicitly model beam attenuation, orbit effects, or spatial beam evolution, and instead treats the fast-ion population in a volume-averaged (0D) sense.
+The model is a reduced beam-target treatment for neutral beam ions injected into the plasma. `PROCESS` first determines an effective beam current that already accounts for beam transport effects such as shine-through losses. The beam-fusion model then uses this net beam current to build a steady population of fast ions and estimates how many of those ions fuse with the background plasma. `beam_fusion()` does not explicitly model beam attenuation, orbit effects, or spatial beam evolution, and instead treats the fast-ion population in a volume-averaged (0D) sense.
 
 1. computes a beam slowing-down time and a critical energy for deuterium and tritium beam ions,
 2. estimates the steady-state hot beam ion densities from the beam source rate and slowing-down residence time,

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -2,7 +2,7 @@
 
 This page describes the neutral beam fusion model currently implemented in `beam_fusion()`.
 
-The model is a reduced beam-target treatment for neutral beam ions injected into the plasma. `PROCESS` first determines an effective beam current that already accounts for beam transport effects such as shine-through losses. The beam-fusion model then uses this net beam current to build a steady population of fast ions and estimates how many of those ions fuse with the background plasma. `beam_fusion()` does not explicitly model beam attenuation, orbit effects, or spatial beam evolution, and instead treats the fast-ion population in a volume-averaged (0D) sense.
+The model is a reduced beam-target treatment for neutral beam ions injected into the plasma. `PROCESS` first determines an effective beam current that already accounts for beam transport effects such as shine-through losses. The beam-fusion model then uses this net beam current to build a steady population of fast ions and estimates how many of those ions fuse with the background plasma. `beam_fusion()` does not explicitly model beam attenuation, orbit effects, or spatial beam evolution, and instead treats the fast-ion population in a volume-averaged (0D) sense. The model is calculated in the following steps:
 
 1. computes a beam slowing-down time and a critical energy for deuterium and tritium beam ions,
 2. estimates the steady-state hot beam ion densities from the beam source rate and slowing-down residence time,

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -14,28 +14,28 @@ The model is a reduced beam-target treatment for neutral beam ions that have bee
 The main functions involved are:
 
 - `beam_fusion()`  
-  Top-level routine. Computes beam slowing-down properties, beam-target fusion alpha power, and neutral beam beta.
+Top-level routine. Computes beam slowing-down properties, beam-target fusion alpha power, and neutral beam beta.
 
 - `beam_slowing_down_state()`  
-  Splits the beam into deuterium and tritium components, computes steady-state hot beam densities, critical speeds, fast-ion pressures, and the density-weighted deposited beam energy.
+Splits the beam into deuterium and tritium components, computes steady-state hot beam densities, critical speeds, fast-ion pressures, and the density-weighted deposited beam energy.
 
 - `fast_ion_pressure_integral()`  
-  Returns the closed-form dimensionless integral factor used in the fast-ion pressure expression.
+Returns the closed-form dimensionless integral factor used in the fast-ion pressure expression.
 
 - `beam_reaction_rate_coefficient()`  
-  Evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population.
+Evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population.
 
 - `_hot_beam_fusion_reaction_rate_integrand()`  
-  Internal integrand used in the beam-target rate coefficient calculation.
+Internal integrand used in the beam-target rate coefficient calculation.
 
 - `_beam_fusion_cross_section()`  
-  Internal beam fusion cross-section fit used by the beam-target rate coefficient calculation.
+Internal beam fusion cross-section fit used by the beam-target rate coefficient calculation.
 
 - `beam_target_reaction_rate()`  
-  Converts beam density, target density, and beam-target reactivity into a total reaction rate.
+Converts beam density, target density, and beam-target reactivity into a total reaction rate.
 
 - `alpha_power_beam()`  
-  Converts the total beam-target reaction rate into alpha power.
+Converts the total beam-target reaction rate into alpha power.
 
 Due to the small contribution of fusion power from the neutral beams, only D-T beam-target reactions are included. D-D beam contributions are neglected in this model.
 
@@ -45,6 +45,8 @@ The NBI parameters taken from the current drive and plasma state are the total b
 
 Please see the [H&CD section](../../eng-models/heating_and_current_drive/heating-and-current-drive.md) of the docs for more info.
 
+---
+
 ## Beam slowing down properties | `beam_fusion()`
 
 This section explains the stages of calculation in the function `beam_fusion()`
@@ -53,7 +55,7 @@ This section explains the stages of calculation in the function `beam_fusion()`
 
 The beam slowing down time used in the model is implemented as:
 
-$$
+```math
 \tau_{\text{slow}} =
 1.99\times10^{19}
 \left[
@@ -63,7 +65,7 @@ A_{\text{T}}f_{\text{beam,T}}
 \right]
 \frac{\langle T_{\text{e}}\rangle^{3/2}}
 {\langle n_{\text{e}}\rangle \ln \Lambda_{\text{ie}}}
-$$
+```
 
 where:
 
@@ -74,13 +76,15 @@ where:
 - $\langle n_{\text{e}}\rangle$ is the volume-averaged electron density in m$^{-3}$,
 - $\ln\Lambda_{\text{ie}}$ is the ion-electron Coulomb logarithm.
 
+---
+
 ### Calculate the beam critical energy
 
 For an energetic ion slowing down in a plasma, there is a critical energy $E_{\text{crit}}$ at which the rate of energy loss to ions equals the rate of energy loss to electrons. Above this energy electron drag dominates, while below it ion drag dominates.
 
 In the current implementation, the deuterium critical energy [^1] is
 
-$$
+```math
 E_{\text{crit,D}} =
 14.8
 A_{\text{D}}
@@ -88,60 +92,60 @@ T_{\text{e}}
 Z_{\text{eff,mw}}^{2/3}
 \frac{\ln\Lambda_{\text{ie}}+4.0}{\ln\Lambda_{\text{ie}}}
 \qquad [\text{keV}]
-$$
+```
 
 where $Z_{\text{eff,mw}}$ is the mass-weighted effective plasma charge.
 
 The tritium critical energy is then scaled by the beam ion mass ratio:
 
-$$
+```math
 E_{\text{crit,T}} =
 E_{\text{crit,D}}
 \left(\frac{A_{\text{T}}}{A_{\text{D}}}\right)
-$$
+```
 
 #### Derivation of beam slowing down rate and critical energy
 
 The rate of slowing down of a test particle of mass $M$, charge $Ze$ and energy $E$, due to Coulomb collisions with a background species of mass $m_j$, charge $Z_j e$, density $n_j$ and temperature $T_j$, is given by[^2]
 
-$$
-\frac{\mathrm{d}E}{\mathrm{d}t}
+```math
+\frac{dE}{dt}
 =
 \left[
 -\Phi(x_j)
 +
-x_j\left(1+\frac{m_j}{M}\Phi'(x_j)\right)
+x_j\left(1+\frac{m_j}{M}\,\Phi^{\prime}(x_j)\right)
 \right]
 \frac{4\pi n_j}{m_j V}
 \left(\frac{Z Z_j e^2}{4\pi\varepsilon_0}\right)^2
-\ln\Lambda_j
-$$
+\ln \Lambda_j
+```
 
 where
 
-$$
-\Phi'(x)=\frac{\mathrm{d}\Phi}{\mathrm{d}x},
-\qquad
-V=\sqrt{\frac{2E}{M}},
-\qquad
-V_j=\sqrt{\frac{2kT_j}{m_j}},
-\qquad
-x_j=\frac{V}{V_j}
-$$
+```math
+\Phi^{\prime}(x) = \frac{d\Phi}{dx}
+```
+
+```math
+V = \sqrt{\frac{2E}{M}}, \qquad
+V_j = \sqrt{\frac{2kT_j}{m_j}}, \qquad
+x_j = \frac{V}{V_j}
+```
 
 For fast ions in fusion plasmas, the ion contribution and electron contribution may be approximated separately, leading to the standard slowing-down form[^3]:
 
-$$
+```math
 \frac{\mathrm{d}E}{\mathrm{d}t}
 =
 -\frac{A Z^2 \sqrt{M}}{\sqrt{E}}
 -
 \frac{B Z^2 E}{M}
-$$
+```
 
 with coefficients
 
-$$
+```math
 \begin{aligned}
 A &=
 \frac{4\pi}{\sqrt{2}}
@@ -156,22 +160,22 @@ B &=
 \left(\frac{e^2}{4\pi\varepsilon_0}\right)^2
 n_e \ln\Lambda_e
 \end{aligned}
-$$
+```
 
 This can be rewritten in the form
 
-$$
+```math
 \frac{\mathrm{d}E}{\mathrm{d}t}
 =
 -\frac{2E}{\tau_{\text{slow}}}
 \left[
 1+\left(\frac{E_c}{E}\right)^{3/2}
 \right]
-$$
+```
 
 where
 
-$$
+```math
 E_c
 =
 \left[
@@ -184,17 +188,17 @@ E_c
 \frac{1}{\ln\Lambda_e}
 \right]^{2/3}
 kT_e
-$$
+```
 
 and
 
-$$
+```math
 \tau_{\text{slow}}
 =
 \frac{3(kT_e)^{3/2}}{4\sqrt{2\pi m_e} Z^2}
 \left(\frac{4\pi\varepsilon_0}{e^2}\right)^2
 \frac{M}{n_e \ln\Lambda_e}
-$$
+```
 
 In this regime, $\tau_{\text{slow}}$ is the characteristic electron-drag slowing-down timescale.
 
@@ -204,21 +208,23 @@ $\blacksquare$
 
 The bulk target ion densities used in the beam-target reactions are
 
-$$
+```math
 n_{\text{D,plasma}}
 =
 n_{\text{fuel}}
 f_{\text{D,plasma}}
-$$
+```
 
-$$
+```math
 n_{\text{T,plasma}}
 =
 n_{\text{fuel}}
 f_{\text{T,plasma}}
-$$
+```
 
 where $n_{\text{fuel}}$ is the volume-averaged total fuel ion density.
+
+---
 
 ### Calculate the beam alpha powers, beam densities and deposited energy
 
@@ -232,7 +238,7 @@ where $n_{\text{fuel}}$ is the volume-averaged total fuel ion density.
 
 The total neutral beam alpha power is
 
-$$
+```math
 P_{\alpha,\text{beam}}
 =
 \mathtt{beamfus0}
@@ -241,13 +247,13 @@ P_{\alpha,\text{D-beam}}
 +
 P_{\alpha,\text{T-beam}}
 \right)
-$$
+```
 
 ### Calculate the neutral beam beta
 
 The neutral beam beta is computed from the hot beam density and the deposited beam energy:
 
-$$
+```math
 \beta_{\text{beam}}
 =
 \mathtt{betbm0}
@@ -257,7 +263,7 @@ $$
 \frac{2}{3}
 \frac{n_{\text{beam,hot}} E_{\text{beam,deposited}}}
 {B_{\phi}^2 + B_{\theta}^2}
-$$
+```
 
 where:
 
@@ -272,362 +278,362 @@ The value of $E_{\text{beam,deposited}}$ is the pressure-equivalent deposited en
 
 1. **Calculate the beam current fractions**
 
-    The beam current is split into deuterium and tritium components:
+The beam current is split into deuterium and tritium components:
 
-    $$
-    I_{\text{beam,D}}
-    =
-    I_{\text{beam}}
-    \left(1-f_{\text{beam,T}}\right)
-    $$
+```math
+I_{\text{beam,D}}
+=
+I_{\text{beam}}
+\left(1-f_{\text{beam,T}}\right)
+```
 
-    $$
-    I_{\text{beam,T}}
-    =
-    I_{\text{beam}}
-    f_{\text{beam,T}}
-    $$
+```math
+I_{\text{beam,T}}
+=
+I_{\text{beam}}
+f_{\text{beam,T}}
+```
 
-2. **Calculate the characteristic slowing-down time to the thermal range**
+1. **Calculate the characteristic slowing-down time to the thermal range**
 
-    Using the classical slowing-down model, the characteristic time for the beam ion energy to slow from the birth energy to the thermal range is implemented as:
+Using the classical slowing-down model, the characteristic time for the beam ion energy to slow from the birth energy to the thermal range is implemented as:
 
-    $$
-    \tau_{\text{slow,D}}^{*}
-    =
-    \frac{\tau_{\text{slow}}}{3}
-    \ln\left[
-    1+
-    \left(
-    \frac{E_{\text{beam}}}{E_{\text{crit,D}}}
-    \right)^{3/2}
-    \right]
-    $$
+```math
+\tau_{\text{slow,D}}^{*}
+=
+\frac{\tau_{\text{slow}}}{3}
+\ln\left[
+1+
+\left(
+\frac{E_{\text{beam}}}{E_{\text{crit,D}}}
+\right)^{3/2}
+\right]
+```
 
-    $$
-    \tau_{\text{slow,T}}^{*}
-    =
-    \frac{\tau_{\text{slow}}}{3}
-    \ln\left[
-    1+
-    \left(
-    \frac{E_{\text{beam}}}{E_{\text{crit,T}}}
-    \right)^{3/2}
-    \right]
-    $$
+```math
+\tau_{\text{slow,T}}^{*}
+=
+\frac{\tau_{\text{slow}}}{3}
+\ln\left[
+1+
+\left(
+\frac{E_{\text{beam}}}{E_{\text{crit,T}}}
+\right)^{3/2}
+\right]
+```
 
-3. **Set the fast beam ion densities**
+1. **Set the fast beam ion densities**
 
-    The steady-state hot beam ion densities are set from source rate times residence time:
+The steady-state hot beam ion densities are set from source rate times residence time:
 
-    $$
-    \langle n_{\text{beam}} \rangle_{\text{D}}
-    =
-    \frac{I_{\text{beam,D}}\tau_{\text{slow,D}}^{*}}
-    {e V_{\text{plasma}}}
-    $$
+```math
+\langle n_{\text{beam}} \rangle_{\text{D}}
+=
+\frac{I_{\text{beam,D}}\tau_{\text{slow,D}}^{*}}
+{e V_{\text{plasma}}}
+```
 
-    $$
-    \langle n_{\text{beam}} \rangle_{\text{T}}
-    =
-    \frac{I_{\text{beam,T}}\tau_{\text{slow,T}}^{*}}
-    {e V_{\text{plasma}}}
-    $$
+```math
+\langle n_{\text{beam}} \rangle_{\text{T}}
+=
+\frac{I_{\text{beam,T}}\tau_{\text{slow,T}}^{*}}
+{e V_{\text{plasma}}}
+```
 
-    The total hot beam ion density is then
+The total hot beam ion density is then
 
-    $$
-    \langle n_{\text{beam}} \rangle_{\text{hot}}
-    =
-    \langle n_{\text{beam}} \rangle_{\text{D}}
-    +
-    \langle n_{\text{beam}} \rangle_{\text{T}}
-    $$
+```math
+\langle n_{\text{beam}} \rangle_{\text{hot}}
+=
+\langle n_{\text{beam}} \rangle_{\text{D}}
++
+\langle n_{\text{beam}} \rangle_{\text{T}}
+```
 
-4. **Calculate the speeds of ions at the critical energy**
+1. **Calculate the speeds of ions at the critical energy**
 
-    Assuming non-relativistic energies, the beam ion speeds at the critical energy are
+Assuming non-relativistic energies, the beam ion speeds at the critical energy are
 
-    $$
-    v_{\text{crit,D}}
-    =
-    \sqrt{
-    \frac{2 e_{\text{keV}} E_{\text{crit,D}}}
-    {m_u A_{\text{D}}}
-    }
-    $$
+```math
+v_{\text{crit,D}}
+=
+\sqrt{
+\frac{2 e_{\text{keV}} E_{\text{crit,D}}}
+{m_u A_{\text{D}}}
+}
+```
 
-    $$
-    v_{\text{crit,T}}
-    =
-    \sqrt{
-    \frac{2 e_{\text{keV}} E_{\text{crit,T}}}
-    {m_u A_{\text{T}}}
-    }
-    $$
+```math
+v_{\text{crit,T}}
+=
+\sqrt{
+\frac{2 e_{\text{keV}} E_{\text{crit,T}}}
+{m_u A_{\text{T}}}
+}
+```
 
-    where:
+where:
 
-    - $e_{\text{keV}}$ is the conversion from keV to joules,
-    - $m_u$ is the atomic mass unit.
+- $e_{\text{keV}}$ is the conversion from keV to joules,
+- $m_u$ is the atomic mass unit.
 
-5. **Calculate the fast ion pressures**
+1. **Calculate the fast ion pressures**
 
-    First define the source rates per unit volume:
+First define the source rates per unit volume:
 
-    $$
-    S_{\text{D}}
-    =
-    \frac{I_{\text{beam,D}}}{e V_{\text{plasma}}}
-    $$
+```math
+S_{\text{D}}
+=
+\frac{I_{\text{beam,D}}}{e V_{\text{plasma}}}
+```
 
-    $$
-    S_{\text{T}}
-    =
-    \frac{I_{\text{beam,T}}}{e V_{\text{plasma}}}
-    $$
+```math
+S_{\text{T}}
+=
+\frac{I_{\text{beam,T}}}{e V_{\text{plasma}}}
+```
 
-    The implemented pressure coefficients are then
+The implemented pressure coefficients are then
 
-    $$
-    C_{p,\text{D}}
-    =
-    \frac{
-    A_{\text{D}} m_u \tau_{\text{slow}} v_{\text{crit,D}}^2 S_{\text{D}}
-    }
-    {3 e_{\text{keV}}}
-    $$
+```math
+C_{p,\text{D}}
+=
+\frac{
+A_{\text{D}} m_u \tau_{\text{slow}} v_{\text{crit,D}}^2 S_{\text{D}}
+}
+{3 e_{\text{keV}}}
+```
 
-    $$
-    C_{p,\text{T}}
-    =
-    \frac{
-    A_{\text{T}} m_u \tau_{\text{slow}} v_{\text{crit,T}}^2 S_{\text{T}}
-    }
-    {3 e_{\text{keV}}}
-    $$
+```math
+C_{p,\text{T}}
+=
+\frac{
+A_{\text{T}} m_u \tau_{\text{slow}} v_{\text{crit,T}}^2 S_{\text{T}}
+}
+{3 e_{\text{keV}}}
+```
 
-    The fast ion pressures are
+The fast ion pressures are
 
-    $$
-    p_{\text{D}}
-    =
-    C_{p,\text{D}}
-    \times
-    \underbrace{
-    \left[
-    \frac{x_c^2}{2}
-    +
-    \frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
-    -
-    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
-    -
-    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
-    \right]
-    }_{\mathtt{fast\_ion\_pressure\_integral}(E_{\text{beam}},E_{\text{crit,D}})}
-    $$
+```math
+p_{\text{D}}
+=
+C_{p,\text{D}}
+\times
+\underbrace{
+\left[
+\frac{x_c^2}{2}
++
+\frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+-
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+-
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
+\right]
+}_{\mathtt{fast\_ion\_pressure\_integral}(E_{\text{beam}},E_{\text{crit,D}})}
+```
 
-    $$
-    p_{\text{T}}
-    =
-    C_{p,\text{T}}
-    \times
-    \underbrace{
-    \left[
-    \frac{x_c^2}{2}
-    +
-    \frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
-    -
-    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
-    -
-    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
-    \right]
-    }_{\mathtt{fast\_ion\_pressure\_integral}(E_{\text{beam}},E_{\text{crit,T}})}
-    $$
+```math
+p_{\text{T}}
+=
+C_{p,\text{T}}
+\times
+\underbrace{
+\left[
+\frac{x_c^2}{2}
++
+\frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+-
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+-
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
+\right]
+}_{\mathtt{fast\_ion\_pressure\_integral}(E_{\text{beam}},E_{\text{crit,T}})}
+```
 
-    with
+with
 
-    $$
-    x_c = \sqrt{\frac{E_{\text{beam}}}{E_{\text{crit}}}}
-    $$
+```math
+x_c = \sqrt{\frac{E_{\text{beam}}}{E_{\text{crit}}}}
+```
 
-   ### Beam fast ion pressure integral | `fast_ion_pressure_integral()`
+### Beam fast ion pressure integral | `fast_ion_pressure_integral()`
 
-    This internal function returns the dimensionless pressure integral factor used in the fast-ion pressure expression. It takes the beam birth energy $E_{\text{beam}}$ and the critical energy $E_{\text{crit}}$ for the required beam ion species.
+This internal function returns the dimensionless pressure integral factor used in the fast-ion pressure expression. It takes the beam birth energy $E_{\text{beam}}$ and the critical energy $E_{\text{crit}}$ for the required beam ion species.
 
-   #### Derivation
+#### Derivation
 
-    The fast ions, because of their finite slowing down time, develop a finite pressure which must be supported by the magnetic field.
+The fast ions, because of their finite slowing down time, develop a finite pressure which must be supported by the magnetic field.
 
-    To calculate this pressure, introduce the distribution function $g(E)$ of fast ions, where $g(E)$ is the number of ions per unit energy per unit volume, satisfying the steady-state kinetic equation
+To calculate this pressure, introduce the distribution function $g(E)$ of fast ions, where $g(E)$ is the number of ions per unit energy per unit volume, satisfying the steady-state kinetic equation
 
-    $$
-    \frac{\partial}{\partial E}
-    \left(
-    g \frac{\mathrm{d}E}{\mathrm{d}t}
-    \right)
-    =
-    S(E)
-    $$
+```math
+\frac{\partial}{\partial E}
+\left(
+g \frac{\mathrm{d}E}{\mathrm{d}t}
+\right)
+=
+S(E)
+```
 
-    with slowing-down law
+with slowing-down law
 
-    $$
-    \frac{\mathrm{d}E}{\mathrm{d}t}
-    =
-    -\frac{2E}{\tau_s}
-    \left[
-    1+\left(\frac{E_c}{E}\right)^{3/2}
-    \right]
-    $$
+```math
+\frac{\mathrm{d}E}{\mathrm{d}t}
+=
+-\frac{2E}{\tau_s}
+\left[
+1+\left(\frac{E_c}{E}\right)^{3/2}
+\right]
+```
 
-    If the ions are born monoenergetically,
+If the ions are born monoenergetically,
 
-    $$
-    S(E)=S_0\delta(E-E_0)
-    $$
+```math
+S(E)=S_0\delta(E-E_0)
+```
 
-    and with the boundary condition $g(E)=0$ for $E>E_0$, the steady-state distribution becomes
+and with the boundary condition $g(E)=0$ for $E>E_0$, the steady-state distribution becomes
 
-    $$
-    g(E)=
-    \begin{cases}
-    \dfrac{S_0\tau_s}{2E\left[1+\left(E_c/E\right)^{3/2}\right]}, & E<E_0 \\
-    0, & E>E_0
-    \end{cases}
-    $$
+```math
+g(E)=
+\begin{cases}
+\dfrac{S_0\tau_s}{2E\left[1+\left(E_c/E\right)^{3/2}\right]}, & E<E_0 \\
+0, & E>E_0
+\end{cases}
+```
 
-    The fast ion pressure is then
+The fast ion pressure is then
 
-    $$
-    p
-    =
-    \frac{2}{3}
-    \int_0^{E_0} g(E) E \, \mathrm{d}E
-    $$
+```math
+p
+=
+\frac{2}{3}
+\int_0^{E_0} g(E) E \, \mathrm{d}E
+```
 
-    which can be written as
+which can be written as
 
-    $$
-    p
-    =
-    \frac{M S_0 \tau_s V_c^2}{3}
-    \int_0^{x_c}
-    \frac{x^4}{1+x^3}\,\mathrm{d}x
-    $$
+```math
+p
+=
+\frac{M S_0 \tau_s V_c^2}{3}
+\int_0^{x_c}
+\frac{x^4}{1+x^3}\,\mathrm{d}x
+```
 
-    and evaluated analytically as
+and evaluated analytically as
 
-    $$
-    p
-    =
-    \frac{M S_0 \tau_s V_c^2}{3}
-    \left[
-    \frac{x_c^2}{2}
-    +
-    \frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
-    -
-    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
-    -
-    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
-    \right]
-    $$
+```math
+p
+=
+\frac{M S_0 \tau_s V_c^2}{3}
+\left[
+\frac{x_c^2}{2}
++
+\frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+-
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+-
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
+\right]
+```
 
-    `fast_ion_pressure_integral()` returns the bracketed dimensionless factor only.
+`fast_ion_pressure_integral()` returns the bracketed dimensionless factor only.
 
-    $\blacksquare$
+$\blacksquare$
 
-    --
+--
 6. **Calculate the deposited fast ion energy from the pressure**
 
-    The deposited beam ion energy is inferred from the pressure relation
+The deposited beam ion energy is inferred from the pressure relation
 
-    $$
-    p = \frac{1}{3}nmv_{\text{rms}}^2 = \frac{2}{3}n\langle E\rangle
-    $$
+```math
+p = \frac{1}{3}nmv_{\text{rms}}^2 = \frac{2}{3}n\langle E\rangle
+```
 
-    so that the pressure-equivalent deposited energies are
+so that the pressure-equivalent deposited energies are
 
-    $$
-    E_{\text{hot,D}}
-    =
-    \frac{3}{2}
-    \frac{p_{\text{D}}}{\langle n_{\text{beam}} \rangle_{\text{D}}}
-    $$
+```math
+E_{\text{hot,D}}
+=
+\frac{3}{2}
+\frac{p_{\text{D}}}{\langle n_{\text{beam}} \rangle_{\text{D}}}
+```
 
-    $$
-    E_{\text{hot,T}}
-    =
-    \frac{3}{2}
-    \frac{p_{\text{T}}}{\langle n_{\text{beam}} \rangle_{\text{T}}}
-    $$
+```math
+E_{\text{hot,T}}
+=
+\frac{3}{2}
+\frac{p_{\text{T}}}{\langle n_{\text{beam}} \rangle_{\text{T}}}
+```
 
-    with the convention that the deposited energy is set to zero if the corresponding hot beam density is zero.
+with the convention that the deposited energy is set to zero if the corresponding hot beam density is zero.
 
-    The total deposited beam ion energy returned to `beam_fusion()` is the density-weighted average:
+The total deposited beam ion energy returned to `beam_fusion()` is the density-weighted average:
 
-    $$
-    E_{\text{hot,total}}
-    =
-    \frac{
-    E_{\text{hot,D}} \langle n_{\text{beam}} \rangle_{\text{D}}
-    +
-    E_{\text{hot,T}} \langle n_{\text{beam}} \rangle_{\text{T}}
-    }
-    {\langle n_{\text{beam}} \rangle_{\text{hot}}}
-    $$
+```math
+E_{\text{hot,total}}
+=
+\frac{
+E_{\text{hot,D}} \langle n_{\text{beam}} \rangle_{\text{D}}
++
+E_{\text{hot,T}} \langle n_{\text{beam}} \rangle_{\text{T}}
+}
+{\langle n_{\text{beam}} \rangle_{\text{hot}}}
+```
 
-    with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle_{\text{hot}}=0$.
+with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle_{\text{hot}}=0$.
 
-7. **Return the slowing-down state**
+1. **Return the slowing-down state**
 
-    `beam_slowing_down_state()` returns:
+`beam_slowing_down_state()` returns:
 
-    - deuterium beam ion density,
-    - tritium beam ion density,
-    - deuterium critical speed,
-    - tritium critical speed,
-    - total hot beam ion density,
-    - density-weighted deposited beam energy.
+- deuterium beam ion density,
+- tritium beam ion density,
+- deuterium critical speed,
+- tritium critical speed,
+- total hot beam ion density,
+- density-weighted deposited beam energy.
 
 ## Beam fusion reaction rate coefficient | `beam_reaction_rate_coefficient()`
 
 1. **Calculate the beam velocity**
 
-    The beam velocity is calculated from the input beam energy and beam ion mass:
+The beam velocity is calculated from the input beam energy and beam ion mass:
 
-    $$
-    v_{\text{beam}}
-    =
-    \sqrt{
-    \frac{2 e_{\text{keV}} E_{\text{beam}}}
-    {m_u A}
-    }
-    $$
+```math
+v_{\text{beam}}
+=
+\sqrt{
+\frac{2 e_{\text{keV}} E_{\text{beam}}}
+{m_u A}
+}
+```
 
-2. **Define the integral coefficient**
+1. **Define the integral coefficient**
 
-    The implemented coefficient is
+The implemented coefficient is
 
-    $$
-    \frac{3v_{\text{crit}}}
-    {\ln\left(1+\left(\frac{v_{\text{beam}}}{v_{\text{crit}}}\right)^3\right)}
-    $$
+```math
+\frac{3v_{\text{crit}}}
+{\ln\left(1+\left(\frac{v_{\text{beam}}}{v_{\text{crit}}}\right)^3\right)}
+```
 
-3. **Perform the fusion rate integral**
+1. **Perform the fusion rate integral**
 
-    The slowing-down-weighted integral is evaluated as
+The slowing-down-weighted integral is evaluated as
 
-    $$
-    \int_0^{v_{\text{beam}}/v_{\text{crit}}}
-    \frac{u^3}{1+u^3}
-    \sigma_{\text{bmfus}}(E_{\text{amu}}(u))
-    \,\mathrm{d}u
-    $$
+```math
+\int_0^{v_{\text{beam}}/v_{\text{crit}}}
+\frac{u^3}{1+u^3}
+\sigma_{\text{bmfus}}(E_{\text{amu}}(u))
+\,\mathrm{d}u
+```
 
-    where $u = v/v_{\text{crit}}$.
+where $u = v/v_{\text{crit}}$.
 
-    The quantity returned by `_beam_fusion_cross_section()` is in cm$^2$, so the integrated area is converted to m$^2$ before forming the final rate coefficient.
+The quantity returned by `_beam_fusion_cross_section()` is in cm$^2$, so the integrated area is converted to m$^2$ before forming the final rate coefficient.
 
 ### Hot beam fusion reaction rate integrand | `_hot_beam_fusion_reaction_rate_integrand()`
 
@@ -635,9 +641,9 @@ This internal function evaluates the integrand used in the beam-target fusion ra
 
 The implemented integrand is
 
-$$
+```math
 \frac{u^3}{1+u^3}\sigma_{\text{bmfus}}(E_{\text{amu}}(u))
-$$
+```
 
 where:
 
@@ -647,11 +653,11 @@ where:
 
 The beam kinetic energy per amu used in the code is constructed from
 
-$$
+```math
 E_{\text{amu}}
 =
 \frac{(u v_{\text{crit}})^2 m_u}{e_{\text{keV}}}
-$$
+```
 
 #### Beam fusion cross section | `_beam_fusion_cross_section()`
 
@@ -661,7 +667,7 @@ The plasma ions are assumed to be stationary.
 
 The implementation is
 
-$$
+```math
 \sigma_{\text{bm}}(E) =
 \begin{cases}
 1.0\times10^{-27}\ \text{cm}^2, & E < 10.0\ \text{keV} \\
@@ -676,15 +682,15 @@ E\left[\exp\left(\dfrac{a_1}{\sqrt{E}}\right)-1.0\right]
 }
 \ \text{cm}^2, & \text{otherwise}
 \end{cases}
-$$
+```
 
 where the beam energy used inside the fit is
 
-$$
+```math
 E
 =
 \frac{1}{2} A_{\text{D}} E_{\text{amu}}
-$$
+```
 
 and the constants are
 
@@ -700,7 +706,7 @@ The exact provenance of this particular fit and its coefficients has not yet bee
 
 The final effective beam-target fusion rate coefficient is
 
-$$
+```math
 \langle \sigma v \rangle_{\text{beam}}
 =
 \frac{3v_{\text{crit}}}
@@ -709,20 +715,20 @@ $$
 \frac{u^3}{1+u^3}
 \sigma_{\text{bmfus}}(E_{\text{amu}}(u))
 \,\mathrm{d}u
-$$
+```
 
 ## Beam-target fusion reaction rate | `beam_target_reaction_rate()`
 
 The present implementation evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population. This is consistent with simple beam-plasma reaction-rate models in which fast ions interact with a Maxwellian background plasma during the slowing-down process[^4]. The total beam-target fusion reaction rate is calculated as
 
-$$
+```math
 R_{\text{beam-target}}
 =
 n_{\text{beam}}
 n_{\text{target}}
 \langle \sigma v \rangle_{\text{beam}}
 V_{\text{plasma}}
-$$
+```
 
 where:
 
@@ -737,11 +743,11 @@ This returns the total reaction rate in s$^{-1}$.
 
 The beam-target alpha power is obtained from the total beam-target reaction rate by
 
-$$
+```math
 P_{\alpha,\text{beam}}
 =
 R_{\text{beam-target}} E_{\alpha}
-$$
+```
 
 and is converted from W to MW in the implementation.
 
@@ -751,41 +757,41 @@ This returns the alpha power in MW.
 
 For the deuterium beam component reacting with thermal tritium:
 
-$$
+```math
 R_{\text{D-beam,DT}}
 =
 \langle n_{\text{beam}} \rangle_{\text{D}}
 n_{\text{T,plasma}}
 \langle \sigma v \rangle_{\text{beam,D}}
 V_{\text{plasma}}
-$$
+```
 
-$$
+```math
 P_{\alpha,\text{D-beam}}
 =
 R_{\text{D-beam,DT}} E_{\alpha}
-$$
+```
 
 For the tritium beam component reacting with thermal deuterium:
 
-$$
+```math
 R_{\text{T-beam,DT}}
 =
 \langle n_{\text{beam}} \rangle_{\text{T}}
 n_{\text{D,plasma}}
 \langle \sigma v \rangle_{\text{beam,T}}
 V_{\text{plasma}}
-$$
+```
 
-$$
+```math
 P_{\alpha,\text{T-beam}}
 =
 R_{\text{T-beam,DT}} E_{\alpha}
-$$
+```
 
 The returned beam alpha power is then
 
-$$
+```math
 P_{\alpha,\text{beam}}
 =
 \mathtt{beamfus0}
@@ -794,7 +800,7 @@ P_{\alpha,\text{D-beam}}
 +
 P_{\alpha,\text{T-beam}}
 \right)
-$$
+```
 
 ## Key Constraints
 

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -567,14 +567,14 @@ $$
 \text{E}_{\text{hot,D}}
 =
 \frac{3}{2}
-\frac{\text{p}_{\text{D}}}{\langle \text{n}_{\text{beam}} \rangle_{\text{D}}}
+\frac{\text{p}_{\text{D}}}{\text{n}_{\text{beam,D}}}
 $$
 
 $$
 \text{E}_{\text{hot,T}}
 =
 \frac{3}{2}
-\frac{\text{p}_{\text{T}}}{\langle \text{n}_{\text{beam}} \rangle_{\text{T}}}
+\frac{\text{p}_{\text{T}}}{\text{n}_{\text{beam,T}}}
 $$
 
 with the convention that the deposited energy is set to zero if the corresponding hot beam density is zero.
@@ -585,16 +585,16 @@ $$
 \text{E}_{\text{hot,total}}
 =
 \frac{
-\text{E}_{\text{hot,D}} \langle \text{n}_{\text{beam}} \rangle_{\text{D}}
+\text{E}_{\text{hot,D}} \text{n}_{\text{beam,D}}
 +
-\text{E}_{\text{hot,T}} \langle \text{n}_{\text{beam}} \rangle_{\text{T}}
+\text{E}_{\text{hot,T}} \text{n}_{\text{beam,T}}
 }
-{\langle \text{n}_{\text{beam}} \rangle_{\text{hot}}}
+{\text{n}_{\text{beam,hot}}}
 $$
 
 with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle_{\text{hot}}=0$.
 
-### Return the slowing-down state {#beam-slowing-down-state}
+### Return the slowing-down state
 
 `beam_slowing_down_state()` returns the key quantities describing the steady-state fast-ion population:
 
@@ -736,7 +736,7 @@ $$
 
 ## Beam-target fusion reaction rate | `beam_target_reaction_rate()` {#beam-target-reaction-rate}
 
-`beam_target_reaction_rate()` calculates the total beam-target fusion reaction rate from the hot beam ion density, thermal target ion density, effective beam-target rate coefficient, and plasma volume:
+`beam_target_reaction_rate()` calculates the total beam-target fusion reaction rate from the hot beam ion density, thermal target ion density, effective beam-target rate coefficient, and plasma volume. This is consistent with simple beam-plasma reaction-rate models in which fast ions interact with a Maxwellian background plasma during the slowing-down process[^niikura1990].
 
 $$
 \text{R}_{\text{beam-target}}
@@ -781,7 +781,7 @@ For the deuterium beam component reacting with thermal tritium:
 $$
 \text{R}_{\text{D-beam,DT}}
 =
-\langle \text{n}_{\text{beam}} \rangle_{\text{D}}
+\text{n}_{\text{beam,D}}
 \text{n}_{\text{T,plasma}}
 \langle \sigma \text{v} \rangle_{\text{beam,D}}
 \text{V}_{\text{plasma}}
@@ -798,7 +798,7 @@ For the tritium beam component reacting with thermal deuterium:
 $$
 \text{R}_{\text{T-beam,DT}}
 =
-\langle \text{n}_{\text{beam}} \rangle_{\text{T}}
+\text{n}_{\text{beam,T}}
 \text{n}_{\text{D,plasma}}
 \langle \sigma \text{v} \rangle_{\text{beam,T}}
 \text{V}_{\text{plasma}}
@@ -842,3 +842,5 @@ The desired value of the hot ion beam density calculated from the code (`nd_beam
 [^deng1987]: B. Deng and G. A. Emmert, “Fast ion pressure in fusion plasma,” *Nuclear Fusion and Plasma Physics*, vol. 9, no. 3, pp. 136–141, 1987. Available: <https://fti.neep.wisc.edu/fti.neep.wisc.edu/pdf/fdm718.pdf>
 
 [^wesson2011]: J. Wesson, *Tokamaks*, 4th ed., Oxford Science Publications, 2011.
+
+[^niikura1990]: S. Niikura and M. Nagami, “Improvement of fusion reactivity and fusion power multiplication factor in the presence of fast ions,” *Fusion Engineering and Design*, vol. 12, pp. 467–480, 1990.

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -210,6 +210,8 @@ In this regime, $\tau_{\text{slow}}$ is the characteristic electron-drag slowing
 
 $\blacksquare$
 
+---
+
 #### Set the plasma deuterium and tritium ion densities
 
 The bulk target ion densities used in the beam-target reactions are
@@ -551,6 +553,8 @@ $$
 
 $\blacksquare$
 
+---
+
 ### Calculate the deposited fast ion energy from the pressure
 
 The deposited beam ion energy is inferred from the pressure relation
@@ -644,6 +648,8 @@ where $u = v/v_{\text{crit}}$.
 
 The quantity returned by `_beam_fusion_cross_section()` is in cm$^2$, so the integrated area is converted to m$^2$ before forming the final rate coefficient.
 
+---
+
 ### Hot beam fusion reaction rate integrand | `_hot_beam_fusion_reaction_rate_integrand()`
 
 This internal function evaluates the integrand used in the beam-target fusion rate coefficient.
@@ -710,6 +716,8 @@ and the constants are
 - $a_5 = 4.09 \times 10^2$
 
 The exact provenance of this particular fit and its coefficients has not yet been fully traced in the present documentation. It is retained here to document the current implementation.
+
+---
 
 ### Multiply by the coefficient to get the full rate coefficient
 
@@ -826,6 +834,8 @@ $$
 This constraint can be activated by stating `icc = 7` in the input file.
 
 The desired value of the hot ion beam density calculated from the code (`nd_beam_ions_out`) can be constrained using the input variable `f_nd_beam_electron`, which is the ratio of the beam density to the plasma electron density. It can be set as an iteration variable by setting `ixc = 7`.
+
+---
 
 ## References
 

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -582,7 +582,7 @@ with the convention that the deposited energy is set to zero if the correspondin
 The total deposited beam ion energy returned to `beam_fusion()` is the density-weighted average beam ion energy:
 
 $$
-\text{E}_{\text{hot,total}}
+\langle \text{E}_{\text{hot}} \rangle_{\text{beam}}
 =
 \frac{
 \text{E}_{\text{hot,D}} \, \text{n}_{\text{beam,D}}
@@ -590,6 +590,10 @@ $$
 \text{E}_{\text{hot,T}} \, \text{n}_{\text{beam,T}}
 }
 {\text{n}_{\text{beam,hot}}}
+$$
+
+$$
+\text{E}_{\text{hot,total}} = \langle \text{E}_{\text{hot}} \rangle_{\text{beam}}
 $$
 
 with the convention that this is set to zero if $\text{n}_{\text{beam,hot}} = 0$. This represents a density-weighted average over the deuterium and tritium fast-ion populations.

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -738,7 +738,7 @@ $$
 
 ## Beam-target fusion reaction rate | `beam_target_reaction_rate()` {#beam-target-reaction-rate}
 
-The present implementation evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population. This is consistent with simple beam-plasma reaction-rate models in which fast ions interact with a Maxwellian background plasma during the slowing-down process[^niikura1990]. The total beam-target fusion reaction rate is calculated as
+`beam_target_reaction_rate()` calculates the total beam-target fusion reaction rate from the hot beam ion density, thermal target ion density, effective beam-target rate coefficient, and plasma volume:
 
 $$
 \text{R}_{\text{beam-target}}
@@ -751,12 +751,12 @@ $$
 
 where:
 
-- $n_{\text{beam}}$ is the hot beam ion density,
-- $n_{\text{target}}$ is the thermal target ion density,
+- $\text{n}_{\text{beam}}$ is the hot beam ion density,
+- $\text{n}_{\text{target}}$ is the thermal target ion density,
 - $\langle \sigma v \rangle_{\text{beam}}$ is the effective beam-target rate coefficient,
-- $V_{\text{plasma}}$ is the plasma volume.
+- $\text{V}_{\text{plasma}}$ is the plasma volume.
 
-This returns the total reaction rate in s$^{-1}$.
+This returns the total reaction rate in $\text{s}^{-1}$.
 
 ---
 
@@ -844,5 +844,3 @@ The desired value of the hot ion beam density calculated from the code (`nd_beam
 [^deng1987]: B. Deng and G. A. Emmert, “Fast ion pressure in fusion plasma,” *Nuclear Fusion and Plasma Physics*, vol. 9, no. 3, pp. 136–141, 1987. Available: <https://fti.neep.wisc.edu/fti.neep.wisc.edu/pdf/fdm718.pdf>
 
 [^wesson2011]: J. Wesson, *Tokamaks*, 4th ed., Oxford Science Publications, 2011.
-
-[^niikura1990]: S. Niikura and M. Nagami, “Improvement of fusion reactivity and fusion power multiplication factor in the presence of fast ions,” *Fusion Engineering and Design*, vol. 12, pp. 467–480, 1990.

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -54,7 +54,7 @@ Please see the [H&CD section](../../eng-models/heating_and_current_drive/heating
 
 ## Beam slowing down properties | `beam_fusion()`
 
-This section explains the stages of calculation in the function `beam_fusion()`
+This section explains the stages of calculation in the function `beam_fusion()`.
 
 ### Calculate the beam ion slowing down time
 
@@ -234,11 +234,11 @@ where $n_{\text{fuel}}$ is the volume-averaged total fuel ion density.
 
 ### Calculate the beam alpha powers, beam densities and deposited energy
 
-[`beam_slowing_down_state()`](#neutral-beam-alpha-power-beam-densities-and-deposited-energy--beam_slowing_down_state) is run to calculate the hot beam densities, critical speeds, and deposited beam energy.
+[`beam_slowing_down_state()`](#beam-slowing-down-state) is run to calculate the hot beam densities, critical speeds, and deposited beam energy.
 
-[`beam_reaction_rate_coefficient()`](#beam-fusion-reaction-rate-coefficient--beam_reaction_rate_coefficient) is then run for the deuterium and tritium beam components to obtain effective beam-target rate coefficients.
+[`beam_reaction_rate_coefficient()`](#beam-reaction-rate-coefficient) is then run for the deuterium and tritium beam components to obtain effective beam-target rate coefficients.
 
-[`beam_target_reaction_rate()`](#beam-target-fusion-reaction-rate--beam_target_reaction_rate) and [`alpha_power_beam()`](#beam-fusion-alpha-power--alpha_power_beam) are used to convert these into alpha power.
+[`beam_target_reaction_rate()`](#beam-target-reaction-rate) and [`alpha_power_beam()`](#alpha-power-beam) are used to convert these into alpha power.
 
 ### Set the returned alpha power
 
@@ -282,7 +282,7 @@ The value of $E_{\text{beam,deposited}}$ is the pressure-equivalent deposited en
 
 ---
 
-## Neutral beam alpha power, beam densities and deposited energy | `beam_slowing_down_state()`
+## Neutral beam alpha power, beam densities and deposited energy | `beam_slowing_down_state()` {#beam-slowing-down-state}
 
 ### Calculate the beam current fractions
 
@@ -592,9 +592,9 @@ $$
 
 with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle_{\text{hot}}=0$.
 
-1. **Return the slowing-down state**
+### Return the slowing-down state {#beam-slowing-down-state}
 
-`beam_slowing_down_state()` returns:
+`beam_slowing_down_state()` returns the key quantities describing the steady-state fast-ion population:
 
 - deuterium beam ion density,
 - tritium beam ion density,
@@ -605,7 +605,7 @@ with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle
 
 ---
 
-## Beam fusion reaction rate coefficient | `beam_reaction_rate_coefficient()`
+## Beam fusion reaction rate coefficient | `beam_reaction_rate_coefficient()` {#beam-reaction-rate-coefficient}
 
 ### Calculate the beam velocity
 
@@ -658,7 +658,7 @@ where:
 
 - $u$ is the ratio of the instantaneous beam speed to the critical speed,
 - $E_{\text{amu}}(u)$ is the instantaneous beam kinetic energy per amu,
-- $\sigma_{\text{bmfus}}$ is returned by [`_beam_fusion_cross_section()`](#beam-fusion-cross-section--_beam_fusion_cross_section).
+- $\sigma_{\text{bmfus}}$ is returned by [`_beam_fusion_cross_section()`](#beam-fusion-cross-section).
 
 The beam kinetic energy per amu used in the code is constructed from
 
@@ -668,7 +668,7 @@ $$
 \frac{(\text{u} \text{v}_{\text{crit}})^2 \text{m}_{\text{u}}}{\text{e}_{\text{keV}}}
 $$
 
-#### Beam fusion cross section | `_beam_fusion_cross_section()`
+#### Beam fusion cross section | `_beam_fusion_cross_section()` {#beam-fusion-cross-section}
 
 This internal function returns the beam fusion cross-section fit used by the beam-target rate coefficient calculation. Note: the provenance of this fit is currently unverified in the documentation.
 
@@ -728,7 +728,7 @@ $$
 
 ---
 
-## Beam-target fusion reaction rate | `beam_target_reaction_rate()`
+## Beam-target fusion reaction rate | `beam_target_reaction_rate()` {#beam-target-reaction-rate}
 
 The present implementation evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population. This is consistent with simple beam-plasma reaction-rate models in which fast ions interact with a Maxwellian background plasma during the slowing-down process[^niikura1990]. The total beam-target fusion reaction rate is calculated as
 
@@ -752,7 +752,7 @@ This returns the total reaction rate in s$^{-1}$.
 
 ---
 
-## Beam fusion alpha power | `alpha_power_beam()`
+## Beam fusion alpha power | `alpha_power_beam()` {#alpha-power-beam}
 
 The beam-target alpha power is obtained from the total beam-target reaction rate by
 

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -620,11 +620,19 @@ with the convention that this is set to zero if $\text{n}_{\text{beam,hot}} = 0$
 The beam velocity is calculated from the input beam energy and beam ion mass:
 
 $$
-\text{v}_{\text{beam}}
-=
+\text{E}_{\text{beam}}[\mathrm{J}] =
+\text{E}_{\text{beam}}[\mathrm{keV}]
+\left(1.602176634\times10^{-16}\,\mathrm{J\,keV^{-1}}\right)
+$$
+
+$$
+\text{v}_{\text{beam}} =
 \sqrt{
-\frac{2 \text{e}_{\text{keV}} \text{E}_{\text{beam}}}
-{\text{m}_{\text{u}} \text{A}}
+\frac{
+2\,\text{E}_{\text{beam}}[\mathrm{J}]
+}{
+\text{A}\,\text{m}_{\text{u}}
+}
 }
 $$
 

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -579,20 +579,20 @@ $$
 
 with the convention that the deposited energy is set to zero if the corresponding hot beam density is zero.
 
-The total deposited beam ion energy returned to `beam_fusion()` is the density-weighted average:
+The total deposited beam ion energy returned to `beam_fusion()` is the density-weighted average beam ion energy:
 
 $$
 \text{E}_{\text{hot,total}}
 =
 \frac{
-\text{E}_{\text{hot,D}} \text{n}_{\text{beam,D}}
+\text{E}_{\text{hot,D}} \, \text{n}_{\text{beam,D}}
 +
-\text{E}_{\text{hot,T}} \text{n}_{\text{beam,T}}
+\text{E}_{\text{hot,T}} \, \text{n}_{\text{beam,T}}
 }
 {\text{n}_{\text{beam,hot}}}
 $$
 
-with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle_{\text{hot}}=0$.
+with the convention that this is set to zero if $\text{n}_{\text{beam,hot}} = 0$. This represents a density-weighted average over the deuterium and tritium fast-ion populations.
 
 ### Return the slowing-down state
 

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -2,7 +2,7 @@
 
 This page describes the neutral beam fusion model currently implemented in `beam_fusion()`.
 
-The model is a reduced beam–target treatment for neutral beam ions injected into the plasma. PROCESS first determines an effective beam current that already accounts for beam transport effects such as shine-through losses. The beam-fusion model then uses this net beam current to build a steady population of fast ions and estimates how many of those ions fuse with the background plasma. `beam_fusion()` does not explicitly model beam attenuation, orbit effects, or spatial beam evolution, and instead treats the fast-ion population in a volume-averaged (0D) sense.
+The model is a reduced beam-target treatment for neutral beam ions injected into the plasma. PROCESS first determines an effective beam current that already accounts for beam transport effects such as shine-through losses. The beam-fusion model then uses this net beam current to build a steady population of fast ions and estimates how many of those ions fuse with the background plasma. `beam_fusion()` does not explicitly model beam attenuation, orbit effects, or spatial beam evolution, and instead treats the fast-ion population in a volume-averaged (0D) sense.
 
 1. computes a beam slowing-down time and a critical energy for deuterium and tritium beam ions,
 2. estimates the steady-state hot beam ion densities from the beam source rate and slowing-down residence time,
@@ -53,19 +53,19 @@ This section explains the stages of calculation in the function `beam_fusion()`
 
 ### Calculate the beam ion slowing down time
 
-The beam slowing down time used in the model is implemented as [2]:
+The beam slowing down time used in the model is implemented as[^deng1987]:
 
-```math
+$$
 \tau_{\text{slow}} =
 1.99\times10^{19}
 \left[
-A_{\text{D}}\left(1-f_{\text{beam,T}}\right)
+\text{A}_{\text{D}}\left(1-\text{f}_{\text{beam,T}}\right)
 +
-A_{\text{T}}f_{\text{beam,T}}
+\text{A}_{\text{T}}\text{f}_{\text{beam,T}}
 \right]
-\frac{\langle T_{\text{e}}\rangle^{3/2}}
-{\langle n_{\text{e}}\rangle \ln \Lambda_{\text{ie}}}
-```
+\frac{\langle \text{T}_{\text{e}}\rangle^{3/2}}
+{\langle \text{n}_{\text{e}}\rangle \ln \Lambda_{\text{ie}}}
+$$
 
 where:
 
@@ -83,145 +83,145 @@ where:
 
 For an energetic ion slowing down in a plasma, there is a critical energy $E_{\text{crit}}$ at which the rate of energy loss to ions equals the rate of energy loss to electrons. Above this energy electron drag dominates, while below it ion drag dominates.
 
-In the current implementation, the deuterium critical energy [^1] is
+In the current implementation, the deuterium critical energy [^sheffield1994] is
 
-```math
-E_{\text{crit,D}} =
+$$
+\text{E}_{\text{crit,D}} =
 14.8
-A_{\text{D}}
-T_{\text{e}}
-Z_{\text{eff,mw}}^{2/3}
+\text{A}_{\text{D}}
+\text{T}_{\text{e}}
+\text{Z}_{\text{eff,mw}}^{2/3}
 \frac{\ln\Lambda_{\text{ie}}+4.0}{\ln\Lambda_{\text{ie}}}
 \qquad [\text{keV}]
-```
+$$
 
 where $Z_{\text{eff,mw}}$ is the mass-weighted effective plasma charge.
 
 The tritium critical energy is then scaled by the beam ion mass ratio:
 
-```math
-E_{\text{crit,T}} =
-E_{\text{crit,D}}
-\left(\frac{A_{\text{T}}}{A_{\text{D}}}\right)
-```
+$$
+\text{E}_{\text{crit,T}} =
+\text{E}_{\text{crit,D}}
+\left(\frac{\text{A}_{\text{T}}}{\text{A}_{\text{D}}}\right)
+$$
 
 #### Derivation of beam slowing down rate and critical energy
 
-The rate of slowing down of a test particle of mass $M$, charge $Ze$ and energy $E$, due to Coulomb collisions with a background species of mass $m_j$, charge $Z_j e$, density $n_j$ and temperature $T_j$, is given by[^2]
+The rate of slowing down of a test particle of mass $M$, charge $Ze$ and energy $E$, due to Coulomb collisions with a background species of mass $m_j$, charge $Z_j e$, density $n_j$ and temperature $T_j$, is given by[^deng1987]
 
-```math
-\frac{dE}{dt}
+$$
+\frac{\text{dE}}{\text{dt}}
 =
 \left[
--\Phi(x_j)
+-\Phi(\text{x}_{\text{j}})
 +
-x_j\left(1+\frac{m_j}{M}\,\Phi^{\prime}(x_j)\right)
+\text{x}_{\text{j}}\left(1+\frac{\text{m}_{\text{j}}}{\text{M}}\,\Phi^{\prime}(\text{x}_{\text{j}})\right)
 \right]
-\frac{4\pi n_j}{m_j V}
-\left(\frac{Z Z_j e^2}{4\pi\varepsilon_0}\right)^2
-\ln \Lambda_j
-```
+\frac{4\pi \text{n}_{\text{j}}}{\text{m}_{\text{j}} \text{V}}
+\left(\frac{\text{Z} \text{Z}_{\text{j}} \text{e}^2}{4\pi\varepsilon_0}\right)^2
+\ln \Lambda_{\text{j}}
+$$
 
 where
 
-```math
-\Phi^{\prime}(x) = \frac{d\Phi}{dx}
-```
+$$
+\Phi^{\prime}(\text{x}) = \frac{\text{d}\Phi}{\text{dx}}
+$$
 
-```math
-V = \sqrt{\frac{2E}{M}}, \qquad
-V_j = \sqrt{\frac{2kT_j}{m_j}}, \qquad
-x_j = \frac{V}{V_j}
-```
+$$
+\text{V} = \sqrt{\frac{2\text{E}}{\text{M}}}, \qquad
+\text{V}_{\text{j}} = \sqrt{\frac{2\text{kT}_{\text{j}}}{\text{m}_{\text{j}}}}, \qquad
+\text{x}_{\text{j}} = \frac{\text{V}}{\text{V}_{\text{j}}}
+$$
 
-For fast ions in fusion plasmas, the ion contribution and electron contribution may be approximated separately, leading to the standard slowing-down form[^3]:
+For fast ions in fusion plasmas, the ion contribution and electron contribution may be approximated separately, leading to the standard slowing-down form[^wesson2011]:
 
-```math
-\frac{\mathrm{d}E}{\mathrm{d}t}
+$$
+\frac{\mathrm{d}\text{E}}{\mathrm{d}\text{t}}
 =
--\frac{A Z^2 \sqrt{M}}{\sqrt{E}}
+-\frac{\text{A} \text{Z}^2 \sqrt{\text{M}}}{\sqrt{\text{E}}}
 -
-\frac{B Z^2 E}{M}
-```
+\frac{\text{B} \text{Z}^2 \text{E}}{\text{M}}
+$$
 
 with coefficients
 
-```math
+$$
 \begin{aligned}
-A &=
+\text{A} &=
 \frac{4\pi}{\sqrt{2}}
-\left(\frac{e^2}{4\pi\varepsilon_0}\right)^2
-\sum_j
+\left(\frac{\text{e}^2}{4\pi\varepsilon_0}\right)^2
+\sum_{\text{j}}
 \left(
-\frac{n_j Z_j^2}{m_j}\ln\Lambda_j
+\frac{\text{n}_{\text{j}} \text{Z}_{\text{j}}^2}{\text{m}_{\text{j}}}\ln\Lambda_{\text{j}}
 \right) \\
-B &=
-\frac{16\sqrt{\pi}}{3kT_e}
-\sqrt{\frac{m_e}{2kT_e}}
-\left(\frac{e^2}{4\pi\varepsilon_0}\right)^2
-n_e \ln\Lambda_e
+\text{B} &=
+\frac{16\sqrt{\pi}}{3\text{kT}_{\text{e}}}
+\sqrt{\frac{\text{m}_{\text{e}}}{2\text{kT}_{\text{e}}}}
+\left(\frac{\text{e}^2}{4\pi\varepsilon_0}\right)^2
+\text{n}_{\text{e}} \ln\Lambda_{\text{e}}
 \end{aligned}
-```
+$$
 
 This can be rewritten in the form
 
-```math
-\frac{\mathrm{d}E}{\mathrm{d}t}
+$$
+\frac{\mathrm{d}\text{E}}{\mathrm{d}\text{t}}
 =
--\frac{2E}{\tau_{\text{slow}}}
+-\frac{2\text{E}}{\tau_{\text{slow}}}
 \left[
-1+\left(\frac{E_c}{E}\right)^{3/2}
+1+\left(\frac{\text{E}_{\text{c}}}{\text{E}}\right)^{3/2}
 \right]
-```
+$$
 
 where
 
-```math
-E_c
+$$
+\text{E}_{\text{c}}
 =
 \left[
 \frac{3\sqrt{\pi}}{4}
-\frac{M^{3/2}}{n_e\sqrt{m_e}}
-\sum_j
+\frac{\text{M}^{3/2}}{\text{n}_{\text{e}}\sqrt{\text{m}_{\text{e}}}}
+\sum_{\text{j}}
 \left(
-\frac{n_j Z_j^2}{m_j}\ln\Lambda_j
+\frac{\text{n}_{\text{j}} \text{Z}_{\text{j}}^2}{\text{m}_{\text{j}}}\ln\Lambda_{\text{j}}
 \right)
-\frac{1}{\ln\Lambda_e}
+\frac{1}{\ln\Lambda_{\text{e}}}
 \right]^{2/3}
-kT_e
-```
+\text{kT}_{\text{e}}
+$$
 
 and
 
-```math
+$$
 \tau_{\text{slow}}
 =
-\frac{3(kT_e)^{3/2}}{4\sqrt{2\pi m_e} Z^2}
-\left(\frac{4\pi\varepsilon_0}{e^2}\right)^2
-\frac{M}{n_e \ln\Lambda_e}
-```
+\frac{3(\text{kT}_{\text{e}})^{3/2}}{4\sqrt{2\pi \text{m}_{\text{e}}} \text{Z}^2}
+\left(\frac{4\pi\varepsilon_0}{\text{e}^2}\right)^2
+\frac{\text{M}}{\text{n}_{\text{e}} \ln\Lambda_{\text{e}}}
+$$
 
 In this regime, $\tau_{\text{slow}}$ is the characteristic electron-drag slowing-down timescale.
 
 $\blacksquare$
 
-#### **Set the plasma deuterium and tritium ion densities**
+#### Set the plasma deuterium and tritium ion densities
 
 The bulk target ion densities used in the beam-target reactions are
 
-```math
-n_{\text{D,plasma}}
+$$
+\text{n}_{\text{D,plasma}}
 =
-n_{\text{fuel}}
-f_{\text{D,plasma}}
-```
+\text{n}_{\text{fuel}}
+\text{f}_{\text{D,plasma}}
+$$
 
-```math
-n_{\text{T,plasma}}
+$$
+\text{n}_{\text{T,plasma}}
 =
-n_{\text{fuel}}
-f_{\text{T,plasma}}
-```
+\text{n}_{\text{fuel}}
+\text{f}_{\text{T,plasma}}
+$$
 
 where $n_{\text{fuel}}$ is the volume-averaged total fuel ion density.
 
@@ -239,22 +239,22 @@ where $n_{\text{fuel}}$ is the volume-averaged total fuel ion density.
 
 The total neutral beam alpha power is
 
-```math
-P_{\alpha,\text{beam}}
+$$
+\text{P}_{\alpha,\text{beam}}
 =
 \mathtt{beamfus0}
 \left(
-P_{\alpha,\text{D-beam}}
+\text{P}_{\alpha,\text{D-beam}}
 +
-P_{\alpha,\text{T-beam}}
+\text{P}_{\alpha,\text{T-beam}}
 \right)
-```
+$$
 
 ### Calculate the neutral beam beta
 
 The neutral beam beta is computed from the hot beam density and the deposited beam energy:
 
-```math
+$$
 \beta_{\text{beam}}
 =
 \mathtt{betbm0}
@@ -262,9 +262,9 @@ The neutral beam beta is computed from the hot beam density and the deposited be
 4.03\times10^{-22}
 \times
 \frac{2}{3}
-\frac{n_{\text{beam,hot}} E_{\text{beam,deposited}}}
-{B_{\phi}^2 + B_{\theta}^2}
-```
+\frac{\text{n}_{\text{beam,hot}} \text{E}_{\text{beam,deposited}}}
+{\text{B}_{\phi}^2 + \text{B}_{\theta}^2}
+$$
 
 where:
 
@@ -275,188 +275,190 @@ where:
 
 The value of $E_{\text{beam,deposited}}$ is the pressure-equivalent deposited energy of the hot beam ions, **not** the initial beam injection energy.
 
+---
+
 ## Neutral beam alpha power, beam densities and deposited energy | `beam_slowing_down_state()`
 
-1. **Calculate the beam current fractions**
+### Calculate the beam current fractions
 
 The beam current is split into deuterium and tritium components:
 
-```math
-I_{\text{beam,D}}
+$$
+\text{I}_{\text{beam,D}}
 =
-I_{\text{beam}}
-\left(1-f_{\text{beam,T}}\right)
-```
+\text{I}_{\text{beam}}
+\left(1-\text{f}_{\text{beam,T}}\right)
+$$
 
-```math
-I_{\text{beam,T}}
+$$
+\text{I}_{\text{beam,T}}
 =
-I_{\text{beam}}
-f_{\text{beam,T}}
-```
+\text{I}_{\text{beam}}
+\text{f}_{\text{beam,T}}
+$$
 
-1. **Calculate the characteristic slowing-down time to the thermal range**
+### Calculate the characteristic slowing-down time to the thermal range
 
 Using the classical slowing-down model, the characteristic time for the beam ion energy to slow from the birth energy to the thermal range is implemented as:
 
-```math
+$$
 \tau_{\text{slow,D}}^{*}
 =
 \frac{\tau_{\text{slow}}}{3}
 \ln\left[
 1+
 \left(
-\frac{E_{\text{beam}}}{E_{\text{crit,D}}}
+\frac{\text{E}_{\text{beam}}}{\text{E}_{\text{crit,D}}}
 \right)^{3/2}
 \right]
-```
+$$
 
-```math
+$$
 \tau_{\text{slow,T}}^{*}
 =
 \frac{\tau_{\text{slow}}}{3}
 \ln\left[
 1+
 \left(
-\frac{E_{\text{beam}}}{E_{\text{crit,T}}}
+\frac{\text{E}_{\text{beam}}}{\text{E}_{\text{crit,T}}}
 \right)^{3/2}
 \right]
-```
+$$
 
-1. **Set the fast beam ion densities**
+### Set the fast beam ion densities
 
 The steady-state hot beam ion densities are set from source rate times residence time:
 
-```math
-\langle n_{\text{beam}} \rangle_{\text{D}}
+$$
+\langle \text{n}_{\text{beam}} \rangle_{\text{D}}
 =
-\frac{I_{\text{beam,D}}\tau_{\text{slow,D}}^{*}}
-{e V_{\text{plasma}}}
-```
+\frac{\text{I}_{\text{beam,D}}\tau_{\text{slow,D}}^{*}}
+{\text{e} \text{V}_{\text{plasma}}}
+$$
 
-```math
-\langle n_{\text{beam}} \rangle_{\text{T}}
+$$
+\langle \text{n}_{\text{beam}} \rangle_{\text{T}}
 =
-\frac{I_{\text{beam,T}}\tau_{\text{slow,T}}^{*}}
-{e V_{\text{plasma}}}
-```
+\frac{\text{I}_{\text{beam,T}}\tau_{\text{slow,T}}^{*}}
+{\text{e} \text{V}_{\text{plasma}}}
+$$
 
 The total hot beam ion density is then
 
-```math
-\langle n_{\text{beam}} \rangle_{\text{hot}}
+$$
+\langle \text{n}_{\text{beam}} \rangle_{\text{hot}}
 =
-\langle n_{\text{beam}} \rangle_{\text{D}}
+\langle \text{n}_{\text{beam}} \rangle_{\text{D}}
 +
-\langle n_{\text{beam}} \rangle_{\text{T}}
-```
+\langle \text{n}_{\text{beam}} \rangle_{\text{T}}
+$$
 
-1. **Calculate the speeds of ions at the critical energy**
+### Calculate the speeds of ions at the critical energy
 
 Assuming non-relativistic energies, the beam ion speeds at the critical energy are
 
-```math
-v_{\text{crit,D}}
+$$
+\text{v}_{\text{crit,D}}
 =
 \sqrt{
-\frac{2 e_{\text{keV}} E_{\text{crit,D}}}
-{m_u A_{\text{D}}}
+\frac{2 \text{e}_{\text{keV}} \text{E}_{\text{crit,D}}}
+{\text{m}_{\text{u}} \text{A}_{\text{D}}}
 }
-```
+$$
 
-```math
-v_{\text{crit,T}}
+$$
+\text{v}_{\text{crit,T}}
 =
 \sqrt{
-\frac{2 e_{\text{keV}} E_{\text{crit,T}}}
-{m_u A_{\text{T}}}
+\frac{2 \text{e}_{\text{keV}} \text{E}_{\text{crit,T}}}
+{\text{m}_{\text{u}} \text{A}_{\text{T}}}
 }
-```
+$$
 
 where:
 
 - $e_{\text{keV}}$ is the conversion from keV to joules,
 - $m_u$ is the atomic mass unit.
 
-1. **Calculate the fast ion pressures**
+### Calculate the fast ion pressures
 
 First define the source rates per unit volume:
 
-```math
-S_{\text{D}}
+$$
+\text{S}_{\text{D}}
 =
-\frac{I_{\text{beam,D}}}{e V_{\text{plasma}}}
-```
+\frac{\text{I}_{\text{beam,D}}}{\text{e} \text{V}_{\text{plasma}}}
+$$
 
-```math
-S_{\text{T}}
+$$
+\text{S}_{\text{T}}
 =
-\frac{I_{\text{beam,T}}}{e V_{\text{plasma}}}
-```
+\frac{\text{I}_{\text{beam,T}}}{\text{e} \text{V}_{\text{plasma}}}
+$$
 
 The implemented pressure coefficients are then
 
-```math
-C_{p,\text{D}}
+$$
+\text{C}_{\text{p},\text{D}}
 =
 \frac{
-A_{\text{D}} m_u \tau_{\text{slow}} v_{\text{crit,D}}^2 S_{\text{D}}
+\text{A}_{\text{D}} \text{m}_{\text{u}} \tau_{\text{slow}} \text{v}_{\text{crit,D}}^2 \text{S}_{\text{D}}
 }
-{3 e_{\text{keV}}}
-```
+{3 \text{e}_{\text{keV}}}
+$$
 
-```math
-C_{p,\text{T}}
+$$
+\text{C}_{\text{p},\text{T}}
 =
 \frac{
-A_{\text{T}} m_u \tau_{\text{slow}} v_{\text{crit,T}}^2 S_{\text{T}}
+\text{A}_{\text{T}} \text{m}_{\text{u}} \tau_{\text{slow}} \text{v}_{\text{crit,T}}^2 \text{S}_{\text{T}}
 }
-{3 e_{\text{keV}}}
-```
+{3 \text{e}_{\text{keV}}}
+$$
 
 The fast ion pressures are
 
-```math
-p_{\text{D}}
+$$
+\text{p}_{\text{D}}
 =
-C_{p,\text{D}}
+\text{C}_{\text{p},\text{D}}
 \times
 \underbrace{
 \left[
-\frac{x_c^2}{2}
+\frac{\text{x}_{\text{c}}^2}{2}
 +
-\frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+\frac{1}{6}\ln\left(\frac{\text{x}_{\text{c}}^2+2\text{x}_{\text{c}}+1}{\text{x}_{\text{c}}^2-\text{x}_{\text{c}}+1}\right)
 -
-\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2\text{x}_{\text{c}}-1}{\sqrt{3}}\right)
 -
 \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
 \right]
-}_{\mathtt{fast\_ion\_pressure\_integral}(E_{\text{beam}},E_{\text{crit,D}})}
-```
+}_{\mathtt{fast\_ion\_pressure\_integral}(\text{E}_{\text{beam}},\text{E}_{\text{crit,D}})}
+$$
 
-```math
-p_{\text{T}}
+$$
+\text{p}_{\text{T}}
 =
-C_{p,\text{T}}
+\text{C}_{\text{p},\text{T}}
 \times
 \underbrace{
 \left[
-\frac{x_c^2}{2}
+\frac{\text{x}_{\text{c}}^2}{2}
 +
-\frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+\frac{1}{6}\ln\left(\frac{\text{x}_{\text{c}}^2+2\text{x}_{\text{c}}+1}{\text{x}_{\text{c}}^2-\text{x}_{\text{c}}+1}\right)
 -
-\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2\text{x}_{\text{c}}-1}{\sqrt{3}}\right)
 -
 \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
 \right]
-}_{\mathtt{fast\_ion\_pressure\_integral}(E_{\text{beam}},E_{\text{crit,T}})}
-```
+}_{\mathtt{fast\_ion\_pressure\_integral}(\text{E}_{\text{beam}},\text{E}_{\text{crit,T}})}
+$$
 
 with
 
-```math
-x_c = \sqrt{\frac{E_{\text{beam}}}{E_{\text{crit}}}}
-```
+$$
+\text{x}_{\text{c}} = \sqrt{\frac{\text{E}_{\text{beam}}}{\text{E}_{\text{crit}}}}
+$$
 
 ### Beam fast ion pressure integral | `fast_ion_pressure_integral()`
 
@@ -468,121 +470,120 @@ The fast ions, because of their finite slowing down time, develop a finite press
 
 To calculate this pressure, introduce the distribution function $g(E)$ of fast ions, where $g(E)$ is the number of ions per unit energy per unit volume, satisfying the steady-state kinetic equation
 
-```math
-\frac{\partial}{\partial E}
+$$
+\frac{\partial}{\partial \text{E}}
 \left(
-g \frac{\mathrm{d}E}{\mathrm{d}t}
+\text{g} \frac{\mathrm{d}\text{E}}{\mathrm{d}\text{t}}
 \right)
 =
-S(E)
-```
+\text{S}(\text{E})
+$$
 
 with slowing-down law
 
-```math
-\frac{\mathrm{d}E}{\mathrm{d}t}
+$$
+\frac{\mathrm{d}\text{E}}{\mathrm{d}\text{t}}
 =
--\frac{2E}{\tau_s}
+-\frac{2\text{E}}{\tau_{\text{s}}}
 \left[
-1+\left(\frac{E_c}{E}\right)^{3/2}
+1+\left(\frac{\text{E}_{\text{c}}}{\text{E}}\right)^{3/2}
 \right]
-```
+$$
 
 If the ions are born monoenergetically,
 
-```math
-S(E)=S_0\delta(E-E_0)
-```
+$$
+\text{S}(\text{E})=\text{S}_0\delta(\text{E}-\text{E}_0)
+$$
 
 and with the boundary condition $g(E)=0$ for $E>E_0$, the steady-state distribution becomes
 
-```math
-g(E)=
+$$
+\text{g}(\text{E})=
 \begin{cases}
-\dfrac{S_0\tau_s}{2E\left[1+\left(E_c/E\right)^{3/2}\right]}, & E<E_0 \\
-0, & E>E_0
+\dfrac{\text{S}_0\tau_{\text{s}}}{2\text{E}\left[1+\left(\text{E}_{\text{c}}/\text{E}\right)^{3/2}\right]}, & \text{E}<\text{E}_0 \\
+0, & \text{E}>\text{E}_0
 \end{cases}
-```
+$$
 
 The fast ion pressure is then
 
-```math
-p
+$$
+\text{p}
 =
 \frac{2}{3}
-\int_0^{E_0} g(E) E \, \mathrm{d}E
-```
+\int_0^{\text{E}_0} \text{g}(\text{E}) \text{E} \, \mathrm{d}\text{E}
+$$
 
 which can be written as
 
-```math
-p
+$$
+\text{p}
 =
-\frac{M S_0 \tau_s V_c^2}{3}
-\int_0^{x_c}
-\frac{x^4}{1+x^3}\,\mathrm{d}x
-```
+\frac{\text{M} \text{S}_0 \tau_{\text{s}} \text{V}_{\text{c}}^2}{3}
+\int_0^{\text{x}_{\text{c}}}
+\frac{\text{x}^4}{1+\text{x}^3}\,\mathrm{d}\text{x}
+$$
 
 and evaluated analytically as
 
-```math
-p
+$$
+\text{p}
 =
-\frac{M S_0 \tau_s V_c^2}{3}
+\frac{\text{M} \text{S}_0 \tau_{\text{s}} \text{V}_{\text{c}}^2}{3}
 \left[
-\frac{x_c^2}{2}
+\frac{\text{x}_{\text{c}}^2}{2}
 +
-\frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+\frac{1}{6}\ln\left(\frac{\text{x}_{\text{c}}^2+2\text{x}_{\text{c}}+1}{\text{x}_{\text{c}}^2-\text{x}_{\text{c}}+1}\right)
 -
-\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+\frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2\text{x}_{\text{c}}-1}{\sqrt{3}}\right)
 -
 \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
 \right]
-```
+$$
 
 `fast_ion_pressure_integral()` returns the bracketed dimensionless factor only.
 
 $\blacksquare$
 
---
-6. **Calculate the deposited fast ion energy from the pressure**
+### Calculate the deposited fast ion energy from the pressure
 
 The deposited beam ion energy is inferred from the pressure relation
 
-```math
-p = \frac{1}{3}nmv_{\text{rms}}^2 = \frac{2}{3}n\langle E\rangle
-```
+$$
+\text{p} = \frac{1}{3}\text{nmv}_{\text{rms}}^2 = \frac{2}{3}\text{n}\langle \text{E}\rangle
+$$
 
 so that the pressure-equivalent deposited energies are
 
-```math
-E_{\text{hot,D}}
+$$
+\text{E}_{\text{hot,D}}
 =
 \frac{3}{2}
-\frac{p_{\text{D}}}{\langle n_{\text{beam}} \rangle_{\text{D}}}
-```
+\frac{\text{p}_{\text{D}}}{\langle \text{n}_{\text{beam}} \rangle_{\text{D}}}
+$$
 
-```math
-E_{\text{hot,T}}
+$$
+\text{E}_{\text{hot,T}}
 =
 \frac{3}{2}
-\frac{p_{\text{T}}}{\langle n_{\text{beam}} \rangle_{\text{T}}}
-```
+\frac{\text{p}_{\text{T}}}{\langle \text{n}_{\text{beam}} \rangle_{\text{T}}}
+$$
 
 with the convention that the deposited energy is set to zero if the corresponding hot beam density is zero.
 
 The total deposited beam ion energy returned to `beam_fusion()` is the density-weighted average:
 
-```math
-E_{\text{hot,total}}
+$$
+\text{E}_{\text{hot,total}}
 =
 \frac{
-E_{\text{hot,D}} \langle n_{\text{beam}} \rangle_{\text{D}}
+\text{E}_{\text{hot,D}} \langle \text{n}_{\text{beam}} \rangle_{\text{D}}
 +
-E_{\text{hot,T}} \langle n_{\text{beam}} \rangle_{\text{T}}
+\text{E}_{\text{hot,T}} \langle \text{n}_{\text{beam}} \rangle_{\text{T}}
 }
-{\langle n_{\text{beam}} \rangle_{\text{hot}}}
-```
+{\langle \text{n}_{\text{beam}} \rangle_{\text{hot}}}
+$$
 
 with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle_{\text{hot}}=0$.
 
@@ -597,40 +598,42 @@ with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle
 - total hot beam ion density,
 - density-weighted deposited beam energy.
 
+---
+
 ## Beam fusion reaction rate coefficient | `beam_reaction_rate_coefficient()`
 
-1. **Calculate the beam velocity**
+### Calculate the beam velocity
 
 The beam velocity is calculated from the input beam energy and beam ion mass:
 
-```math
-v_{\text{beam}}
+$$
+\text{v}_{\text{beam}}
 =
 \sqrt{
-\frac{2 e_{\text{keV}} E_{\text{beam}}}
-{m_u A}
+\frac{2 \text{e}_{\text{keV}} \text{E}_{\text{beam}}}
+{\text{m}_{\text{u}} \text{A}}
 }
-```
+$$
 
-1. **Define the integral coefficient**
+### Define the integral coefficient
 
 The implemented coefficient is
 
-```math
-\frac{3v_{\text{crit}}}
-{\ln\left(1+\left(\frac{v_{\text{beam}}}{v_{\text{crit}}}\right)^3\right)}
-```
+$$
+\frac{3\text{v}_{\text{crit}}}
+{\ln\left(1+\left(\frac{\text{v}_{\text{beam}}}{\text{v}_{\text{crit}}}\right)^3\right)}
+$$
 
-1. **Perform the fusion rate integral**
+### Perform the fusion rate integral
 
 The slowing-down-weighted integral is evaluated as
 
-```math
-\int_0^{v_{\text{beam}}/v_{\text{crit}}}
-\frac{u^3}{1+u^3}
-\sigma_{\text{bmfus}}(E_{\text{amu}}(u))
-\,\mathrm{d}u
-```
+$$
+\int_0^{\text{v}_{\text{beam}}/\text{v}_{\text{crit}}}
+\frac{\text{u}^3}{1+\text{u}^3}
+\sigma_{\text{bmfus}}(\text{E}_{\text{amu}}(\text{u}))
+\,\mathrm{d}\text{u}
+$$
 
 where $u = v/v_{\text{crit}}$.
 
@@ -642,9 +645,9 @@ This internal function evaluates the integrand used in the beam-target fusion ra
 
 The implemented integrand is
 
-```math
-\frac{u^3}{1+u^3}\sigma_{\text{bmfus}}(E_{\text{amu}}(u))
-```
+$$
+\frac{\text{u}^3}{1+\text{u}^3}\sigma_{\text{bmfus}}(\text{E}_{\text{amu}}(\text{u}))
+$$
 
 where:
 
@@ -654,11 +657,11 @@ where:
 
 The beam kinetic energy per amu used in the code is constructed from
 
-```math
-E_{\text{amu}}
+$$
+\text{E}_{\text{amu}}
 =
-\frac{(u v_{\text{crit}})^2 m_u}{e_{\text{keV}}}
-```
+\frac{(\text{u} \text{v}_{\text{crit}})^2 \text{m}_{\text{u}}}{\text{e}_{\text{keV}}}
+$$
 
 #### Beam fusion cross section | `_beam_fusion_cross_section()`
 
@@ -668,30 +671,30 @@ The plasma ions are assumed to be stationary.
 
 The implementation is
 
-```math
-\sigma_{\text{bm}}(E) =
+$$
+\sigma_{\text{bm}}(\text{E}) =
 \begin{cases}
-1.0\times10^{-27}\ \text{cm}^2, & E < 10.0\ \text{keV} \\
-8.0\times10^{-26}\ \text{cm}^2, & E > 10^4\ \text{keV} \\
+1.0\times10^{-27}\ \text{cm}^2, & \text{E} < 10.0\ \text{keV} \\
+8.0\times10^{-26}\ \text{cm}^2, & \text{E} > 10^4\ \text{keV} \\
 \dfrac{
 1.0\times10^{-24}
 \left[
-\dfrac{a_2}{1.0+(a_3 E-a_4)^2}+a_5
+\dfrac{\text{a}_2}{1.0+(\text{a}_3 \text{E}-\text{a}_4)^2}+\text{a}_5
 \right]
 }{
-E\left[\exp\left(\dfrac{a_1}{\sqrt{E}}\right)-1.0\right]
+\text{E}\left[\exp\left(\dfrac{\text{a}_1}{\sqrt{\text{E}}}\right)-1.0\right]
 }
 \ \text{cm}^2, & \text{otherwise}
 \end{cases}
-```
+$$
 
 where the beam energy used inside the fit is
 
-```math
-E
+$$
+\text{E}
 =
-\frac{1}{2} A_{\text{D}} E_{\text{amu}}
-```
+\frac{1}{2} \text{A}_{\text{D}} \text{E}_{\text{amu}}
+$$
 
 and the constants are
 
@@ -703,33 +706,35 @@ and the constants are
 
 The exact provenance of this particular fit and its coefficients has not yet been fully traced in the present documentation. It is retained here to document the current implementation.
 
-1. **Multiply by the coefficient to get the full rate coefficient**
+### Multiply by the coefficient to get the full rate coefficient
 
 The final effective beam-target fusion rate coefficient is
 
-```math
-\langle \sigma v \rangle_{\text{beam}}
+$$
+\langle \sigma \text{v} \rangle_{\text{beam}}
 =
-\frac{3v_{\text{crit}}}
-{\ln\left(1+\left(\frac{v_{\text{beam}}}{v_{\text{crit}}}\right)^3\right)}
-\int_0^{v_{\text{beam}}/v_{\text{crit}}}
-\frac{u^3}{1+u^3}
-\sigma_{\text{bmfus}}(E_{\text{amu}}(u))
-\,\mathrm{d}u
-```
+\frac{3\text{v}_{\text{crit}}}
+{\ln\left(1+\left(\frac{\text{v}_{\text{beam}}}{\text{v}_{\text{crit}}}\right)^3\right)}
+\int_0^{\text{v}_{\text{beam}}/\text{v}_{\text{crit}}}
+\frac{\text{u}^3}{1+\text{u}^3}
+\sigma_{\text{bmfus}}(\text{E}_{\text{amu}}(\text{u}))
+\,\mathrm{d}\text{u}
+$$
+
+---
 
 ## Beam-target fusion reaction rate | `beam_target_reaction_rate()`
 
-The present implementation evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population. This is consistent with simple beam-plasma reaction-rate models in which fast ions interact with a Maxwellian background plasma during the slowing-down process[^4]. The total beam-target fusion reaction rate is calculated as
+The present implementation evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population. This is consistent with simple beam-plasma reaction-rate models in which fast ions interact with a Maxwellian background plasma during the slowing-down process[^niikura1990]. The total beam-target fusion reaction rate is calculated as
 
-```math
-R_{\text{beam-target}}
+$$
+\text{R}_{\text{beam-target}}
 =
-n_{\text{beam}}
-n_{\text{target}}
-\langle \sigma v \rangle_{\text{beam}}
-V_{\text{plasma}}
-```
+\text{n}_{\text{beam}}
+\text{n}_{\text{target}}
+\langle \sigma \text{v} \rangle_{\text{beam}}
+\text{V}_{\text{plasma}}
+$$
 
 where:
 
@@ -740,68 +745,74 @@ where:
 
 This returns the total reaction rate in s$^{-1}$.
 
+---
+
 ## Beam fusion alpha power | `alpha_power_beam()`
 
 The beam-target alpha power is obtained from the total beam-target reaction rate by
 
-```math
-P_{\alpha,\text{beam}}
+$$
+\text{P}_{\alpha,\text{beam}}
 =
-R_{\text{beam-target}} E_{\alpha}
-```
+\text{R}_{\text{beam-target}} \text{E}_{\alpha}
+$$
 
 and is converted from W to MW in the implementation.
 
 This returns the alpha power in MW.
 
+---
+
 ## Full beam-target alpha power calculation in `beam_fusion()`
 
 For the deuterium beam component reacting with thermal tritium:
 
-```math
-R_{\text{D-beam,DT}}
+$$
+\text{R}_{\text{D-beam,DT}}
 =
-\langle n_{\text{beam}} \rangle_{\text{D}}
-n_{\text{T,plasma}}
-\langle \sigma v \rangle_{\text{beam,D}}
-V_{\text{plasma}}
-```
+\langle \text{n}_{\text{beam}} \rangle_{\text{D}}
+\text{n}_{\text{T,plasma}}
+\langle \sigma \text{v} \rangle_{\text{beam,D}}
+\text{V}_{\text{plasma}}
+$$
 
-```math
-P_{\alpha,\text{D-beam}}
+$$
+\text{P}_{\alpha,\text{D-beam}}
 =
-R_{\text{D-beam,DT}} E_{\alpha}
-```
+\text{R}_{\text{D-beam,DT}} \text{E}_{\alpha}
+$$
 
 For the tritium beam component reacting with thermal deuterium:
 
-```math
-R_{\text{T-beam,DT}}
+$$
+\text{R}_{\text{T-beam,DT}}
 =
-\langle n_{\text{beam}} \rangle_{\text{T}}
-n_{\text{D,plasma}}
-\langle \sigma v \rangle_{\text{beam,T}}
-V_{\text{plasma}}
-```
+\langle \text{n}_{\text{beam}} \rangle_{\text{T}}
+\text{n}_{\text{D,plasma}}
+\langle \sigma \text{v} \rangle_{\text{beam,T}}
+\text{V}_{\text{plasma}}
+$$
 
-```math
-P_{\alpha,\text{T-beam}}
+$$
+\text{P}_{\alpha,\text{T-beam}}
 =
-R_{\text{T-beam,DT}} E_{\alpha}
-```
+\text{R}_{\text{T-beam,DT}} \text{E}_{\alpha}
+$$
 
 The returned beam alpha power is then
 
-```math
-P_{\alpha,\text{beam}}
+$$
+\text{P}_{\alpha,\text{beam}}
 =
 \mathtt{beamfus0}
 \left(
-P_{\alpha,\text{D-beam}}
+\text{P}_{\alpha,\text{D-beam}}
 +
-P_{\alpha,\text{T-beam}}
+\text{P}_{\alpha,\text{T-beam}}
 \right)
-```
+$$
+
+---
 
 ## Key Constraints
 
@@ -813,10 +824,10 @@ The desired value of the hot ion beam density calculated from the code (`nd_beam
 
 ## References
 
-1. J. W. Sheffield, “The physics of magnetic fusion reactors,” *Rev. Mod. Phys.*, vol. 66, no. 3, pp. 1015–1103, Jul. 1994. <https://doi.org/10.1103/RevModPhys.66.1015>
+[^sheffield1994]: J. W. Sheffield, “The physics of magnetic fusion reactors,” *Rev. Mod. Phys.*, vol. 66, no. 3, pp. 1015–1103, Jul. 1994. <https://doi.org/10.1103/RevModPhys.66.1015>
 
-2. B. Deng and G. A. Emmert, “Fast ion pressure in fusion plasma,” *Nuclear Fusion and Plasma Physics*, vol. 9, no. 3, pp. 136–141, 1987. Available: <https://fti.neep.wisc.edu/fti.neep.wisc.edu/pdf/fdm718.pdf>
+[^deng1987]: B. Deng and G. A. Emmert, “Fast ion pressure in fusion plasma,” *Nuclear Fusion and Plasma Physics*, vol. 9, no. 3, pp. 136–141, 1987. Available: <https://fti.neep.wisc.edu/fti.neep.wisc.edu/pdf/fdm718.pdf>
 
-3. J. Wesson, *Tokamaks*, 4th ed., Oxford Science Publications, 2011.
+[^wesson2011]: J. Wesson, *Tokamaks*, 4th ed., Oxford Science Publications, 2011.
 
-4. S. Niikura and M. Nagami, “Improvement of fusion reactivity and fusion power multiplication factor in the presence of fast ions,” *Fusion Engineering and Design*, vol. 12, pp. 467–480, 1990.
+[^niikura1990]: S. Niikura and M. Nagami, “Improvement of fusion reactivity and fusion power multiplication factor in the presence of fast ions,” *Fusion Engineering and Design*, vol. 12, pp. 467–480, 1990.

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -465,6 +465,8 @@ $$
 \text{x}_{\text{c}} = \sqrt{\frac{\text{E}_{\text{beam}}}{\text{E}_{\text{crit}}}}
 $$
 
+---
+
 ### Beam fast ion pressure integral | `fast_ion_pressure_integral()`
 
 This internal function returns the dimensionless pressure integral factor used in the fast-ion pressure expression. It takes the beam birth energy $E_{\text{beam}}$ and the critical energy $E_{\text{crit}}$ for the required beam ion species.

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -53,7 +53,7 @@ This section explains the stages of calculation in the function `beam_fusion()`
 
 ### Calculate the beam ion slowing down time
 
-The beam slowing down time used in the model is implemented as:
+The beam slowing down time used in the model is implemented as [2]:
 
 ```math
 \tau_{\text{slow}} =

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -73,8 +73,9 @@ where:
 - $A_{\text{T}}$ is the triton mass in amu,
 - $f_{\text{beam,T}}$ is the tritium fraction in the injected beam,
 - $\langle T_{\text{e}}\rangle$ is the density-weighted electron temperature in keV,
-- $\langle n_{\text{e}}\rangle$ is the volume-averaged electron density in m$^{-3}$,
+- $\langle n_{\text{e}}\rangle$ is the volume-averaged electron density in $\text{m}^{-3}$
 - $\ln\Lambda_{\text{ie}}$ is the ion-electron Coulomb logarithm.
+- The numerical prefactor $1.99\times10^{19}$ arises from rewriting the classical slowing-down time expression in practical units.
 
 ---
 

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -1,383 +1,800 @@
-# Neutral Beam Injection Fusion
+# Beam Fusion Model
 
-The main function called for calculating the fusion reactions produced by neutral beam injection is `beam_fusion()`
-Due to the small contribution of fusion power from the neutral beams only D-T reactions are taken into account, as D-D additions to fusion power are deemed to be negligible.
-The beam fusion calculations will only run if the calculated beam current is greater than 0. This is done by having a NBI heating and current drive configuration. 
+This page describes the neutral beam fusion model currently implemented in `beam_fusion()`.
 
-The NBI parameters taken from the current drive module to be used in the beam fusion calculations are the beam current (`c_beam_total`), beam energy (`e_beam_kev`) and the tritium component of the beam (`f_beam_tritium`).
+The model is a reduced beam-target treatment for neutral beam ions that have been injected into the plasma. PROCESS builds a steady population of fast ions from a beam source, then calculates how many of those ions fuse with the background plasma. It does not model neutral beam attenuation, shine-through, or orbit effects explicitly. Instead, it starts from the total beam current available to the beam-fusion model and then:
+
+1. computes a beam slowing-down time and a critical energy for deuterium and tritium beam ions,
+2. estimates the steady-state hot beam ion densities from the beam source rate and slowing-down residence time,
+3. evaluates a fast-ion pressure and a pressure-equivalent deposited beam energy,
+4. computes effective beam-target fusion rate coefficients for hot deuterium and hot tritium beam ions,
+5. forms total beam-target reaction rates and converts them to alpha power,
+6. computes the neutral beam beta contribution from the hot beam population.
+
+The main functions involved are:
+
+- `beam_fusion()`  
+  Top-level routine. Computes beam slowing-down properties, beam-target fusion alpha power, and neutral beam beta.
+
+- `beam_slowing_down_state()`  
+  Splits the beam into deuterium and tritium components, computes steady-state hot beam densities, critical speeds, fast-ion pressures, and the density-weighted deposited beam energy.
+
+- `fast_ion_pressure_integral()`  
+  Returns the closed-form dimensionless integral factor used in the fast-ion pressure expression.
+
+- `beam_reaction_rate_coefficient()`  
+  Evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population.
+
+- `_hot_beam_fusion_reaction_rate_integrand()`  
+  Internal integrand used in the beam-target rate coefficient calculation.
+
+- `_beam_fusion_cross_section()`  
+  Internal beam fusion cross-section fit used by the beam-target rate coefficient calculation.
+
+- `beam_target_reaction_rate()`  
+  Converts beam density, target density, and beam-target reactivity into a total reaction rate.
+
+- `alpha_power_beam()`  
+  Converts the total beam-target reaction rate into alpha power.
+
+Due to the small contribution of fusion power from the neutral beams, only D-T beam-target reactions are included. D-D beam contributions are neglected in this model.
+
+The beam fusion calculations will only run if the calculated beam current is greater than 0, i.e. when an NBI heating and current drive configuration is active. Currently, the model only runs when the plasma is not ignited `i_plasma_ignited = 0`.
+
+The NBI parameters taken from the current drive and plasma state are the total beam current (`c_beam_total`), the beam energy (`e_beam_kev`), the tritium fraction in the beam (`f_beam_tritium`), the bulk deuterium and tritium fractions (`f_deuterium_plasma`, `f_tritium_plasma`), and the plasma state quantities required for slowing down.
 
 Please see the [H&CD section](../../eng-models/heating_and_current_drive/heating-and-current-drive.md) of the docs for more info.
 
-------------------------
-
 ## Beam slowing down properties | `beam_fusion()`
 
-1. **Calculate the beam ion slowing down time given by**:
+This section explains the stages of calculation in the function `beam_fusion()`
+
+### Calculate the beam ion slowing down time
+
+The beam slowing down time used in the model is implemented as:
+
+$$
+\tau_{\text{slow}} =
+1.99\times10^{19}
+\left[
+A_{\text{D}}\left(1-f_{\text{beam,T}}\right)
++
+A_{\text{T}}f_{\text{beam,T}}
+\right]
+\frac{\langle T_{\text{e}}\rangle^{3/2}}
+{\langle n_{\text{e}}\rangle \ln \Lambda_{\text{ie}}}
+$$
+
+where:
+
+- $A_{\text{D}}$ is the deuteron mass in amu,
+- $A_{\text{T}}$ is the triton mass in amu,
+- $f_{\text{beam,T}}$ is the tritium fraction in the injected beam,
+- $\langle T_{\text{e}}\rangle$ is the density-weighted electron temperature in keV,
+- $\langle n_{\text{e}}\rangle$ is the volume-averaged electron density in m$^{-3}$,
+- $\ln\Lambda_{\text{ie}}$ is the ion-electron Coulomb logarithm.
+
+### Calculate the beam critical energy
+
+For an energetic ion slowing down in a plasma, there is a critical energy $E_{\text{crit}}$ at which the rate of energy loss to ions equals the rate of energy loss to electrons. Above this energy electron drag dominates, while below it ion drag dominates.
+
+In the current implementation, the deuterium critical energy [^1] is
+
+$$
+E_{\text{crit,D}} =
+14.8
+A_{\text{D}}
+T_{\text{e}}
+Z_{\text{eff,mw}}^{2/3}
+\frac{\ln\Lambda_{\text{ie}}+4.0}{\ln\Lambda_{\text{ie}}}
+\qquad [\text{keV}]
+$$
+
+where $Z_{\text{eff,mw}}$ is the mass-weighted effective plasma charge.
+
+The tritium critical energy is then scaled by the beam ion mass ratio:
+
+$$
+E_{\text{crit,T}} =
+E_{\text{crit,D}}
+\left(\frac{A_{\text{T}}}{A_{\text{D}}}\right)
+$$
+
+#### Derivation of beam slowing down rate and critical energy
+
+The rate of slowing down of a test particle of mass $M$, charge $Ze$ and energy $E$, due to Coulomb collisions with a background species of mass $m_j$, charge $Z_j e$, density $n_j$ and temperature $T_j$, is given by[^2]
+
+$$
+\frac{\mathrm{d}E}{\mathrm{d}t}
+=
+\left[
+-\Phi(x_j)
++
+x_j\left(1+\frac{m_j}{M}\Phi'(x_j)\right)
+\right]
+\frac{4\pi n_j}{m_j V}
+\left(\frac{Z Z_j e^2}{4\pi\varepsilon_0}\right)^2
+\ln\Lambda_j
+$$
+
+where
+
+$$
+\Phi'(x)=\frac{\mathrm{d}\Phi}{\mathrm{d}x},
+\qquad
+V=\sqrt{\frac{2E}{M}},
+\qquad
+V_j=\sqrt{\frac{2kT_j}{m_j}},
+\qquad
+x_j=\frac{V}{V_j}
+$$
+
+For fast ions in fusion plasmas, the ion contribution and electron contribution may be approximated separately, leading to the standard slowing-down form[^3]:
+
+$$
+\frac{\mathrm{d}E}{\mathrm{d}t}
+=
+-\frac{A Z^2 \sqrt{M}}{\sqrt{E}}
+-
+\frac{B Z^2 E}{M}
+$$
+
+with coefficients
+
+$$
+\begin{aligned}
+A &=
+\frac{4\pi}{\sqrt{2}}
+\left(\frac{e^2}{4\pi\varepsilon_0}\right)^2
+\sum_j
+\left(
+\frac{n_j Z_j^2}{m_j}\ln\Lambda_j
+\right) \\
+B &=
+\frac{16\sqrt{\pi}}{3kT_e}
+\sqrt{\frac{m_e}{2kT_e}}
+\left(\frac{e^2}{4\pi\varepsilon_0}\right)^2
+n_e \ln\Lambda_e
+\end{aligned}
+$$
+
+This can be rewritten in the form
+
+$$
+\frac{\mathrm{d}E}{\mathrm{d}t}
+=
+-\frac{2E}{\tau_{\text{slow}}}
+\left[
+1+\left(\frac{E_c}{E}\right)^{3/2}
+\right]
+$$
+
+where
+
+$$
+E_c
+=
+\left[
+\frac{3\sqrt{\pi}}{4}
+\frac{M^{3/2}}{n_e\sqrt{m_e}}
+\sum_j
+\left(
+\frac{n_j Z_j^2}{m_j}\ln\Lambda_j
+\right)
+\frac{1}{\ln\Lambda_e}
+\right]^{2/3}
+kT_e
+$$
+
+and
+
+$$
+\tau_{\text{slow}}
+=
+\frac{3(kT_e)^{3/2}}{4\sqrt{2\pi m_e} Z^2}
+\left(\frac{4\pi\varepsilon_0}{e^2}\right)^2
+\frac{M}{n_e \ln\Lambda_e}
+$$
+
+In this regime, $\tau_{\text{slow}}$ is the characteristic electron-drag slowing-down timescale.
+
+$\blacksquare$
+
+#### **Set the plasma deuterium and tritium ion densities**
+
+The bulk target ion densities used in the beam-target reactions are
+
+$$
+n_{\text{D,plasma}}
+=
+n_{\text{fuel}}
+f_{\text{D,plasma}}
+$$
+
+$$
+n_{\text{T,plasma}}
+=
+n_{\text{fuel}}
+f_{\text{T,plasma}}
+$$
+
+where $n_{\text{fuel}}$ is the volume-averaged total fuel ion density.
+
+### Calculate the beam alpha powers, beam densities and deposited energy
+
+[`beam_slowing_down_state()`](#neutral-beam-alpha-power-beam-densities-and-deposited-energy--beam_slowing_down_state) is run to calculate the hot beam densities, critical speeds, and deposited beam energy.
+
+[`beam_reaction_rate_coefficient()`](#beam-fusion-reaction-rate-coefficient--beam_reaction_rate_coefficient) is then run for the deuterium and tritium beam components to obtain effective beam-target rate coefficients.
+
+[`beam_target_reaction_rate()`](#beam-target-fusion-reaction-rate--beam_target_reaction_rate) and [`alpha_power_beam()`](#beam-fusion-alpha-power--alpha_power_beam) are used to convert these into alpha power.
+
+### Set the returned alpha power
+
+The total neutral beam alpha power is
+
+$$
+P_{\alpha,\text{beam}}
+=
+\mathtt{beamfus0}
+\left(
+P_{\alpha,\text{D-beam}}
++
+P_{\alpha,\text{T-beam}}
+\right)
+$$
+
+### Calculate the neutral beam beta
+
+The neutral beam beta is computed from the hot beam density and the deposited beam energy:
+
+$$
+\beta_{\text{beam}}
+=
+\mathtt{betbm0}
+\times
+4.03\times10^{-22}
+\times
+\frac{2}{3}
+\frac{n_{\text{beam,hot}} E_{\text{beam,deposited}}}
+{B_{\phi}^2 + B_{\theta}^2}
+$$
+
+where:
+
+- $n_{\text{beam,hot}}$ is the total hot beam ion density,
+- $E_{\text{beam,deposited}}$ is the density-weighted deposited beam ion energy in keV,
+- $B_{\phi}$ is the toroidal magnetic field on axis,
+- $B_{\theta}$ is the poloidal magnetic field.
+
+The value of $E_{\text{beam,deposited}}$ is the pressure-equivalent deposited energy of the hot beam ions, **not** the initial beam injection energy.
+
+## Neutral beam alpha power, beam densities and deposited energy | `beam_slowing_down_state()`
+
+1. **Calculate the beam current fractions**
+
+    The beam current is split into deuterium and tritium components:
 
     $$
-    \tau_{\text{slow}} = 1.99 \times 10^{19}\left(A_{\text{D}}\left(1.0-f_{\text{tritium-beam}}\right)+(A_{\text{T}}f_{\text{tritium-beam}})\right)\frac{\langle T_{\text{e}}\rangle^{3/2}}{\langle n_{\text{e}} \rangle \Lambda_{\text{ie}}}
+    I_{\text{beam,D}}
+    =
+    I_{\text{beam}}
+    \left(1-f_{\text{beam,T}}\right)
     $$
 
-2. **Calculate the the beam critical energy**
-
-    The alpha particles are born with an energy of 3.5 MeV and initially slow down mainly by collisions with electrons. At a critical energy $E_{\text{crit}}$ the rate of loss to the ions becomes equal to that to the electrons, and at lower energies the loss to the ions predominates.[^1]
-
     $$
-    E_{\text{crit}} = 14.8 A T_{\text{e}}\left[\frac{1}{n_{\text{e} \ln{ \Lambda_{\text{e}}}}}\left[\Sigma \frac{n_j Z_j^2\ln{\Lambda_{\text{i}}}}{A_j}\right]\right]^{2/3} \ [\text{eV}]
-    $$
-
-    This can be approximated to:
-
-    $$
-    E_{\text{crit}} \approx 0.1AT_{10} \ \ [\text{MeV}]
+    I_{\text{beam,T}}
+    =
+    I_{\text{beam}}
+    f_{\text{beam,T}}
     $$
 
-    Though is currently implemented for deuterium as:
+2. **Calculate the characteristic slowing-down time to the thermal range**
+
+    Using the classical slowing-down model, the characteristic time for the beam ion energy to slow from the birth energy to the thermal range is implemented as:
 
     $$
-    E_{\text{crit,D}} = 14.8A_{\text{D}}T_{\text{e}}Z_{\text{eff}}^{2/3}\frac{\ln \Lambda_{\text{ie}}+4.0}{\Lambda_{\text{ie}}}
+    \tau_{\text{slow,D}}^{*}
+    =
+    \frac{\tau_{\text{slow}}}{3}
+    \ln\left[
+    1+
+    \left(
+    \frac{E_{\text{beam}}}{E_{\text{crit,D}}}
+    \right)^{3/2}
+    \right]
     $$
 
-    The tritium critical energy is simply just scaled with the ratio of atomic mass numbers
-
     $$
-    E_{\text{crit,T}} = E_{\text{crit,D}}\left(\frac{A_{\text{T}}}{A_{\text{D}}}\right)
+    \tau_{\text{slow,T}}^{*}
+    =
+    \frac{\tau_{\text{slow}}}{3}
+    \ln\left[
+    1+
+    \left(
+    \frac{E_{\text{beam}}}{E_{\text{crit,T}}}
+    \right)^{3/2}
+    \right]
     $$
-
-    ---------------------------
-
-    ### Derivation of beam slowing down rate and critical energy
-
-    The rate of slowing down of a test particle of mass $M$, charge $Z\text{e}$ and energy $E$, due to Coulomb collisions with a background species off mass $m_{\text{j}}$, charge $Z_{\text{j}}\text{e}$, density $n_{\text{j}}$ and temperature $T_{\text{j}}$ is given by[^2]:
-
-    $$
-    \frac{\mathrm{dE}}{\mathrm{dt}}=\left[-\Phi\left(x_{\text{j}}\right)+x_{\text{j}}\left(1+\frac{m_{\text{j}}}{M} \Phi^{\prime}\left(x_{\text{j}}\right)\right)\right] \frac{4 \pi n_{\text{j}}}{m_{\text{j}} V}\left(\frac{Z z_{\text{j}} Z \text{e}^2}{4 \pi \varepsilon_0}\right)^2 \ln \Lambda_{\text{j}},
-    $$
-
-    where $\Phi(x)$ is the error function,
-
-    $$
-    \Phi^{\prime}(x) = \frac{\mathrm{d\Phi}}{\mathrm{dx}}, \ \ V = \sqrt{\frac{2E}{M}}, \ \ V_{\text{j}} = \sqrt{\frac{2kT_{\text{j}}}{m_{\text{j}}}}, \ \ x_{\text{j}} = \frac{V}{V_{\text{j}}}
-    $$
-
-    and $\ln \Lambda_{\text{j}}$ is the usual Coulomb logarithm for the test particle and background species interactions.
-
-    For the contribution to the slowing down due to interaction with the background ions, we can use a large argument expansion for the error function. This is because the fusion born ions have a velocity $V$, much greater than the thermal velocity $V_{\text{j}}$, of the background ions. The velocity of the fast ions is much less than the thermal velocity of electrons, however. For the electron contribution to the slowing down we use the small argument expansion for the error function. The net slowing down rate is then given by
-    $$
-    \frac{\mathrm{d E}}{\mathrm{d t}}=-\frac{A Z^2 \sqrt{M}}{\sqrt{E}}-\frac{B Z^2 E}{M}
-    $$
-    where the coefficients $A$ and $B$ are given by
-    $$
-    \begin{aligned}
-    & A=\frac{4 \pi}{\sqrt{2}}\left(\frac{\text{e}^2}{4 \pi \varepsilon_0}\right)^2 \sum_j\left(\frac{n_{\text{j}} Z_{\text{j}}^2}{m_{\text{j}}} \ln \Lambda_j\right) \\
-    & B=\frac{16 \sqrt{\pi}}{3 k T_{\text{e}}} \sqrt{\frac{m_{\text{e}}}{2 k T_{\text{e}}}}\left(\frac{\text{e}^2}{4 \pi \varepsilon_0}\right)^2 n_{\text{e}} \ln \Lambda_{\text{e}}
-    \end{aligned}
-    $$
-
-    The sum over $\text{j}$ in $A$ is over the various ionic species. The quantities with subscript $\text{e}$ refer to the electrons.
-
-    $\frac{\mathrm{d E}}{\mathrm{d t}}$ can be rewritten in the form,
-
-    $$
-    \frac{d E}{d t}=-\frac{2 E}{\tau_{\text{slow}}}\left[1+\left(\frac{E}{E}\right)^{3 / 2}\right]
-    $$
-
-    The critical energy $E_{\text{c}}$ is given by
-
-    $$
-    E_c=\left[\frac{3 \sqrt{\pi}}{4} \frac{M^{3 / 2}}{n_{\text{e}} \sqrt{m}_{\text{e}}} \sum_j\left(\frac{n_{\text{j}} z_{\text{j}}^2}{m_{\text{j}}} \ln \Lambda_{\text{j}}\right) \frac{1}{\ln \Lambda_{\text{e}}}\right]^{2 / 3} k T_{\text{e}}
-    $$
-
-    Some authors take $\ln \Lambda_i=\ln \Lambda_{\text{e}}$ in the expression for $E_C$, but this is not a good approximation for fast ion slowing down in fusion plasmas since $\ln \Lambda_{\text{e}} \approx 17$, while $\ln \Lambda_i \approx 22$. The slowing down time, $\tau_{\text{slow}}$ is given by
-
-    $$
-    \tau_{\text{slow}}=\frac{3(k T_{\text{e}})^{3 / 2}}{4 \sqrt{2 \pi m_{\text{e}}} Z^2}\left(\frac{4 \pi \varepsilon_0}{\text{e}^2}\right)^2 \frac{M}{n_{\text{e}} \ln \Lambda_{\text{e}}}
-    $$
-
-    When the particle energy $E$ is above $E_C$ the contribution of the electrons to the slowing down is larger than that of the ions. The slowing down time $\tau_s$ is actually the time scale for $V$ to decrease due to electron drag, i.e. $\tau_{\text{slow}}=-V /(d V / d t) e^*$
-
-    $\blacksquare$
-
-    -------------------------
-
-3. **Set the plasma tritium and ion densities**
-
-    $$
-    \mathtt{deuterium\_density = nd_plasma_fuel_ions_vol_avg * f\_deuterium\_plasma} \\
-    \mathtt{tritium\_density = nd_plasma_fuel_ions_vol_avg * f\_tritium\_plasma}
-    $$
-
-4. **Calculate the beam alpha powers, density and deposited energy**
-
-    [`beamcalc()`](#neutral-beam-alpha-power-and-ion-energy--beamcalc) is ran to find the alpha power from the beams, the beam densities and the total energy deposited into the plasma.
-
-5. **Set the returned alpha power**
-
-    $$
-    P_{\alpha,\text{beam}} = \mathtt{beamfus0} \times \left(P_{\alpha,\text{D-beam}} + P_{\alpha,\text{T-beam}}\right)
-    $$
-
-6. **Calculate the neutral beam beta**
-
-    $$
-    \beta_{\text{beam}} = \mathtt{betbm0}\times \frac{2}{3}4.03\times10^{-22} \frac{n_{\text{beam}}E_{\text{hot,beam}}}{B_{\text{tot}}^2}
-    $$
-
-    The value of $E_{\text{hot,beam}}$ is the energy deposited by the fast beam ions into the plasma, NOT the initial energy of the beam.
-
-------------------------
-
-## Neutral beam alpha powers, density and deposited energy | `beamcalc()`
-
-1. **Calculate the beam current densities**
-
-    $$
-    I_{\text{beam,D}} = I_{\text{beam}} \times \left(1-\mathtt{f\_tritium\_beam}\right) \\
-    I_{\text{beam,T}} = I_{\text{beam}} \times \mathtt{f\_tritium\_beam}
-    $$
-
-2. **Calculate the characteristic time taken for the beam energy to comparable to that of the thermal energy**
-
-    The attenuation of the beam energy as it penetrates into the plasma is given by[^3]:
-
-    $$
-    E_{\text{beam}} = E_{\text{beam,0}} \left[e^{-\frac{3t}{\tau_{\text{slow}}}}-\left(\frac{E_{\text{crit}}}{E_{\text{beam,0}}}\right)^{\frac{3}{2}}\left(1-e^{-\frac{3t}{\tau_{\text{slow}}}}\right)\right]^{\frac{2}{3}}
-    $$
-
-    Where the characteristic time taken for the beam energy to fall to that of the thermal energy:
-
-    $$
-    \tau_{\text{slow,D*}} = \frac{\tau_{\text{slow}}}{3}\ln\left(1+\left(\frac{E_{\text{beam,0}}}{E_{\text{crit,D}}}\right)^{\frac{3}{2}}\right) \\
-    \tau_{\text{slow,T*}} = \frac{\tau_{\text{slow}}}{3}\ln\left(1+\left(\frac{E_{\text{beam,0}}}{E_{\text{crit,T}}}\right)^{\frac{3}{2}}\right)
-    $$
-
-    This is calculated for the deuterium and the tritium beam components
 
 3. **Set the fast beam ion densities**
 
-    $$
-    \langle n_{\text{beam}} \rangle_{\text{D}} = \frac{I_{\text{beam,D}}\tau_{\text{slow,D*}}}{V_{\text{plasma}}} \\
-    \langle n_{\text{beam}} \rangle_{\text{T}} = \frac{I_{\text{beam,T}}\tau_{\text{slow,T*}}}{V_{\text{plasma}}}
-    $$
-
-    We can also set the total hot ion beam density as:
+    The steady-state hot beam ion densities are set from source rate times residence time:
 
     $$
-    \langle n_{\text{beam}} \rangle_{\text{total}} = \langle n_{\text{beam}} \rangle_{\text{D}} + \langle n_{\text{beam}} \rangle_{\text{T}}
+    \langle n_{\text{beam}} \rangle_{\text{D}}
+    =
+    \frac{I_{\text{beam,D}}\tau_{\text{slow,D}}^{*}}
+    {e V_{\text{plasma}}}
     $$
 
-4. **Calculate the speeds of ions when at the critical energy**
+    $$
+    \langle n_{\text{beam}} \rangle_{\text{T}}
+    =
+    \frac{I_{\text{beam,T}}\tau_{\text{slow,T}}^{*}}
+    {e V_{\text{plasma}}}
+    $$
 
-    Assuming non-relativistic energies, we set the velocities of the deuterium and tritium particles when they have the critical energy:
+    The total hot beam ion density is then
 
     $$
-    v_{\text{crit,D}} = \sqrt{\left(2m_{\text{D}}E_{\text{crit,D}}\right)} \quad
-    v_{\text{crit,T}} = \sqrt{\left(2m_{\text{T}}E_{\text{crit,T}}\right)}
+    \langle n_{\text{beam}} \rangle_{\text{hot}}
+    =
+    \langle n_{\text{beam}} \rangle_{\text{D}}
+    +
+    \langle n_{\text{beam}} \rangle_{\text{T}}
     $$
+
+4. **Calculate the speeds of ions at the critical energy**
+
+    Assuming non-relativistic energies, the beam ion speeds at the critical energy are
+
+    $$
+    v_{\text{crit,D}}
+    =
+    \sqrt{
+    \frac{2 e_{\text{keV}} E_{\text{crit,D}}}
+    {m_u A_{\text{D}}}
+    }
+    $$
+
+    $$
+    v_{\text{crit,T}}
+    =
+    \sqrt{
+    \frac{2 e_{\text{keV}} E_{\text{crit,T}}}
+    {m_u A_{\text{T}}}
+    }
+    $$
+
+    where:
+
+    - $e_{\text{keV}}$ is the conversion from keV to joules,
+    - $m_u$ is the atomic mass unit.
 
 5. **Calculate the fast ion pressures**
-    
-    The fast ion pressure is set as:
+
+    First define the source rates per unit volume:
 
     $$
-    p_{\text{D}}=\frac{m_{\text{D}} \tau_{\text{slow}} v_{\text{crit,D}}^2 I_{\text{beam,D}}}{3 V_{\text{plasma}}} \times \\
-    \underbrace{\left[\frac{x_c^2}{2}+\frac{1}{6} \ln \left(\frac{x_c^2+2 x_c+1}{x_c^2-x_c+1}\right)-\frac{1}{\sqrt{3}} \tan ^{-1}\left(\frac{2 x_c-1}{\sqrt{3}}\right)-\frac{1}{\sqrt{3}} \tan \left(\frac{1}{\sqrt{3}}\right)\right]}_{\mathtt{\_fast\_ion\_pressure\_integral(E_{\text{beam}},E_{\text{crit,D}})}} \\
-    p_{\text{T}}=\frac{m_{\text{T}} \tau_{\text{slow}} v_{\text{crit,T}}^2 I_{\text{beam,T}}}{3 V_{\text{plasma}}} \times \\ \quad
-    \underbrace{\left[\frac{x_c^2}{2}+\frac{1}{6} \ln \left(\frac{x_c^2+2 x_c+1}{x_c^2-x_c+1}\right)-\frac{1}{\sqrt{3}} \tan ^{-1}\left(\frac{2 x_c-1}{\sqrt{3}}\right)-\frac{1}{\sqrt{3}} \tan \left(\frac{1}{\sqrt{3}}\right)\right]}_{\mathtt{\_fast\_ion\_pressure\_integral(E_{\text{beam}},E_{\text{crit,T}})}}
+    S_{\text{D}}
+    =
+    \frac{I_{\text{beam,D}}}{e V_{\text{plasma}}}
     $$
 
-    ---------------------------------
-
-    ### Beam fast ion pressure integral | `fast_ion_pressure_integral()`
-
-    This internal function is for returning the main integral value for the fast ion pressure. It takes the initial beam energy ($E_{\text{beam}}$) and the critical energy ($E_{\text{crit}}$) for the required ion species.
-
-    This integral derivation is originally of the form derived by D.Baiquan et.al.[^2]
-
-    #### Derivation
-
-    The fast ions, because of their finite slowing down time, develop a certain amount of pressure which has to be supported by the magnetic field.
-
-    This is in addition to the pressure of accumulated thermal "ash" in the plasma. To calculate this pressure we introduce a kinetic equation for the slowing down particles and solve it for their distribution function. Integration of the distribution function then determines the fast ion pressure.
-
-    We introduce the distribution function $g$ , of fast ions; $g$ is defined as the number of ions per unit energy per unit spatial volume and satisfies the steady-state kinetic equation,
-
     $$
-    \frac{\partial}{\partial E}\left(g \frac{d E}{d t}\right)=S(E),
+    S_{\text{T}}
+    =
+    \frac{I_{\text{beam,T}}}{e V_{\text{plasma}}}
     $$
 
-    where $S(E)$ is the source function in this "phase" space and $d E / d t$ is given by:
+    The implemented pressure coefficients are then
 
     $$
-    \frac{dE}{dT} = -\frac{2E}{\tau_s}\left[1+\left(\frac{E_c}{E}^{\frac{3}{2}}\right)\right]
+    C_{p,\text{D}}
+    =
+    \frac{
+    A_{\text{D}} m_u \tau_{\text{slow}} v_{\text{crit,D}}^2 S_{\text{D}}
+    }
+    {3 e_{\text{keV}}}
     $$
 
-    This is the same form as above for deriving the critical energy and beam slow time in [`beam_fusion()`](#beam-slowing-down-properties--beam_fusion)
-
-    This equation assumes the ions have a confinement time much longer than the slowing down time. For cases in which this is not true, an additional loss term would have to be introduced in the equation above. If we assume the ions are born monoenergetically, then:
-
     $$
-    S(E)=S_0 \delta\left(E-E_0\right),
-    $$
-
-    where $\mathrm{S}_0$ is the number of ions born per unit time per unit volume and $\delta$ is the [Dirac delta function](https://en.wikipedia.org/wiki/Dirac_delta_function).
-
-    We impose the boundary condition that $\mathrm{g}=0$ for $\mathrm{E}>\mathrm{E}_0$. Our steady state kinetic distribution function can then be integrated to yield:
-
-    $$
-    g(E)= \begin{cases}\frac{S_0 T_s}{2 E\left(1+\left(E_c / E\right)^{3 / 2}\right)}, & E<E_0 \\ 0, & E>E_0\end{cases}
+    C_{p,\text{T}}
+    =
+    \frac{
+    A_{\text{T}} m_u \tau_{\text{slow}} v_{\text{crit,T}}^2 S_{\text{T}}
+    }
+    {3 e_{\text{keV}}}
     $$
 
-    If we consider the appropriate limiting cases.
-
-    The pressure $p$ of the fast ions is
+    The fast ion pressures are
 
     $$
-    p=\frac{2}{3} \int_0^{E_0}  g(E) E  \ \ \mathrm{dE}
+    p_{\text{D}}
+    =
+    C_{p,\text{D}}
+    \times
+    \underbrace{
+    \left[
+    \frac{x_c^2}{2}
+    +
+    \frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+    -
+    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+    -
+    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
+    \right]
+    }_{\mathtt{fast\_ion\_pressure\_integral}(E_{\text{beam}},E_{\text{crit,D}})}
     $$
 
-    which can be rewritten as
+    $$
+    p_{\text{T}}
+    =
+    C_{p,\text{T}}
+    \times
+    \underbrace{
+    \left[
+    \frac{x_c^2}{2}
+    +
+    \frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+    -
+    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+    -
+    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
+    \right]
+    }_{\mathtt{fast\_ion\_pressure\_integral}(E_{\text{beam}},E_{\text{crit,T}})}
+    $$
+
+    with
 
     $$
-    p=\frac{M S_0 \tau_s V_c^2}{3} \int_0^{X_c}  \frac{x^4}{1+x^3} \quad \mathrm{dx}
+    x_c = \sqrt{\frac{E_{\text{beam}}}{E_{\text{crit}}}}
     $$
 
-    The integral above can also be evaluated analytically  to yield:
+   ### Beam fast ion pressure integral | `fast_ion_pressure_integral()`
+
+    This internal function returns the dimensionless pressure integral factor used in the fast-ion pressure expression. It takes the beam birth energy $E_{\text{beam}}$ and the critical energy $E_{\text{crit}}$ for the required beam ion species.
+
+   #### Derivation
+
+    The fast ions, because of their finite slowing down time, develop a finite pressure which must be supported by the magnetic field.
+
+    To calculate this pressure, introduce the distribution function $g(E)$ of fast ions, where $g(E)$ is the number of ions per unit energy per unit volume, satisfying the steady-state kinetic equation
 
     $$
-    p=\frac{M \tau_s V_c^2 S_0}{3}\left[\frac{x_c^2}{2}+\frac{1}{6} \ln \left(\frac{x_c^2+2 x_c+1}{x_c^2-x_c+1}\right) \\
-    -\frac{1}{\sqrt{3}} \tan ^{-1}\left(\frac{2 x_c-1}{\sqrt{3}}\right)-\frac{1}{\sqrt{3}} \tan \left(\frac{1}{\sqrt{3}}\right)\right]
+    \frac{\partial}{\partial E}
+    \left(
+    g \frac{\mathrm{d}E}{\mathrm{d}t}
+    \right)
+    =
+    S(E)
     $$
 
-    For most applications to fusion born particles, the dominant term is the first term in the square brackets.
-    This function returns the terms in the square brackets.
+    with slowing-down law
+
+    $$
+    \frac{\mathrm{d}E}{\mathrm{d}t}
+    =
+    -\frac{2E}{\tau_s}
+    \left[
+    1+\left(\frac{E_c}{E}\right)^{3/2}
+    \right]
+    $$
+
+    If the ions are born monoenergetically,
+
+    $$
+    S(E)=S_0\delta(E-E_0)
+    $$
+
+    and with the boundary condition $g(E)=0$ for $E>E_0$, the steady-state distribution becomes
+
+    $$
+    g(E)=
+    \begin{cases}
+    \dfrac{S_0\tau_s}{2E\left[1+\left(E_c/E\right)^{3/2}\right]}, & E<E_0 \\
+    0, & E>E_0
+    \end{cases}
+    $$
+
+    The fast ion pressure is then
+
+    $$
+    p
+    =
+    \frac{2}{3}
+    \int_0^{E_0} g(E) E \, \mathrm{d}E
+    $$
+
+    which can be written as
+
+    $$
+    p
+    =
+    \frac{M S_0 \tau_s V_c^2}{3}
+    \int_0^{x_c}
+    \frac{x^4}{1+x^3}\,\mathrm{d}x
+    $$
+
+    and evaluated analytically as
+
+    $$
+    p
+    =
+    \frac{M S_0 \tau_s V_c^2}{3}
+    \left[
+    \frac{x_c^2}{2}
+    +
+    \frac{1}{6}\ln\left(\frac{x_c^2+2x_c+1}{x_c^2-x_c+1}\right)
+    -
+    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{2x_c-1}{\sqrt{3}}\right)
+    -
+    \frac{1}{\sqrt{3}}\tan^{-1}\left(\frac{1}{\sqrt{3}}\right)
+    \right]
+    $$
+
+    `fast_ion_pressure_integral()` returns the bracketed dimensionless factor only.
 
     $\blacksquare$
 
-    --------------------------
-
+    --
 6. **Calculate the deposited fast ion energy from the pressure**
 
-    This can be simply done by applying the Ideal gas law approximation that, $P = \frac{1}{3}nmv_{\text{rms}^2} = \frac{2}{3}n \langle E \rangle$
+    The deposited beam ion energy is inferred from the pressure relation
 
     $$
-    E_{\text{hot,D}} = \frac{3}{2}p_{\text{D}} \langle n_{\text{beam}} \rangle_{\text{D}} \\
-    E_{\text{hot,T}} = \frac{3}{2}p_{\text{T}} \langle n_{\text{beam}} \rangle_{\text{T}}
+    p = \frac{1}{3}nmv_{\text{rms}}^2 = \frac{2}{3}n\langle E\rangle
     $$
 
-    We can thus also define the total hot ion depoisted energy as:
+    so that the pressure-equivalent deposited energies are
 
     $$
-    E_{\text{hot,total}} = \frac{\left( E_{\text{hot,D}}  \langle n_{\text{beam}} \rangle_{\text{D}}\right) + \left( E_{\text{hot,T}}  \langle n_{\text{beam}} \rangle_{\text{T}}\right)}{\langle n_{\text{beam}} \rangle_{\text{total}}}
+    E_{\text{hot,D}}
+    =
+    \frac{3}{2}
+    \frac{p_{\text{D}}}{\langle n_{\text{beam}} \rangle_{\text{D}}}
     $$
 
-7. **Calculate the hot ion species fusion rates**
+    $$
+    E_{\text{hot,T}}
+    =
+    \frac{3}{2}
+    \frac{p_{\text{T}}}{\langle n_{\text{beam}} \rangle_{\text{T}}}
+    $$
 
-    The D-T fusion reaction rate is calculated from the [`beam_reaction_rate()`](#beam-fusion-reaction-rate--beam_reaction_rate) function.
+    with the convention that the deposited energy is set to zero if the corresponding hot beam density is zero.
 
-    ------------------------
+    The total deposited beam ion energy returned to `beam_fusion()` is the density-weighted average:
 
-    ### Beam fusion reaction rate | `beam_reaction_rate()`
+    $$
+    E_{\text{hot,total}}
+    =
+    \frac{
+    E_{\text{hot,D}} \langle n_{\text{beam}} \rangle_{\text{D}}
+    +
+    E_{\text{hot,T}} \langle n_{\text{beam}} \rangle_{\text{T}}
+    }
+    {\langle n_{\text{beam}} \rangle_{\text{hot}}}
+    $$
 
-    1. **Calculate beam velocity**
+    with the convention that this is set to zero if $\langle n_{\text{beam}} \rangle_{\text{hot}}=0$.
 
-        The beam velocity ($v_{\text{beam}}$) is calculated from the inputted beam energy and relative ion mass of the beam by simply re-arranging the kinetic energy equation
+7. **Return the slowing-down state**
 
-    2. **Define the integral coefficient**
+    `beam_slowing_down_state()` returns:
 
-        $$
-        \frac{3v_{\text{critical}}}{\ln\left(1+\frac{v_{\text{beam}}}{v_{\text{critical}}}\right)^{3}}
-        $$
+    - deuterium beam ion density,
+    - tritium beam ion density,
+    - deuterium critical speed,
+    - tritium critical speed,
+    - total hot beam ion density,
+    - density-weighted deposited beam energy.
 
-    3. **Perform the fusion rate integral**
+## Beam fusion reaction rate coefficient | `beam_reaction_rate_coefficient()`
 
-        $$
-        \int_0^{v_{\text{relative}}} \frac{u^3}{1+u^3}\sigma_{\text{bmfus}}(E_{\text{amu}})
-        $$
-        
-        --------------------
+1. **Calculate the beam velocity**
 
-        #### Hot Beam Fusion Reaction Rate Integrand | `_hot_beam_fusion_reaction_rate_integrand()`
+    The beam velocity is calculated from the input beam energy and beam ion mass:
 
-        This function computes the integrand for the hot beam fusion reaction rate based on the ratio of beam velocity to the critical velocity and the critical velocity for electron/ion slowing down of the beam ion.
+    $$
+    v_{\text{beam}}
+    =
+    \sqrt{
+    \frac{2 e_{\text{keV}} E_{\text{beam}}}
+    {m_u A}
+    }
+    $$
 
-        The integrand function is:
+2. **Define the integral coefficient**
 
-        $$
-        \int \frac{u^3}{1+u^3}\sigma_{\text{bmfus}}(E_{\text{amu}})
-        $$
+    The implemented coefficient is
 
-        Where $u$ is the inputted ratio of the beam to the critical velocity.
-        $E_{\text{amu}}$ represents the beam kinetic energy per atomic mass unit.
+    $$
+    \frac{3v_{\text{crit}}}
+    {\ln\left(1+\left(\frac{v_{\text{beam}}}{v_{\text{crit}}}\right)^3\right)}
+    $$
 
-        The calculated beam fusion cross section $\sigma_{\text{bmfus}}$ is calculated from [`_beam_fusion_cross_section()`](#beam-fusion-cross-section--_beam_fusion_cross_section)
+3. **Perform the fusion rate integral**
 
-        ------------------------
+    The slowing-down-weighted integral is evaluated as
 
-        #### Beam fusion cross section | `_beam_fusion_cross_section()`
+    $$
+    \int_0^{v_{\text{beam}}/v_{\text{crit}}}
+    \frac{u^3}{1+u^3}
+    \sigma_{\text{bmfus}}(E_{\text{amu}}(u))
+    \,\mathrm{d}u
+    $$
 
-        This internal function is used to find the beam cross section.
-        It sets limits on cross-section at low and high beam energies. The plasma ions are assumed to be stationary:
+    where $u = v/v_{\text{crit}}$.
 
-        $$
-        \sigma_{\text{bm}}(E) = 
-        \begin{cases} 
-        1.0 \times 10^{-27} \ \text{cm}^2 & \text{if } E < 10.0 \ \text{keV/amu} \\
-        8.0 \times 10^{-26} \ \text{cm}^2 & \text{if } E > 10^4 \ \text{keV/amu} \\
-        \frac{1.0 \times 10^{-24} \cdot \left( \frac{a_2}{1.0 + (a_3 E - a_4)^2} + a_5 \right)}{E \left( \exp\left(\frac{a_1}{\sqrt{E}}\right) - 1.0 \right)} \ \text{cm}^2 & \text{otherwise}
-        \end{cases}
-        $$
+    The quantity returned by `_beam_fusion_cross_section()` is in cm$^2$, so the integrated area is converted to m$^2$ before forming the final rate coefficient.
 
-        where:
+### Hot beam fusion reaction rate integrand | `_hot_beam_fusion_reaction_rate_integrand()`
 
-        - \( E \) is the beam energy in, $\text{keV/amu}$
+This internal function evaluates the integrand used in the beam-target fusion rate coefficient.
 
-        - \( a_1, a_2, a_3, a_4, a_5 \) are constants.
+The implemented integrand is
 
-        The constants are defined as:
+$$
+\frac{u^3}{1+u^3}\sigma_{\text{bmfus}}(E_{\text{amu}}(u))
+$$
 
-        - \( a_1 = 45.95 \)
-        - \( a_2 = 5.02 \times 10^4 \)
-        - \( a_3 = 1.368 \times 10^{-2} \)
-        - \( a_4 = 1.076 \)
-        - \( a_5 = 4.09 \times 10^2 \)
+where:
 
-        ----------------------
+- $u$ is the ratio of the instantaneous beam speed to the critical speed,
+- $E_{\text{amu}}(u)$ is the instantaneous beam kinetic energy per amu,
+- $\sigma_{\text{bmfus}}$ is returned by [`_beam_fusion_cross_section()`](#beam-fusion-cross-section--_beam_fusion_cross_section).
 
-    4. **Multiply by the coefficient to get the full fusion rate**
+The beam kinetic energy per amu used in the code is constructed from
 
-        $$
-        \frac{3v_{\text{critical}}}{\ln\left(1+\frac{v_{\text{beam}}}{v_{\text{critical}}}\right)^{3}}\int_0^{v_{\text{relative}}} \frac{u^3}{1+u^3}\sigma_{\text{bmfus}}(E_{\text{amu}})
-        $$
+$$
+E_{\text{amu}}
+=
+\frac{(u v_{\text{crit}})^2 m_u}{e_{\text{keV}}}
+$$
 
-    -------------------------    
+#### Beam fusion cross section | `_beam_fusion_cross_section()`
 
-8. **Calculate the alpha power produced by the hot ion species**
+This internal function returns the beam fusion cross-section fit used by the beam-target rate coefficient calculation. Note: the provenance of this fit is currently unverified in the documentation.
 
-    The function [`alpha_power_beam()`](#beam-fusion-alpha-power--alpha_power_beam) is ran to calculate the alpha power produced by the deuterium and tritium fast ions.
+The plasma ions are assumed to be stationary.
 
-    -----------------------
+The implementation is
 
-    ### Beam fusion alpha power | `alpha_power_beam()`
+$$
+\sigma_{\text{bm}}(E) =
+\begin{cases}
+1.0\times10^{-27}\ \text{cm}^2, & E < 10.0\ \text{keV} \\
+8.0\times10^{-26}\ \text{cm}^2, & E > 10^4\ \text{keV} \\
+\dfrac{
+1.0\times10^{-24}
+\left[
+\dfrac{a_2}{1.0+(a_3 E-a_4)^2}+a_5
+\right]
+}{
+E\left[\exp\left(\dfrac{a_1}{\sqrt{E}}\right)-1.0\right]
+}
+\ \text{cm}^2, & \text{otherwise}
+\end{cases}
+$$
 
-    1. **Calculate reactivity ratio**
+where the beam energy used inside the fit is
 
-        The ratio between the profile averaged reactivity for D-T reactions and the reactivity for the D-T reactions if the plasma is assumed to be homogeneously at the volume averaged ion temperature ($T_{\text{i}}$) is calculated.
+$$
+E
+=
+\frac{1}{2} A_{\text{D}} E_{\text{amu}}
+$$
 
-        $$
-        f_{\text{DT}} = \frac{\langle\langle \sigma v \rangle\rangle_{\text{DT}}}{\langle \sigma v \rangle_{\text{DT}}}
-        $$
+and the constants are
 
-    2. **Calculate the alpha fusion power**
+- $a_1 = 45.95$
+- $a_2 = 5.02 \times 10^4$
+- $a_3 = 1.368 \times 10^{-2}$
+- $a_4 = 1.076$
+- $a_5 = 4.09 \times 10^2$
 
-        The alpha powers from the deuterium and tritium beam components are calculated:
+The exact provenance of this particular fit and its coefficients has not yet been fully traced in the present documentation. It is retained here to document the current implementation.
 
-        $$
-        P_{\alpha,\text{D}} = \langle n_{\text{beam}} \rangle_{\text{D}} n_{\text{i}} \langle \sigma v \rangle_{\text{beam}} E_{\alpha} V_{\text{plasma}} f_{\text{DT}} \\
-        P_{\alpha,\text{T}} = \langle n_{\text{beam}} \rangle_{\text{T}} n_{\text{i}} \langle \sigma v \rangle_{\text{beam}} E_{\alpha} V_{\text{plasma}} f_{\text{DT}}
-        $$
+1. **Multiply by the coefficient to get the full rate coefficient**
 
-------------------------------
+The final effective beam-target fusion rate coefficient is
+
+$$
+\langle \sigma v \rangle_{\text{beam}}
+=
+\frac{3v_{\text{crit}}}
+{\ln\left(1+\left(\frac{v_{\text{beam}}}{v_{\text{crit}}}\right)^3\right)}
+\int_0^{v_{\text{beam}}/v_{\text{crit}}}
+\frac{u^3}{1+u^3}
+\sigma_{\text{bmfus}}(E_{\text{amu}}(u))
+\,\mathrm{d}u
+$$
+
+## Beam-target fusion reaction rate | `beam_target_reaction_rate()`
+
+The present implementation evaluates an effective beam-target fusion rate coefficient for a slowing-down fast-ion population. This is consistent with simple beam-plasma reaction-rate models in which fast ions interact with a Maxwellian background plasma during the slowing-down process[^4]. The total beam-target fusion reaction rate is calculated as
+
+$$
+R_{\text{beam-target}}
+=
+n_{\text{beam}}
+n_{\text{target}}
+\langle \sigma v \rangle_{\text{beam}}
+V_{\text{plasma}}
+$$
+
+where:
+
+- $n_{\text{beam}}$ is the hot beam ion density,
+- $n_{\text{target}}$ is the thermal target ion density,
+- $\langle \sigma v \rangle_{\text{beam}}$ is the effective beam-target rate coefficient,
+- $V_{\text{plasma}}$ is the plasma volume.
+
+This returns the total reaction rate in s$^{-1}$.
+
+## Beam fusion alpha power | `alpha_power_beam()`
+
+The beam-target alpha power is obtained from the total beam-target reaction rate by
+
+$$
+P_{\alpha,\text{beam}}
+=
+R_{\text{beam-target}} E_{\alpha}
+$$
+
+and is converted from W to MW in the implementation.
+
+This returns the alpha power in MW.
+
+## Full beam-target alpha power calculation in `beam_fusion()`
+
+For the deuterium beam component reacting with thermal tritium:
+
+$$
+R_{\text{D-beam,DT}}
+=
+\langle n_{\text{beam}} \rangle_{\text{D}}
+n_{\text{T,plasma}}
+\langle \sigma v \rangle_{\text{beam,D}}
+V_{\text{plasma}}
+$$
+
+$$
+P_{\alpha,\text{D-beam}}
+=
+R_{\text{D-beam,DT}} E_{\alpha}
+$$
+
+For the tritium beam component reacting with thermal deuterium:
+
+$$
+R_{\text{T-beam,DT}}
+=
+\langle n_{\text{beam}} \rangle_{\text{T}}
+n_{\text{D,plasma}}
+\langle \sigma v \rangle_{\text{beam,T}}
+V_{\text{plasma}}
+$$
+
+$$
+P_{\alpha,\text{T-beam}}
+=
+R_{\text{T-beam,DT}} E_{\alpha}
+$$
+
+The returned beam alpha power is then
+
+$$
+P_{\alpha,\text{beam}}
+=
+\mathtt{beamfus0}
+\left(
+P_{\alpha,\text{D-beam}}
++
+P_{\alpha,\text{T-beam}}
+\right)
+$$
 
 ## Key Constraints
 
@@ -385,8 +802,14 @@ Please see the [H&CD section](../../eng-models/heating_and_current_drive/heating
 
 This constraint can be activated by stating `icc = 7` in the input file.
 
-The desired value of the hot ion beam density calculated from the code (`nd_beam_ions_out`) can be constrained using the input variable, `f_nd_beam_electron`. Which is the ratio of the beam density to the plasma electron density. It can be set as an iteration variable by setting `ixc = 7`.
+The desired value of the hot ion beam density calculated from the code (`nd_beam_ions_out`) can be constrained using the input variable `f_nd_beam_electron`, which is the ratio of the beam density to the plasma electron density. It can be set as an iteration variable by setting `ixc = 7`.
 
-[^1]: J. W. Sheffield, “The physics of magnetic fusion reactors,” vol. 66, no. 3, pp. 1015–1103,Jul. 1994, doi: https://doi.org/10.1103/revmodphys.66.1015.
-[^2]: Deng Baiquan and G. A. Emmert, “Fast ion pressure in fusion plasma,” Nuclear Fusion and Plasma Physics,vol. 9, no. 3, pp. 136–141, 2022, Available: https://fti.neep.wisc.edu/fti.neep.wisc.edu/pdf/fdm718.pdf  
-[^3]: Wesson, J. (2011) Tokamaks. 4th Edition, 2011 Oxford Science Publications,International Series of Monographs on Physics, Volume 149.
+## References
+
+1. J. W. Sheffield, “The physics of magnetic fusion reactors,” *Rev. Mod. Phys.*, vol. 66, no. 3, pp. 1015–1103, Jul. 1994. <https://doi.org/10.1103/RevModPhys.66.1015>
+
+2. B. Deng and G. A. Emmert, “Fast ion pressure in fusion plasma,” *Nuclear Fusion and Plasma Physics*, vol. 9, no. 3, pp. 136–141, 1987. Available: <https://fti.neep.wisc.edu/fti.neep.wisc.edu/pdf/fdm718.pdf>
+
+3. J. Wesson, *Tokamaks*, 4th ed., Oxford Science Publications, 2011.
+
+4. S. Niikura and M. Nagami, “Improvement of fusion reactivity and fusion power multiplication factor in the presence of fast ions,” *Fusion Engineering and Design*, vol. 12, pp. 467–480, 1990.

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -334,17 +334,17 @@ $$
 
 ### Set the fast beam ion densities
 
-The steady-state hot beam ion densities are set from source rate times residence time:
+The steady-state hot beam ion densities are obtained from the balance between the beam particle source rate and the slowing-down residence time:
 
 $$
-\langle \text{n}_{\text{beam}} \rangle_{\text{D}}
+\text{n}_{\text{beam,D}}
 =
 \frac{\text{I}_{\text{beam,D}}\tau_{\text{slow,D}}^{*}}
 {\text{e} \text{V}_{\text{plasma}}}
 $$
 
 $$
-\langle \text{n}_{\text{beam}} \rangle_{\text{T}}
+\text{n}_{\text{beam,T}}
 =
 \frac{\text{I}_{\text{beam,T}}\tau_{\text{slow,T}}^{*}}
 {\text{e} \text{V}_{\text{plasma}}}
@@ -353,11 +353,9 @@ $$
 The total hot beam ion density is then
 
 $$
-\langle \text{n}_{\text{beam}} \rangle_{\text{hot}}
+\text{n}_{\text{beam,hot}}
 =
-\langle \text{n}_{\text{beam}} \rangle_{\text{D}}
-+
-\langle \text{n}_{\text{beam}} \rangle_{\text{T}}
+\text{n}_{\text{beam,D}} + \text{n}_{\text{beam,T}}
 $$
 
 ### Calculate the speeds of ions at the critical energy

--- a/documentation/source/physics-models/fusion_reactions/beam_reactions.md
+++ b/documentation/source/physics-models/fusion_reactions/beam_reactions.md
@@ -37,7 +37,12 @@ Converts beam density, target density, and beam-target reactivity into a total r
 - `alpha_power_beam()`  
 Converts the total beam-target reaction rate into alpha power.
 
-Due to the small contribution of fusion power from the neutral beams, only D-T beam-target reactions are included. D-D beam contributions are neglected in this model.
+!!! info "Model assumption: beam fusion channels"
+
+    Due to the relatively small contribution of fusion power from neutral beams,  
+    only D–T beam–target reactions are included in this model.  
+
+    Beam-driven D–D reactions are neglected.
 
 The beam fusion calculations will only run if the calculated beam current is greater than 0, i.e. when an NBI heating and current drive configuration is active. Currently, the model only runs when the plasma is not ignited `i_plasma_ignited = 0`.
 

--- a/process/models/physics/fusion_reactions.py
+++ b/process/models/physics/fusion_reactions.py
@@ -934,11 +934,12 @@ def beam_fusion(
 
     Returns
     -------
-    :
-        tuple[float, float, float]: A tuple containing:
-        - Neutral beam beta contribution.
-        - Hot beam ion density (m^-3).
-        - Alpha power from beam-target fusion (MW).
+    beta_beam :
+        Neutral beam beta contribution.
+    n_beam :
+        Hot beam ion density (m^-3).
+    p_alpha_beam :
+        Alpha power from beam-target fusion (MW).
 
     Notes
     -----
@@ -991,14 +992,7 @@ def beam_fusion(
     nd_plasma_deuterium = nd_plasma_fuel_ions_vol_avg * f_deuterium_plasma
     nd_plasma_tritium = nd_plasma_fuel_ions_vol_avg * f_tritium_plasma
 
-    (
-        nd_beam_deuterium,
-        nd_beam_tritium,
-        deuterium_critical_energy_speed,
-        tritium_critical_energy_speed,
-        nd_beam_hot,
-        e_beam_deposited_kev,
-    ) = beam_slowing_down_state(
+    beam_state = beam_slowing_down_state(
         e_beam_kev,
         critical_energy_deuterium,
         critical_energy_tritium,
@@ -1009,15 +1003,19 @@ def beam_fusion(
     )
 
     sigv_beam_deuterium = beam_reaction_rate_coefficient(
-        constants.M_DEUTERON_AMU, deuterium_critical_energy_speed, e_beam_kev
+        constants.M_DEUTERON_AMU,
+        beam_state.deuterium_critical_energy_speed,
+        e_beam_kev,
     )
 
     sigv_beam_tritium = beam_reaction_rate_coefficient(
-        constants.M_TRITON_AMU, tritium_critical_energy_speed, e_beam_kev
+        constants.M_TRITON_AMU,
+        beam_state.tritium_critical_energy_speed,
+        e_beam_kev,
     )
 
     reaction_rate_beam_deuterium_dt = beam_target_reaction_rate(
-        nd_beam_deuterium,
+        beam_state.deuterium_beam_density,
         nd_plasma_tritium,
         sigv_beam_deuterium,
         vol_plasma,
@@ -1027,7 +1025,7 @@ def beam_fusion(
     )
 
     reaction_rate_beam_tritium_dt = beam_target_reaction_rate(
-        nd_beam_tritium,
+        beam_state.tritium_beam_density,
         nd_plasma_deuterium,
         sigv_beam_tritium,
         vol_plasma,
@@ -1046,12 +1044,42 @@ def beam_fusion(
         betbm0
         * 4.03e-22
         * (2 / 3)
-        * nd_beam_hot
-        * e_beam_deposited_kev
+        * beam_state.nd_beam_hot
+        * beam_state.e_beam_deposited_kev
         / (b_plasma_toroidal_on_axis**2 + b_plasma_poloidal_average**2)
     )
 
-    return beta_beam, nd_beam_hot, p_beam_alpha_mw
+    return beta_beam, beam_state.nd_beam_hot, p_beam_alpha_mw
+
+
+@dataclass(frozen=True)
+class BeamSlowingDownState:
+    """Beam slowing-down state and hot-ion properties.
+
+    Attributes
+    ----------
+    deuterium_beam_density :
+        Steady-state deuterium beam ion density (m^-3).
+    tritium_beam_density :
+        Steady-state tritium beam ion density (m^-3).
+    deuterium_critical_energy_speed :
+        Critical speed of deuterium beam ions corresponding to the
+        critical energy (m/s).
+    tritium_critical_energy_speed :
+        Critical speed of tritium beam ions corresponding to the
+        critical energy (m/s).
+    nd_beam_hot :
+        Total hot beam ion density (m^-3).
+    e_beam_deposited_kev :
+        Density-weighted average deposited beam ion energy (keV).
+    """
+
+    deuterium_beam_density: float
+    tritium_beam_density: float
+    deuterium_critical_energy_speed: float
+    tritium_critical_energy_speed: float
+    nd_beam_hot: float
+    e_beam_deposited_kev: float
 
 
 def beam_slowing_down_state(
@@ -1062,7 +1090,7 @@ def beam_slowing_down_state(
     f_beam_tritium: float,
     c_beam_total: float,
     vol_plasma: float,
-) -> tuple[float, float, float, float, float, float]:
+) -> BeamSlowingDownState:
     """Calculate beam slowing-down state and hot ion properties.
 
     Estimates the steady-state hot D and T beam-ion densities from beam
@@ -1090,13 +1118,10 @@ def beam_slowing_down_state(
 
     Returns
     -------
-        tuple[float, float, float, float, float, float]: A tuple containing:
-        - Deuterium beam ion density (m^-3).
-        - Tritium beam ion density (m^-3).
-        - Deuterium critical speed (m/s).
-        - Tritium critical speed (m/s).
-        - Total hot beam ion density (m^-3).
-        - Average deposited beam ion energy (keV).
+     :
+        Beam slowing-down state containing deuterium and tritium hot beam-ion
+        densities, deuterium and tritium critical speeds, total hot beam-ion
+        density, and average deposited beam-ion energy.
 
     Notes
     -----
@@ -1223,7 +1248,7 @@ def beam_slowing_down_state(
         else 0.0
     )
 
-    total_deposited_energy = (
+    e_beam_deposited_kev = (
         (
             deuterium_beam_density * deuterium_deposited_energy
             + tritium_beam_density * tritium_deposited_energy
@@ -1233,13 +1258,13 @@ def beam_slowing_down_state(
         else 0.0
     )
 
-    return (
-        deuterium_beam_density,
-        tritium_beam_density,
-        deuterium_critical_energy_speed,
-        tritium_critical_energy_speed,
-        nd_beam_hot,
-        total_deposited_energy,
+    return BeamSlowingDownState(
+        deuterium_beam_density=deuterium_beam_density,
+        tritium_beam_density=tritium_beam_density,
+        deuterium_critical_energy_speed=deuterium_critical_energy_speed,
+        tritium_critical_energy_speed=tritium_critical_energy_speed,
+        nd_beam_hot=nd_beam_hot,
+        e_beam_deposited_kev=e_beam_deposited_kev,
     )
 
 

--- a/process/models/physics/fusion_reactions.py
+++ b/process/models/physics/fusion_reactions.py
@@ -880,8 +880,7 @@ def set_fusion_powers(
 def beam_fusion(
     beamfus0: float,
     betbm0: float,
-    b_plasma_poloidal_average: float,
-    b_plasma_toroidal_on_axis: float,
+    b_plasma_total: float,
     c_beam_total: float,
     nd_plasma_electrons_vol_avg: float,
     nd_plasma_fuel_ions_vol_avg: float,
@@ -1046,7 +1045,7 @@ def beam_fusion(
         * (2 / 3)
         * beam_state.nd_beam_hot
         * beam_state.e_beam_deposited_kev
-        / (b_plasma_toroidal_on_axis**2 + b_plasma_poloidal_average**2)
+        / (b_plasma_total**2)
     )
 
     return beta_beam, beam_state.nd_beam_hot, p_beam_alpha_mw

--- a/process/models/physics/fusion_reactions.py
+++ b/process/models/physics/fusion_reactions.py
@@ -1118,7 +1118,7 @@ def beam_slowing_down_state(
 
     Returns
     -------
-     :
+    :
         Beam slowing-down state containing deuterium and tritium hot beam-ion
         densities, deuterium and tritium critical speeds, total hot beam-ion
         density, and average deposited beam-ion energy.
@@ -1284,7 +1284,7 @@ def fast_ion_pressure_integral(e_beam_kev: float, critical_energy: float) -> flo
 
     Returns
     -------
-    float
+    :
         Dimensionless pressure integral factor.
 
     Notes
@@ -1345,7 +1345,8 @@ def beam_target_reaction_rate(
 
     Returns
     -------
-        float: Total beam-target fusion reaction rate (s^-1).
+    :
+        Total beam-target fusion reaction rate (s^-1).
 
     Notes
     -----
@@ -1378,7 +1379,8 @@ def alpha_power_beam(
 
     Returns
     -------
-        float: Alpha power from beam-target fusion (MW).
+    :
+        Alpha power from beam-target fusion (MW).
     """
     return beam_target_reaction_rate * constants.DT_ALPHA_ENERGY / 1.0e6
 
@@ -1407,7 +1409,7 @@ def beam_reaction_rate_coefficient(
     Returns
     -------
     :
-        float: Hot beam fusion rate coefficient [m^3/s].
+        Hot beam fusion rate coefficient [m^3/s].
 
     Notes
     -----
@@ -1469,7 +1471,8 @@ def _hot_beam_fusion_reaction_rate_integrand(
 
     Returns
     -------
-        float: Value of the integrand for the hot beam fusion reaction rate.
+    :
+        Value of the integrand for the hot beam fusion reaction rate.
 
     Notes
     -----
@@ -1517,6 +1520,7 @@ def _beam_fusion_cross_section(vrelsq: float) -> float:
 
     Returns
     -------
+    :
         Fusion reaction cross-section (cm^2).
 
     Notes

--- a/process/models/physics/fusion_reactions.py
+++ b/process/models/physics/fusion_reactions.py
@@ -890,69 +890,62 @@ def beam_fusion(
     f_deuterium_plasma: float,
     f_tritium_plasma: float,
     f_beam_tritium: float,
-    sigmav_dt_average: float,
     temp_plasma_electron_density_weighted_kev: float,
-    temp_plasma_ion_density_weighted_kev: float,
     vol_plasma: float,
     n_charge_plasma_effective_mass_weighted_vol_avg: float,
-) -> tuple:
-    """Routine to calculate beam slowing down properties.
+) -> tuple[float, float, float]:
+    """Calculate neutral beam slowing-down properties and beam-target fusion.
 
-    This function computes the neutral beam beta component, hot beam ion density,
-    and alpha power from hot neutral beam ions based on the provided plasma parameters.
+    This function computes the neutral beam beta contribution, hot beam ion density,
+    and alpha power generated from beam-target fusion reactions in the plasma.
 
     Parameters
     ----------
     beamfus0:
-        Multiplier for beam-background fusion calculation.
+        Multiplier for beam target fusion calculation.
     betbm0:
         Leading coefficient for neutral beam beta fraction.
-    b_plasma_poloidal_average:
-        Poloidal field (T).
-    b_plasma_toroidal_on_axis:
-         Toroidal field on axis (T).
-    c_beam_total:
-        Neutral beam current (A).
-    nd_plasma_electrons_vol_avg:
-        Electron density (m^-3).
-    nd_plasma_fuel_ions_vol_avg:
-        Fuel ion density (m^-3).
-    ion_electron_coulomb_log:
-        Ion-electron coulomb logarithm.
-    e_beam_kev:
-        Neutral beam energy (keV).
-    f_deuterium_plasma:
-        Deuterium fraction of main plasma.
-    f_tritium_plasma:
-        Tritium fraction of main plasma.
-    f_beam_tritium:
-        Tritium fraction of neutral beam.
-    sigmav_dt_average:
-        Profile averaged <sigma v> for D-T (m^3/s).
-    temp_plasma_electron_density_weighted_kev:
-        Density-weighted electron temperature (keV).
-    temp_plasma_ion_density_weighted_kev:
-        Density-weighted ion temperature (keV).
-    vol_plasma:
+    b_plasma_poloidal_average :
+        Poloidal magnetic field (T).
+    b_plasma_toroidal_on_axis :
+        Toroidal magnetic field on axis (T).
+    c_beam_total :
+        Total neutral beam current (A).
+    nd_plasma_electrons_vol_avg :
+        Volume-averaged electron density (m^-3).
+    nd_plasma_fuel_ions_vol_avg :
+        Volume-averaged fuel ion density (m^-3).
+    ion_electron_coulomb_log :
+        Ion-electron Coulomb logarithm.
+    e_beam_kev :
+        Neutral beam injection energy (keV).
+    f_deuterium_plasma :
+        Deuterium fraction in the bulk plasma.
+    f_tritium_plasma :
+        Tritium fraction in the bulk plasma.
+    f_beam_tritium :
+        Tritium fraction in the injected beam.
+    temp_plasma_electron_density_weighted_kev :
+        Density weighted average electron temperature (keV).
+    vol_plasma :
         Plasma volume (m^3).
-    n_charge_plasma_effective_mass_weighted_vol_avg:
-        Mass weighted plasma effective charge.
+    n_charge_plasma_effective_mass_weighted_vol_avg :
+        Mass-weighted effective plasma charge.
 
     Returns
     -------
     :
-        tuple: A tuple containing the following elements:
-        - beta_beam (float): Neutral beam beta component.
-        - nd_beam_ions_out (float): Hot beam ion density (m^-3).
-        - p_beam_alpha_mw (float): Alpha power from hot neutral beam ions (MW).
+        tuple[float, float, float]: A tuple containing:
+        - Neutral beam beta contribution.
+        - Hot beam ion density (m^-3).
+        - Alpha power from beam-target fusion (MW).
 
     Notes
     -----
-        - The function uses the Bosch-Hale parametrization to compute the reactivity.
-        - The critical energy for electron/ion slowing down of the beam ion is calculated
-        for both deuterium and tritium neutral beams.
-        - The function integrates the hot beam fusion reaction rate integrand over the
-        range of beam velocities up to the critical velocity.
+        - The function uses the Bosch-Hale parametrization to evaluate fusion reactivity.
+        - Beam ion slowing-down properties are computed using Coulomb collision physics.
+        - Fusion power is obtained by integrating the beam-target reaction rate over
+        the fast-ion distribution.
 
     References
     ----------
@@ -960,15 +953,16 @@ def beam_fusion(
         Nuclear Fusion, vol. 32, no. 4, pp. 611-631, Apr. 1992,
         doi: https://doi.org/10.1088/0029-5515/32/4/i07.
 
-        - J. W. Sheffield, “The physics of magnetic fusion reactors,” vol. 66, no. 3, pp. 1015-1103,
-        Jul. 1994, doi: https://doi.org/10.1103/revmodphys.66.1015.
+        - J. W. Sheffield, “The physics of magnetic fusion reactors,”
+        Rev. Mod. Phys., vol. 66, no. 3, pp. 1015-1103, Jul. 1994, Jul. 1994,
+        doi: https://doi.org/10.1103/revmodphys.66.1015.
 
-        - Deng Baiquan and G. A. Emmert, “Fast ion pressure in fusion plasma,” Nuclear Fusion and Plasma Physics,
-        vol. 9, no. 3, pp. 136-141, 2022, Available: https://fti.neep.wisc.edu/fti.neep.wisc.edu/pdf/fdm718.pdf
-        ‌
+        - Deng Baiquan and G. A. Emmert, “Fast ion pressure in fusion plasma,”
+        Nuclear Fusion and Plasma Physics, vol. 9, no. 3, pp. 136-141, 2022.
+        Available: https://fti.neep.wisc.edu/fti.neep.wisc.edu/pdf/fdm718.pdf
     """
     # Beam ion slowing down time given by Deng Baiquan and G. A. Emmert 1987
-    beam_slow_time = (
+    t_beam_slow = (
         1.99e19
         * (
             constants.M_DEUTERON_AMU * (1.0 - f_beam_tritium)
@@ -994,100 +988,118 @@ def beam_fusion(
     )
 
     # Deuterium and tritium ion densities
-    deuterium_density = nd_plasma_fuel_ions_vol_avg * f_deuterium_plasma
-    tritium_density = nd_plasma_fuel_ions_vol_avg * f_tritium_plasma
+    nd_plasma_deuterium = nd_plasma_fuel_ions_vol_avg * f_deuterium_plasma
+    nd_plasma_tritium = nd_plasma_fuel_ions_vol_avg * f_tritium_plasma
 
     (
-        deuterium_beam_alpha_power,
-        tritium_beam_alpha_power,
-        hot_beam_density,
-        beam_deposited_energy,
-    ) = beamcalc(
-        deuterium_density,
-        tritium_density,
+        nd_beam_deuterium,
+        nd_beam_tritium,
+        deuterium_critical_energy_speed,
+        tritium_critical_energy_speed,
+        nd_beam_hot,
+        e_beam_deposited_kev,
+    ) = beam_slowing_down_state(
         e_beam_kev,
         critical_energy_deuterium,
         critical_energy_tritium,
-        beam_slow_time,
+        t_beam_slow,
         f_beam_tritium,
         c_beam_total,
-        temp_plasma_ion_density_weighted_kev,
         vol_plasma,
-        sigmav_dt_average,
+    )
+
+    sigv_beam_deuterium = beam_reaction_rate_coefficient(
+        constants.M_DEUTERON_AMU, deuterium_critical_energy_speed, e_beam_kev
+    )
+
+    sigv_beam_tritium = beam_reaction_rate_coefficient(
+        constants.M_TRITON_AMU, tritium_critical_energy_speed, e_beam_kev
+    )
+
+    reaction_rate_beam_deuterium_dt = beam_target_reaction_rate(
+        nd_beam_deuterium,
+        nd_plasma_tritium,
+        sigv_beam_deuterium,
+        vol_plasma,
+    )
+    p_alpha_beam_deuterium_dt_mw = alpha_power_beam(
+        reaction_rate_beam_deuterium_dt,
+    )
+
+    reaction_rate_beam_tritium_dt = beam_target_reaction_rate(
+        nd_beam_tritium,
+        nd_plasma_deuterium,
+        sigv_beam_tritium,
+        vol_plasma,
+    )
+    p_alpha_beam_tritium_dt_mw = alpha_power_beam(
+        reaction_rate_beam_tritium_dt,
     )
 
     # Neutral beam alpha power
-    p_beam_alpha_mw = beamfus0 * (deuterium_beam_alpha_power + tritium_beam_alpha_power)
+    p_beam_alpha_mw = beamfus0 * (
+        p_alpha_beam_deuterium_dt_mw + p_alpha_beam_tritium_dt_mw
+    )
 
     # Neutral beam beta
     beta_beam = (
         betbm0
         * 4.03e-22
         * (2 / 3)
-        * hot_beam_density
-        * beam_deposited_energy
+        * nd_beam_hot
+        * e_beam_deposited_kev
         / (b_plasma_toroidal_on_axis**2 + b_plasma_poloidal_average**2)
     )
 
-    return beta_beam, hot_beam_density, p_beam_alpha_mw
+    return beta_beam, nd_beam_hot, p_beam_alpha_mw
 
 
-def beamcalc(
-    nd: float,
-    nt: float,
+def beam_slowing_down_state(
     e_beam_kev: float,
     critical_energy_deuterium: float,
     critical_energy_tritium: float,
-    beam_slow_time: float,
+    t_beam_slow: float,
     f_beam_tritium: float,
     c_beam_total: float,
-    temp_plasma_ion_vol_avg_kev: float,
     vol_plasma: float,
-    svdt: float,
-) -> tuple[float, float, float, float]:
-    """Calculate neutral beam alpha power and ion energy.
+) -> tuple[float, float, float, float, float, float]:
+    """Calculate beam slowing-down state and hot ion properties.
 
-    This function computes the alpha power generated from the interaction between
-    hot beam ions and thermal ions in the plasma, as well as the hot beam ion density
-    and average hot beam ion energy.
+    Estimates the steady-state hot D and T beam-ion densities from beam
+    source rate times slowing-down residence time, computes species critical
+    velocities from critical energies, evaluates a slowing-down-distribution
+    fast-ion pressure for each species, and converts that pressure into a
+    pressure-equivalent mean fast-ion energy.
 
     Parameters
     ----------
-    nd :
-        Thermal deuterium density (m^-3).
-    nt :
-        Thermal tritium density (m^-3).
     e_beam_kev :
         Beam energy (keV).
     critical_energy_deuterium :
-        Critical energy for electron/ion slowing down of the beam ion (deuterium neutral beam) (keV).
+        Critical energy for electron/ion slowing down of deuterium beam ions (keV).
     critical_energy_tritium :
-        Critical energy for beam slowing down (tritium neutral beam) (keV).
-    beam_slow_time :
-        Beam ion slowing down time on electrons (s).
+        Critical energy for electron/ion slowing down of tritium beam ions (keV).
+    t_beam_slow :
+        Beam ion slowing-down time on electrons (s).
     f_beam_tritium :
-        Beam tritium fraction (0.0 = deuterium beam).
+        Tritium fraction in the injected beam (0.0 = pure deuterium beam).
     c_beam_total :
-        Beam current (A).
-    temp_plasma_ion_vol_avg_kev :
-        Thermal ion temperature (keV).
+        Total neutral beam current (A).
     vol_plasma :
         Plasma volume (m^3).
-    svdt :
-        Profile averaged <sigma v> for D-T (m^3/s).
 
     Returns
     -------
-    :
-        tuple[float, float, float, float]: A tuple containing the following elements:
-        - Alpha power from deuterium beam-background fusion (MW).
-        - Alpha power from tritium beam-background fusion (MW).
-        - Hot beam ion density (m^-3).
-        - Average hot beam ion energy (keV).
+        tuple[float, float, float, float, float, float]: A tuple containing:
+        - Deuterium beam ion density (m^-3).
+        - Tritium beam ion density (m^-3).
+        - Deuterium critical speed (m/s).
+        - Tritium critical speed (m/s).
+        - Total hot beam ion density (m^-3).
+        - Average deposited beam ion energy (keV).
 
     Notes
     -----
-        - The function uses the Bosch-Hale parametrization to compute the reactivity.
         - The critical energy for electron/ion slowing down of the beam ion is calculated
         for both deuterium and tritium neutral beams.
         - The function integrates the hot beam fusion reaction rate integrand over the
@@ -1119,13 +1131,13 @@ def beamcalc(
     beam_energy_ratio_deuterium = e_beam_kev / critical_energy_deuterium
 
     # Calculate the characterstic time for the deuterium ions to slow down to the thermal energy, eg E = 0.
-    characteristic_deuterium_beam_slow_time = (
-        beam_slow_time / 3.0 * np.log(1.0 + (beam_energy_ratio_deuterium) ** 1.5)
+    characteristic_deuterium_t_beam_slow = (
+        t_beam_slow / 3.0 * np.log(1.0 + (beam_energy_ratio_deuterium) ** 1.5)
     )
 
     deuterium_beam_density = (
         beam_current_deuterium
-        * characteristic_deuterium_beam_slow_time
+        * characteristic_deuterium_t_beam_slow
         / (constants.ELECTRON_CHARGE * vol_plasma)
     )
 
@@ -1134,17 +1146,17 @@ def beamcalc(
 
     # Calculate the characterstic time for the tritium to slow down to the thermal energy, eg E = 0.
     # Wesson, J. (2011) Tokamaks.
-    characteristic_tritium_beam_slow_time = (
-        beam_slow_time / 3.0 * np.log(1.0 + (beam_energy_ratio_tritium) ** 1.5)
+    characteristic_tritium_t_beam_slow = (
+        t_beam_slow / 3.0 * np.log(1.0 + (beam_energy_ratio_tritium) ** 1.5)
     )
 
     tritium_beam_density = (
         beam_current_tritium
-        * characteristic_tritium_beam_slow_time
+        * characteristic_tritium_t_beam_slow
         / (constants.ELECTRON_CHARGE * vol_plasma)
     )
 
-    hot_beam_density = deuterium_beam_density + tritium_beam_density
+    nd_beam_hot = deuterium_beam_density + tritium_beam_density
 
     # Find the speed of the deuterium particle when it has the critical energy.
     # Re-arrange kinetic energy equation to find speed. Non-relativistic.
@@ -1175,7 +1187,7 @@ def beamcalc(
     pressure_coeff_deuterium = (
         constants.M_DEUTERON_AMU
         * constants.ATOMIC_MASS_UNIT
-        * beam_slow_time
+        * t_beam_slow
         * deuterium_critical_energy_speed**2
         * source_deuterium
         / (constants.KILOELECTRON_VOLT * 3.0)
@@ -1183,7 +1195,7 @@ def beamcalc(
     pressure_coeff_tritium = (
         constants.M_TRITON_AMU
         * constants.ATOMIC_MASS_UNIT
-        * beam_slow_time
+        * t_beam_slow
         * tritium_critical_energy_speed**2
         * source_tritium
         / (constants.KILOELECTRON_VOLT * 3.0)
@@ -1200,64 +1212,55 @@ def beamcalc(
 
     # Beam deposited energy
     # Find the energy from the ideal gas pressure, P=1/3 * nmv^2 = 2/3 * n<E>
-    deuterium_deposited_energy = 1.5 * deuterium_pressure / deuterium_beam_density
-    tritium_deposited_energy = 1.5 * tritium_pressure / tritium_beam_density
-
-    total_depsoited_energy = (
-        (deuterium_beam_density * deuterium_deposited_energy)
-        + (tritium_beam_density * tritium_deposited_energy)
-    ) / hot_beam_density
-
-    hot_deuterium_rate = 1e-4 * beam_reaction_rate(
-        constants.M_DEUTERON_AMU, deuterium_critical_energy_speed, e_beam_kev
+    deuterium_deposited_energy = (
+        1.5 * deuterium_pressure / deuterium_beam_density
+        if deuterium_beam_density > 0.0
+        else 0.0
+    )
+    tritium_deposited_energy = (
+        1.5 * tritium_pressure / tritium_beam_density
+        if tritium_beam_density > 0.0
+        else 0.0
     )
 
-    hot_tritium_rate = 1e-4 * beam_reaction_rate(
-        constants.M_TRITON_AMU, tritium_critical_energy_speed, e_beam_kev
-    )
-
-    deuterium_beam_alpha_power = alpha_power_beam(
-        deuterium_beam_density,
-        nt,
-        hot_deuterium_rate,
-        vol_plasma,
-        temp_plasma_ion_vol_avg_kev,
-        svdt,
-    )
-    tritium_beam_alpha_power = alpha_power_beam(
-        tritium_beam_density,
-        nd,
-        hot_tritium_rate,
-        vol_plasma,
-        temp_plasma_ion_vol_avg_kev,
-        svdt,
+    total_deposited_energy = (
+        (
+            deuterium_beam_density * deuterium_deposited_energy
+            + tritium_beam_density * tritium_deposited_energy
+        )
+        / nd_beam_hot
+        if nd_beam_hot > 0.0
+        else 0.0
     )
 
     return (
-        deuterium_beam_alpha_power,
-        tritium_beam_alpha_power,
-        hot_beam_density,
-        total_depsoited_energy,
+        deuterium_beam_density,
+        tritium_beam_density,
+        deuterium_critical_energy_speed,
+        tritium_critical_energy_speed,
+        nd_beam_hot,
+        total_deposited_energy,
     )
 
 
 def fast_ion_pressure_integral(e_beam_kev: float, critical_energy: float) -> float:
-    """Calculate the fraction of initial beam energy given to the ions.
+    """Evaluate the dimensionless fast-ion pressure integral.
 
-    This function computes the fraction of initial beam energy given to the ions. based on the neutral beam energy
-    and the critical energy for electron/ion slowing down of the beam ion.
+    This function returns the closed-form dimensionless integral factor
+    appearing in the analytic fast-ion pressure expression for a
+    monoenergetic source with a classical slowing-down distribution.
 
     Parameters
     ----------
     e_beam_kev :
-        Neutral beam energy (keV).
+        Beam birth energy (keV).
     critical_energy :
-        Critical energy for electron/ion slowing down of the beam ion (keV).
+        Critical energy for electron/ion slowing down (keV).
 
     Returns
     -------
-    :
-        float: Fraction of initial beam energy given to the ions.
+    float
+        Dimensionless pressure integral factor.
 
     Notes
     -----
@@ -1287,130 +1290,149 @@ def fast_ion_pressure_integral(e_beam_kev: float, critical_energy: float) -> flo
     return t1 + t2 - t3 - t4
 
 
-def alpha_power_beam(
-    beam_ion_desnity: float,
-    plasma_ion_desnity: float,
-    sigv: float,
+def beam_target_reaction_rate(
+    nd_beam_ion: float,
+    nd_target_ion: float,
+    sigv_beam: float,
     vol_plasma: float,
-    temp_plasma_ion_vol_avg_kev: float,
-    sigmav_dt: float,
 ) -> float:
-    """Calculate alpha power from beam-background fusion.
+    """Calculate the total beam-target fusion reaction rate.
 
-    This function computes the alpha power generated from the interaction between
-    hot beam ions and thermal ions in the plasma.
+    This function computes the total number of beam-target fusion reactions
+    occurring per second in the plasma.
+
+    The total beam-target reaction rate is given by:
+        reaction_rate = nd_beam_ion * nd_target_ion * sigv_beam * vol_plasma
+
+    Unit analysis:
+        (m^-3) * (m^-3) * (m^3/s) * (m^3) = s^-1
 
     Parameters
     ----------
-    beam_ion_desnity :
+    nd_beam_ion :
         Hot beam ion density (m^-3).
-    plasma_ion_desnity :
-        Thermal ion density (m^-3).
-    sigv :
-        Hot beam fusion reaction rate (m^3/s).
+    nd_target_ion :
+        Thermal target ion density (m^-3).
+    sigv_beam :
+        Beam-target fusion reactivity (m^3/s).
     vol_plasma :
         Plasma volume (m^3).
-    temp_plasma_ion_vol_avg_kev :
-        Thermal ion temperature (keV).
-    sigmav_dt :
-        Profile averaged <sigma v> for D-T (m^3/s).
 
     Returns
     -------
-    :
-        float: Alpha power from beam-background fusion (MW).
+        float: Total beam-target fusion reaction rate (s^-1).
 
     Notes
     -----
-    - The function uses the Bosch-Hale parametrization to compute the reactivity.
-    - The ratio of the profile-averaged <sigma v> to the reactivity at the given
-    thermal ion temperature is used to scale the alpha power.
-
-    References
-    ----------
-    - H.-S. Bosch and G. M. Hale, “Improved formulas for fusion cross-sections and thermal reactivities,”
-    Nuclear Fusion, vol. 32, no. 4, pp. 611-631, Apr. 1992,
-    doi: https://doi.org/10.1088/0029-5515/32/4/i07.
+    Any spatial/profile effects should be introduced through the
+    supplied nd_target_ion.
     """
-    # Calculate the reactivity ratio
-    ratio = (
-        sigmav_dt
-        / bosch_hale_reactivity(
-            np.array([temp_plasma_ion_vol_avg_kev]),
-            BoschHaleConstants(**REACTION_CONSTANTS_DT),
-        ).item()
-    )
-
-    # Calculate and return the alpha power
-    return (
-        beam_ion_desnity
-        * plasma_ion_desnity
-        * sigv
-        * (constants.DT_ALPHA_ENERGY / 1e6)
-        * vol_plasma
-        * ratio
-    )
+    return nd_beam_ion * nd_target_ion * sigv_beam * vol_plasma
 
 
-def beam_reaction_rate(
-    relative_mass_ion: float, critical_velocity: float, beam_energy_keV: float
+def alpha_power_beam(
+    beam_target_reaction_rate: float,
 ) -> float:
-    """Calculate the hot beam fusion reaction rate.
+    """Calculate alpha power from beam-target fusion.
 
-    This function computes the fusion reaction rate for hot beam ions
-    using the critical velocity for electron/ion slowing down and the
-    neutral beam energy.
+    This function converts the total beam-target fusion reaction rate into
+    alpha particle power.
+
+    The alpha power is given by:
+        P_alpha = beam_target_reaction_rate * DT_ALPHA_ENERGY
+
+    Unit analysis:
+        (s^-1) * (J) = W
+
+    The result is converted from watts to megawatts (MW).
+
+    Parameters
+    ----------
+    beam_target_reaction_rate :
+        Total beam-target fusion reaction rate (s^-1).
+
+    Returns
+    -------
+        float: Alpha power from beam-target fusion (MW).
+    """
+    return beam_target_reaction_rate * constants.DT_ALPHA_ENERGY / 1.0e6
+
+
+def beam_reaction_rate_coefficient(
+    relative_mass_ion: float, critical_velocity: float, beam_energy_kev: float
+) -> float:
+    """Calculate an effective beam-target fusion rate coefficient.
+
+    This function evaluates an effective fusion rate coefficient for a
+    slowing-down fast-ion population interacting with a thermal target
+    plasma. The beam ions are assumed to follow a classical slowing-down
+    distribution characterised by the critical velocity, and the fusion
+    contribution is obtained by integrating a beam-energy-dependent fusion
+    cross-section over the slowing-down distribution.
 
     Parameters
     ----------
     relative_mass_ion :
-        Relative atomic mass of the ion (e.g., approx 2.0 for D, 3.0 for T).
+        Relative atomic mass of the ion (e.g. approx 2.0 for D, 3.0 for T).
     critical_velocity :
         Critical velocity for electron/ion slowing down of the beam ion [m/s].
-    beam_energy_keV :
+    beam_energy_kev :
         Neutral beam energy [keV].
 
     Returns
     -------
     :
-        float: Hot beam fusion reaction rate (m^3/s).
+        float: Hot beam fusion rate coefficient [m^3/s].
 
     Notes
     -----
-    - The function integrates the hot beam fusion reaction rate integrand
-    over the range of beam velocities up to the critical velocity.
-    - The integration is performed using the quad function from scipy.integrate.
+    - The function returns a reactivity rate coefficient, not the reaction rate itself.
+    - The integration variable is the beam speed normalised to the critical speed.
+    - The underlying beam fusion cross-section is evaluated in cm^2 and converted
+      internally to m^2 so that this function returns an SI rate coefficient.
+    - The integration is performed using scipy.integrate.quad.
 
+    References
+    ----------
+    - S. Niikura and M. Nagami, "Improvement of fusion reactivity and fusion
+      power multiplication factor in the presence of fast ions," Fusion
+      Engineering and Design, vol. 12, pp. 467-480, 1990.
     """
     # Find the speed of the beam particle when it has the critical energy.
     # Re-arrange kinetic energy equation to find speed. Non-relativistic.
     beam_velocity = np.sqrt(
-        (beam_energy_keV * constants.KILOELECTRON_VOLT)
+        (beam_energy_kev * constants.KILOELECTRON_VOLT)
         * 2.0
         / (relative_mass_ion * constants.ATOMIC_MASS_UNIT)
     )
 
     relative_velocity = beam_velocity / critical_velocity
-    integral_coefficient = 3.0 * critical_velocity / np.log(1.0 + (relative_velocity**3))
+    integral_coefficient = 3.0 * critical_velocity / np.log(1.0 + relative_velocity**3)
 
-    fusion_integral = integrate.quad(
+    fusion_integral_cm2 = integrate.quad(
         _hot_beam_fusion_reaction_rate_integrand,
         0.0,
         relative_velocity,
         args=(critical_velocity,),
     )[0]
 
-    return integral_coefficient * fusion_integral
+    # _hot_beam_fusion_cross_section returns cm^2, so the integrated quantity is in
+    # cm^2. Convert to m^2 here so the final rate coefficient is returned in m^3/s.
+    fusion_integral_m2 = fusion_integral_cm2 * 1.0e-4
+
+    return integral_coefficient * fusion_integral_m2
 
 
 def _hot_beam_fusion_reaction_rate_integrand(
     velocity_ratio: float, critical_velocity: float
 ) -> float:
-    """Integrand function for the hot beam fusion reaction rate.
+    """Evaluate the integrand for the beam-target fusion rate coefficient.
 
-    This function computes the integrand for the hot beam fusion reaction rate
-    based on the ratio of beam velocity to the critical velocity and the critical
-    velocity for electron/ion slowing down of the beam ion.
+    This function returns the slowing-down-weighted integrand used to
+    compute the effective beam-target fusion rate coefficient for a fast-ion
+    population. The integration variable is the beam speed normalised to the
+    critical speed, and the integrand combines a slowing-down weighting with
+    the beam fusion cross-section evaluated at the corresponding beam energy.
 
     Parameters
     ----------
@@ -1422,15 +1444,22 @@ def _hot_beam_fusion_reaction_rate_integrand(
 
     Returns
     -------
-    :
         float: Value of the integrand for the hot beam fusion reaction rate.
 
     Notes
     -----
-    - The function uses the ratio of the beam velocity to the critical velocity
-    to compute the integrand.
-    - The integrand involves the fusion reaction cross-section and the critical
-    velocity for electron/ion slowing down of the beam ion.
+    - The factor `velocity_ratio**3 / (1.0 + velocity_ratio**3)` represents
+      the slowing-down weighting in the normalised velocity variable.
+    - The beam energy passed to `_beam_fusion_cross_section` is constructed
+      from the instantaneous beam speed and expressed in keV/amu.
+    - This function is an internal helper used by
+      `beam_reaction_rate_coefficient`.
+
+    References
+    ----------
+    - S. Niikura and M. Nagami, "Improvement of fusion reactivity and fusion
+      power multiplication factor in the presence of fast ions," Fusion
+      Engineering and Design, vol. 12, pp. 467-480, 1990.
 
     """
     intgeral_term = (velocity_ratio**3) / (1.0 + velocity_ratio**3)
@@ -1448,7 +1477,7 @@ def _hot_beam_fusion_reaction_rate_integrand(
 
 
 def _beam_fusion_cross_section(vrelsq: float) -> float:
-    """Calculate the fusion reaction cross-section.
+    """Calculate the beam fusion cross-section from beam energy.
 
     This function computes the fusion reaction cross-section based on the
     square of the speed of the beam ion (keV/amu). The functional form of
@@ -1463,16 +1492,16 @@ def _beam_fusion_cross_section(vrelsq: float) -> float:
 
     Returns
     -------
-    :
         Fusion reaction cross-section (cm^2).
 
     Notes
     -----
-    The cross-section is limited at low and high beam energies.
-    For beam kinetic energy less than 10 keV, the cross-section is set to 1.0e-27 cm^2.
-    For beam kinetic energy greater than 10,000 keV, the cross-section is set to 8.0e-26 cm^2.
-    The cross-section is calculated using a functional form with parameters a1 to a5.
-
+    - The cross-section is limited at low and high beam energies.
+    - For beam kinetic energy less than 10 keV, the cross-section is set to 1.0e-27 cm^2.
+    - For beam kinetic energy greater than 10,000 keV, the cross-section is set to 8.0e-26 cm^2.
+    - The cross-section is calculated using a functional form with parameters a1 to a5.
+    - The exact provenance of this particular fit and its coefficients has
+      not yet been traced in the present code documentation.
     """
     a1 = 45.95
     a2 = 5.02e4

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -568,7 +568,7 @@ class Physics(Model):
 
         # Calculate neutral beam slowing down effects
         # If ignited, then ignore beam fusion effects
-
+        print(physics_variables.b_plasma_total)
         if (current_drive_variables.c_beam_total != 0.0e0) and (  # noqa: RUF069
             physics_variables.i_plasma_ignited == 0
         ):
@@ -579,8 +579,7 @@ class Physics(Model):
             ) = reactions.beam_fusion(
                 physics_variables.beamfus0,
                 physics_variables.betbm0,
-                physics_variables.b_plasma_surface_poloidal_average,
-                physics_variables.b_plasma_toroidal_on_axis,
+                physics_variables.b_plasma_total,
                 current_drive_variables.c_beam_total,
                 physics_variables.nd_plasma_electrons_vol_avg,
                 physics_variables.nd_plasma_fuel_ions_vol_avg,

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -568,7 +568,6 @@ class Physics(Model):
 
         # Calculate neutral beam slowing down effects
         # If ignited, then ignore beam fusion effects
-        print(physics_variables.b_plasma_total)
         if (current_drive_variables.c_beam_total != 0.0e0) and (  # noqa: RUF069
             physics_variables.i_plasma_ignited == 0
         ):

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -589,9 +589,7 @@ class Physics(Model):
                 physics_variables.f_plasma_fuel_deuterium,
                 physics_variables.f_plasma_fuel_tritium,
                 current_drive_variables.f_beam_tritium,
-                physics_variables.sigmav_dt_average,
                 physics_variables.temp_plasma_electron_density_weighted_kev,
-                physics_variables.temp_plasma_ion_density_weighted_kev,
                 physics_variables.vol_plasma,
                 physics_variables.n_charge_plasma_effective_mass_weighted_vol_avg,
             )

--- a/process/models/stellarator/stellarator.py
+++ b/process/models/stellarator/stellarator.py
@@ -2040,8 +2040,7 @@ class Stellarator(Model):
             ) = reactions.beam_fusion(
                 physics_variables.beamfus0,
                 physics_variables.betbm0,
-                physics_variables.b_plasma_surface_poloidal_average,
-                physics_variables.b_plasma_toroidal_on_axis,
+                physics_variables.b_plasma_total,
                 current_drive_variables.c_beam_total,
                 physics_variables.nd_plasma_electrons_vol_avg,
                 physics_variables.nd_plasma_fuel_ions_vol_avg,

--- a/process/models/stellarator/stellarator.py
+++ b/process/models/stellarator/stellarator.py
@@ -2050,9 +2050,7 @@ class Stellarator(Model):
                 physics_variables.f_plasma_fuel_deuterium,
                 physics_variables.f_plasma_fuel_tritium,
                 current_drive_variables.f_beam_tritium,
-                physics_variables.sigmav_dt_average,
                 physics_variables.temp_plasma_electron_density_weighted_kev,
-                physics_variables.temp_plasma_ion_density_weighted_kev,
                 physics_variables.vol_plasma,
                 physics_variables.n_charge_plasma_effective_mass_weighted_vol_avg,
             )

--- a/tests/unit/models/physics/test_fusion_reactions.py
+++ b/tests/unit/models/physics/test_fusion_reactions.py
@@ -5,6 +5,7 @@ from typing import Any, NamedTuple
 import numpy as np
 import pytest
 
+from process.core import constants
 from process.data_structure import physics_variables as pv
 from process.models.physics import fusion_reactions as reactions
 
@@ -228,7 +229,7 @@ def test_bosch_hale(t, reaction, expected_bosch_hale):
     assert bosch_hale == pytest.approx(expected_bosch_hale, abs=1e-23)
 
 
-def test_beam_fusion():
+def test_beam_fusion(monkeypatch):
     beta_beam, nd_beam_ions_out, p_beam_alpha_mw = reactions.beam_fusion(
         1.0,
         1.5,
@@ -242,8 +243,6 @@ def test_beam_fusion():
         0.5,
         0.5,
         1e-06,
-        2.8e-22,
-        13.5,
         13.5,
         1888.0,
         0.425,
@@ -251,31 +250,30 @@ def test_beam_fusion():
 
     assert beta_beam == pytest.approx(0.0026264022466211366)
     assert nd_beam_ions_out == pytest.approx(4.2133504058678246e17)
-    assert p_beam_alpha_mw == pytest.approx(11.593221085189192)
+    assert p_beam_alpha_mw == pytest.approx(9.271206216041564)
 
 
-def test_beamcalc():
+def test_beam_slowing_down_state():
     (
-        deuterium_beam_alpha_power,
-        tritium_beam_alpha_power,
+        deuterium_beam_density,
+        tritium_beam_density,
+        deuterium_critical_energy_speed,
+        tritium_critical_energy_speed,
         hot_beam_density,
         beam_deposited_energy,
-    ) = reactions.beamcalc(
-        3.3e19,
-        3.3e19,
+    ) = reactions.beam_slowing_down_state(
         1000.0,
         276.7,
         415.0,
         1.42,
         1e-06,
         130,
-        13.5,
         1888.0,
-        2.8e-22,
     )
-
-    assert deuterium_beam_alpha_power == pytest.approx(11.561197668655383)
-    assert tritium_beam_alpha_power == pytest.approx(1.0434445041616093e-05)
+    assert deuterium_beam_density == pytest.approx(4.1968331737565126e17)
+    assert tritium_beam_density == pytest.approx(316553077182.4059, rel=1e-6)
+    assert deuterium_critical_energy_speed == pytest.approx(5.1495e6, rel=1e-4)
+    assert tritium_critical_energy_speed == pytest.approx(5.1534e6, rel=1e-4)
     assert hot_beam_density == pytest.approx(4.1968331737565126e17)
     assert beam_deposited_energy == pytest.approx(445.05787301616635)
 
@@ -286,15 +284,28 @@ def test__fast_ion_pressure_integral():
     assert pressure_integral == pytest.approx(1.1061397270783706)
 
 
-def test_alpha_power_beam():
-    alpha_power_beam = reactions.alpha_power_beam(
-        316000000000, 3.3e19, 7.5e-22, 1888.0, 13.5, 2.8e-22
+def test_beam_target_reaction_rate():
+    reaction_rate = reactions.beam_target_reaction_rate(
+        nd_beam_ion=3.16e11,
+        nd_target_ion=3.3e19,
+        sigv_beam=7.5e-22,
+        vol_plasma=1888.0,
     )
 
-    assert alpha_power_beam == pytest.approx(1.047572705194316e-05)
+    assert reaction_rate == pytest.approx(1.4766048e13)
 
 
-def test_beam_reaction_rate():
-    beam_reaction_rate = reactions.beam_reaction_rate(3.01550071597, 5140000.0, 1000.0)
+def test_alpha_power_beam():
+    beam_target_rate = 1.0e13  # s^-1
+    result = reactions.alpha_power_beam(beam_target_rate)
+    expected = beam_target_rate * constants.DT_ALPHA_ENERGY / 1.0e6
 
-    assert beam_reaction_rate == pytest.approx(7.465047902975452e-18)
+    assert result == pytest.approx(expected)
+
+
+def test_beam_reaction_rate_coefficient():
+    beam_reaction_rate = reactions.beam_reaction_rate_coefficient(
+        3.01550071597, 5140000.0, 1000.0
+    )
+
+    assert beam_reaction_rate == pytest.approx(7.465047902975452e-22)

--- a/tests/unit/models/physics/test_fusion_reactions.py
+++ b/tests/unit/models/physics/test_fusion_reactions.py
@@ -229,7 +229,7 @@ def test_bosch_hale(t, reaction, expected_bosch_hale):
     assert bosch_hale == pytest.approx(expected_bosch_hale, abs=1e-23)
 
 
-def test_beam_fusion(monkeypatch):
+def test_beam_fusion():
     beta_beam, nd_beam_ions_out, p_beam_alpha_mw = reactions.beam_fusion(
         1.0,
         1.5,

--- a/tests/unit/models/physics/test_fusion_reactions.py
+++ b/tests/unit/models/physics/test_fusion_reactions.py
@@ -254,14 +254,7 @@ def test_beam_fusion():
 
 
 def test_beam_slowing_down_state():
-    (
-        deuterium_beam_density,
-        tritium_beam_density,
-        deuterium_critical_energy_speed,
-        tritium_critical_energy_speed,
-        hot_beam_density,
-        beam_deposited_energy,
-    ) = reactions.beam_slowing_down_state(
+    beam_state = reactions.beam_slowing_down_state(
         1000.0,
         276.7,
         415.0,
@@ -270,12 +263,15 @@ def test_beam_slowing_down_state():
         130,
         1888.0,
     )
-    assert deuterium_beam_density == pytest.approx(4.1968331737565126e17)
-    assert tritium_beam_density == pytest.approx(316553077182.4059, rel=1e-6)
-    assert deuterium_critical_energy_speed == pytest.approx(5.1495e6, rel=1e-4)
-    assert tritium_critical_energy_speed == pytest.approx(5.1534e6, rel=1e-4)
-    assert hot_beam_density == pytest.approx(4.1968331737565126e17)
-    assert beam_deposited_energy == pytest.approx(445.05787301616635)
+
+    assert beam_state.deuterium_beam_density == pytest.approx(4.1968331737565126e17)
+    assert beam_state.tritium_beam_density == pytest.approx(316553077182.4059, rel=1e-6)
+    assert beam_state.deuterium_critical_energy_speed == pytest.approx(
+        5.1495e6, rel=1e-4
+    )
+    assert beam_state.tritium_critical_energy_speed == pytest.approx(5.1534e6, rel=1e-4)
+    assert beam_state.nd_beam_hot == pytest.approx(4.1968331737565126e17)
+    assert beam_state.e_beam_deposited_kev == pytest.approx(445.05787301616635)
 
 
 def test__fast_ion_pressure_integral():

--- a/tests/unit/models/physics/test_fusion_reactions.py
+++ b/tests/unit/models/physics/test_fusion_reactions.py
@@ -233,8 +233,7 @@ def test_beam_fusion():
     beta_beam, nd_beam_ions_out, p_beam_alpha_mw = reactions.beam_fusion(
         1.0,
         1.5,
-        0.85,
-        5.3,
+        5.367727,
         130,
         7.8e19,
         6.6e19,


### PR DESCRIPTION
## Description

Refactored beam_fusion model.

The model now directly computes beam alpha power from:

- fast beam ion density (from a slowing-down model)
- beam-weighted thermal target density
- beam-target fusion reactivity
- plasma volume

The previous thermal reactivity correction (Bosch-Hale) has been removed.

This was not physically consistent:

- thermal fusion involves two Maxwellian populations
- beam-target fusion involves one fast population and one thermal population
- the beam reactivity already includes fast-ion averaging

- See the docs for outline of the routine. I haven't changed much else of the physics but it's been listed more clearly in the docs in the new functional form.
- Most of the changes are clarifying what each function is actually calculating and changing docstring and name accordingly.

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
