### PR TITLE
:bug:   Add full tf midplane thickness

### DIFF
--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -10072,7 +10072,7 @@ def plot_tf_coil_structure(axis: plt.Axes, mfile: MFile, scan: int, colour_schem
     axis.text(
         (r_tf_inboard_out + r_tf_outboard_in) / 1.5,
         -z_tf_inside_half / 12,
-        f"{r_tf_outboard_in - r_tf_inboard_in:.3f} m",
+        f"{mfile.get('dr_tf_internal_midplane', scan=scan):.3f} m",
         fontsize=7,
         color="black",
         verticalalignment="center",
@@ -10096,7 +10096,7 @@ def plot_tf_coil_structure(axis: plt.Axes, mfile: MFile, scan: int, colour_schem
     axis.text(
         (r_tf_inboard_out + r_tf_outboard_in) / 1.5,
         0.0,
-        f"{(r_tf_outboard_in + dr_tf_outboard) - r_tf_inboard_in:.3f} m",
+        f"{mfile.get('dr_tf_full_midplane', scan=scan):.3f} m",
         fontsize=7,
         color="black",
         verticalalignment="center",

--- a/process/data_structure/tfcoil_variables.py
+++ b/process/data_structure/tfcoil_variables.py
@@ -767,6 +767,12 @@ dr_tf_nose_case: float = None
 (calculated for stellarators)
 """
 
+dr_tf_full_midplane: float = None
+"""Full radial thickness of TF coil at midplane (m)"""
+
+dr_tf_internal_midplane: float = None
+"""Internal radial thickness of TF coil at midplane (m)"""
+
 
 dr_tf_wp_with_insulation: float = None
 """radial thickness of winding pack (m) (`iteration variable 140`) (issue #514)"""
@@ -1221,6 +1227,8 @@ def init_tfcoil_variables():
         dx_tf_turn_insulation, \
         layer_ins, \
         dr_tf_nose_case, \
+        dr_tf_full_midplane, \
+        dr_tf_internal_midplane, \
         dr_tf_wp_with_insulation, \
         dx_tf_turn_steel, \
         dx_tf_wp_insulation, \
@@ -1454,6 +1462,8 @@ def init_tfcoil_variables():
     dx_tf_turn_insulation = 8e-4
     layer_ins = 0.0
     dr_tf_nose_case = 0.3
+    dr_tf_full_midplane = 0.0
+    dr_tf_internal_midplane = 0.0
     dr_tf_wp_with_insulation = 0.0
     dx_tf_turn_steel = 8e-3
     dx_tf_wp_insulation = 0.018

--- a/process/models/tfcoil/base.py
+++ b/process/models/tfcoil/base.py
@@ -239,35 +239,34 @@ class TFCoil(Model):
 
         Parameters
         ----------
-        i_tf_case_geom : int
+        i_tf_case_geom
             Geometry type of the TF coil case (e.g., circular or straight plasma-facing front case).
-        i_f_dr_tf_plasma_case : bool
+        i_f_dr_tf_plasma_case
             Whether the plasma-facing case thickness is specified as a fraction of the inboard thickness.
-        f_dr_tf_plasma_case : float
+        f_dr_tf_plasma_case
             Fraction of the inboard thickness used for the plasma-facing case thickness.
-        tfc_sidewall_is_fraction : bool
+        tfc_sidewall_is_fraction
             Whether the sidewall case thickness is specified as a fraction of the inboard radius.
-        casths_fraction : float
+        casths_fraction
             Fraction of the inboard radius used for the sidewall case thickness.
-        n_tf_coils : int
+        n_tf_coils
             Number of TF coils.
-        dr_tf_inboard : float
+        dr_tf_inboard
             Radial thickness of the inboard leg of the TF coil [m].
-        dr_tf_nose_case : float
+        dr_tf_nose_case
             Thickness of the inboard leg case at the nose region [m].
-        r_tf_inboard_out : float
+        r_tf_inboard_out
             Outer radius of the inboard leg of the TF coil [m].
-        r_tf_inboard_in : float
+        r_tf_inboard_in
             Inner radius of the inboard leg of the TF coil [m].
-        r_tf_outboard_mid : float
+        r_tf_outboard_mid
             Mid-plane radius of the outboard leg of the TF coil [m].
-        dr_tf_outboard : float
+        dr_tf_outboard
             Radial thickness of the outboard leg of the TF coil [m].
 
         Returns
         -------
-        TFGlobalGeometry
-            A dataclass containing the calculated global geometry parameters of the TF coil.
+        A dataclass containing the calculated global geometry parameters of the TF coil.
 
         """
         # The angular space of each TF coil in the toroidal direction [rad]

--- a/process/models/tfcoil/base.py
+++ b/process/models/tfcoil/base.py
@@ -105,6 +105,8 @@ class TFCoil(Model):
             superconducting_tf_coil_variables.r_tf_outboard_out,
             tfcoil_variables.dx_tf_inboard_out_toroidal,
             tfcoil_variables.a_tf_leg_outboard,
+            tfcoil_variables.dr_tf_full_midplane,
+            tfcoil_variables.dr_tf_internal_midplane,
             tfcoil_variables.dr_tf_plasma_case,
             tfcoil_variables.dx_tf_side_case_min,
         ) = self.tf_global_geometry(
@@ -227,6 +229,8 @@ class TFCoil(Model):
             - **rad_tf_coil_inboard_toroidal_half** (*float*): Toroidal angular spacing of each TF coil [radians].
             - **tan_theta_coil** (*float*): Tangent of the toroidal angular spacing.
             - **a_tf_inboard_total** (*float*): Cross-sectional area of the inboard leg of the TF coil [m²].
+            - **dr_tf_full_midplane** (*float*): Full radial thickness of the TF coil at the mid-plane [m].
+            - **dr_tf_internal_midplane** (*float*): Internal radial thickness of the TF coil at the mid-plane [m].
             - **r_tf_outboard_in** (*float*): Inner radius of the outboard leg of the TF coil [m].
             - **r_tf_outboard_out** (*float*): Outer radius of the outboard leg of the TF coil [m].
             - **dx_tf_inboard_out_toroidal** (*float*): Width of the inboard leg at the outer edge in the toroidal direction [m].
@@ -266,8 +270,18 @@ class TFCoil(Model):
 
         # Area of rectangular cross-section TF outboard leg [m^2]
         a_tf_leg_outboard = dx_tf_inboard_out_toroidal * dr_tf_outboard
+        
+        # =====================================================================
+        
+        # Full external coil width at mid-plane [m]
+
+        dr_tf_full_midplane = r_tf_outboard_out - r_tf_inboard_in
+
+        # Full internal coil width at mid-plane [m]
+        dr_tf_internal_midplane = r_tf_outboard_in - r_tf_inboard_out
 
         # ======================================================================
+        
         # Plasma facing front case thickness [m]
 
         if i_f_dr_tf_plasma_case:
@@ -315,6 +329,8 @@ class TFCoil(Model):
             r_tf_outboard_out,
             dx_tf_inboard_out_toroidal,
             a_tf_leg_outboard,
+            dr_tf_full_midplane,
+            dr_tf_internal_midplane,
             dr_tf_plasma_case,
             dx_tf_side_case_min,
         )
@@ -774,6 +790,20 @@ class TFCoil(Model):
             "Total outboard leg radial thickness (m)",
             "(dr_tf_outboard)",
             build_variables.dr_tf_outboard,
+        )
+        po.ovarre(
+            self.outfile,
+            "Full external coil width at mid-plane (m)",
+            "(dr_tf_full_midplane)",
+            tfcoil_variables.dr_tf_full_midplane,
+            "OP ",
+        )
+        po.ovarre(
+            self.outfile,
+            "Full internal coil width at mid-plane (m)",
+            "(dr_tf_internal_midplane)",
+            tfcoil_variables.dr_tf_internal_midplane,
+            "OP ",
         )
         po.ovarre(
             self.outfile,

--- a/process/models/tfcoil/base.py
+++ b/process/models/tfcoil/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+from dataclasses import dataclass
 from enum import IntEnum
 from types import DynamicClassAttribute
 from typing import TYPE_CHECKING
@@ -83,6 +84,21 @@ class TFPlasmaCaseType(IntEnum):
         return self._description_
 
 
+@dataclass
+class TFGlobalGeometry:
+    rad_tf_coil_inboard_toroidal_half: float
+    tan_theta_coil: float
+    a_tf_inboard_total: float
+    r_tf_outboard_in: float
+    r_tf_outboard_out: float
+    dx_tf_inboard_out_toroidal: float
+    a_tf_leg_outboard: float
+    dr_tf_full_midplane: float
+    dr_tf_internal_midplane: float
+    dr_tf_plasma_case: float
+    dx_tf_side_case_min: float
+
+
 class TFCoil(Model):
     """Calculates the parameters of a resistive TF coil system for a fusion power plant"""
 
@@ -97,19 +113,9 @@ class TFCoil(Model):
 
     def run_base_tf(self):
         """Run main tfcoil subroutine without outputting."""
-        (
-            superconducting_tf_coil_variables.rad_tf_coil_inboard_toroidal_half,
-            superconducting_tf_coil_variables.tan_theta_coil,
-            tfcoil_variables.a_tf_inboard_total,
-            superconducting_tf_coil_variables.r_tf_outboard_in,
-            superconducting_tf_coil_variables.r_tf_outboard_out,
-            tfcoil_variables.dx_tf_inboard_out_toroidal,
-            tfcoil_variables.a_tf_leg_outboard,
-            tfcoil_variables.dr_tf_full_midplane,
-            tfcoil_variables.dr_tf_internal_midplane,
-            tfcoil_variables.dr_tf_plasma_case,
-            tfcoil_variables.dx_tf_side_case_min,
-        ) = self.tf_global_geometry(
+        global_tf_geometry = TFGlobalGeometry
+
+        global_tf_geometry = self.tf_global_geometry(
             i_tf_case_geom=tfcoil_variables.i_tf_case_geom,
             i_f_dr_tf_plasma_case=tfcoil_variables.i_f_dr_tf_plasma_case,
             f_dr_tf_plasma_case=tfcoil_variables.f_dr_tf_plasma_case,
@@ -123,6 +129,30 @@ class TFCoil(Model):
             r_tf_outboard_mid=build_variables.r_tf_outboard_mid,
             dr_tf_outboard=build_variables.dr_tf_outboard,
         )
+
+        superconducting_tf_coil_variables.rad_tf_coil_inboard_toroidal_half = (
+            global_tf_geometry.rad_tf_coil_inboard_toroidal_half
+        )
+        superconducting_tf_coil_variables.tan_theta_coil = (
+            global_tf_geometry.tan_theta_coil
+        )
+        tfcoil_variables.a_tf_inboard_total = global_tf_geometry.a_tf_inboard_total
+        superconducting_tf_coil_variables.r_tf_outboard_in = (
+            global_tf_geometry.r_tf_outboard_in
+        )
+        superconducting_tf_coil_variables.r_tf_outboard_out = (
+            global_tf_geometry.r_tf_outboard_out
+        )
+        tfcoil_variables.dx_tf_inboard_out_toroidal = (
+            global_tf_geometry.dx_tf_inboard_out_toroidal
+        )
+        tfcoil_variables.a_tf_leg_outboard = global_tf_geometry.a_tf_leg_outboard
+        tfcoil_variables.dr_tf_full_midplane = global_tf_geometry.dr_tf_full_midplane
+        tfcoil_variables.dr_tf_internal_midplane = (
+            global_tf_geometry.dr_tf_internal_midplane
+        )
+        tfcoil_variables.dr_tf_plasma_case = global_tf_geometry.dr_tf_plasma_case
+        tfcoil_variables.dx_tf_side_case_min = global_tf_geometry.dx_tf_side_case_min
 
         tfcoil_variables.r_b_tf_inboard_peak = (
             build_variables.r_tf_inboard_out
@@ -185,7 +215,7 @@ class TFCoil(Model):
         r_tf_inboard_in: float,
         r_tf_outboard_mid: float,
         dr_tf_outboard: float,
-    ) -> tuple[float, float, float, float, float, float, float, float, float]:
+    ) -> TFGlobalGeometry:
         """Calculate the global geometry of the Toroidal Field (TF) coil.
 
         This method computes the overall geometry of the TF coil, including:
@@ -224,17 +254,20 @@ class TFCoil(Model):
 
         Returns
         -------
-        tuple
-            A tuple containing:
-            - **rad_tf_coil_inboard_toroidal_half** (*float*): Toroidal angular spacing of each TF coil [radians].
-            - **tan_theta_coil** (*float*): Tangent of the toroidal angular spacing.
-            - **a_tf_inboard_total** (*float*): Cross-sectional area of the inboard leg of the TF coil [m²].
-            - **dr_tf_full_midplane** (*float*): Full radial thickness of the TF coil at the mid-plane [m].
-            - **dr_tf_internal_midplane** (*float*): Internal radial thickness of the TF coil at the mid-plane [m].
-            - **r_tf_outboard_in** (*float*): Inner radius of the outboard leg of the TF coil [m].
-            - **r_tf_outboard_out** (*float*): Outer radius of the outboard leg of the TF coil [m].
-            - **dx_tf_inboard_out_toroidal** (*float*): Width of the inboard leg at the outer edge in the toroidal direction [m].
-            - **a_tf_leg_outboard** (*float*): Cross-sectional area of the outboard leg of the TF coil [m²].
+        TFGlobalGeometry
+            A dataclass containing the calculated global geometry parameters of the TF coil.
+            - rad_tf_coil_inboard_toroidal_half: Angular space of each TF coil in the toroidal direction [rad].
+            - tan_theta_coil: Tangent of the angle of the TF coil.
+            - a_tf_inboard_total: Total mid-plane cross-sectional area of the inboard legs [m²].
+            - r_tf_outboard_in: Inner radius of the outboard leg [m].
+            - r_tf_outboard_out: Outer radius of the outboard leg [m].
+            - dx_tf_inboard_out_toroidal: Toroidal width of the inboard leg at the outer edge [m].
+            - a_tf_leg_outboard: Cross-sectional area of the outboard leg [m²].
+            - dr_tf_full_midplane: Full external coil width at mid-plane [m].
+            - dr_tf_internal_midplane: Full internal coil width at mid-plane [m].
+            - dr_tf_plasma_case: Thickness of the plasma-facing case [m].
+            - dx_tf_side_case_min: Minimum thickness of the sidewall case [m].
+
         """
         # The angular space of each TF coil in the toroidal direction [rad]
         # The angular space between each coil is the same as that of the coils
@@ -270,9 +303,9 @@ class TFCoil(Model):
 
         # Area of rectangular cross-section TF outboard leg [m^2]
         a_tf_leg_outboard = dx_tf_inboard_out_toroidal * dr_tf_outboard
-        
+
         # =====================================================================
-        
+
         # Full external coil width at mid-plane [m]
 
         dr_tf_full_midplane = r_tf_outboard_out - r_tf_inboard_in
@@ -281,7 +314,7 @@ class TFCoil(Model):
         dr_tf_internal_midplane = r_tf_outboard_in - r_tf_inboard_out
 
         # ======================================================================
-        
+
         # Plasma facing front case thickness [m]
 
         if i_f_dr_tf_plasma_case:
@@ -321,18 +354,18 @@ class TFCoil(Model):
         else:
             dx_tf_side_case_min = tfcoil_variables.dx_tf_side_case_min
 
-        return (
-            rad_tf_coil_inboard_toroidal_half,
-            tan_theta_coil,
-            a_tf_inboard_total,
-            r_tf_outboard_in,
-            r_tf_outboard_out,
-            dx_tf_inboard_out_toroidal,
-            a_tf_leg_outboard,
-            dr_tf_full_midplane,
-            dr_tf_internal_midplane,
-            dr_tf_plasma_case,
-            dx_tf_side_case_min,
+        return TFGlobalGeometry(
+            rad_tf_coil_inboard_toroidal_half=rad_tf_coil_inboard_toroidal_half,
+            tan_theta_coil=tan_theta_coil,
+            a_tf_inboard_total=a_tf_inboard_total,
+            r_tf_outboard_in=r_tf_outboard_in,
+            r_tf_outboard_out=r_tf_outboard_out,
+            dx_tf_inboard_out_toroidal=dx_tf_inboard_out_toroidal,
+            a_tf_leg_outboard=a_tf_leg_outboard,
+            dr_tf_full_midplane=dr_tf_full_midplane,
+            dr_tf_internal_midplane=dr_tf_internal_midplane,
+            dr_tf_plasma_case=dr_tf_plasma_case,
+            dx_tf_side_case_min=dx_tf_side_case_min,
         )
 
     def tf_current(

--- a/process/models/tfcoil/base.py
+++ b/process/models/tfcoil/base.py
@@ -87,31 +87,30 @@ class TFPlasmaCaseType(IntEnum):
 @dataclass
 class TFGlobalGeometry:
     """
-    A dataclass containing the calculated global geometry parameters of the TF coil.
-        - rad_tf_coil_inboard_toroidal_half: Angular space of each TF coil in the toroidal direction [rad].
-        - tan_theta_coil: Tangent of the angle of the TF coil.
-        - a_tf_inboard_total: Total mid-plane cross-sectional area of the inboard legs [m²].
-        - r_tf_outboard_in: Inner radius of the outboard leg [m].
-        - r_tf_outboard_out: Outer radius of the outboard leg [m].
-        - dx_tf_inboard_out_toroidal: Toroidal width of the inboard leg at the outer edge [m].
-        - a_tf_leg_outboard: Cross-sectional area of the outboard leg [m²].
-        - dr_tf_full_midplane: Full external coil width at mid-plane [m].
-        - dr_tf_internal_midplane: Full internal coil width at mid-plane [m].
-        - dr_tf_plasma_case: Thickness of the plasma-facing case [m].
-        - dx_tf_side_case_min: Minimum thickness of the sidewall case [m].
-    """
+    A dataclass containing the calculated global geometry parameters of the TF coil."""
 
     rad_tf_coil_inboard_toroidal_half: float
+    """Angular space of each TF coil in the toroidal direction [rad]"""
     tan_theta_coil: float
+    """Tangent of the angle of the TF coil."""
     a_tf_inboard_total: float
+    """Total mid-plane cross-sectional area of the inboard legs [m²]."""
     r_tf_outboard_in: float
+    """Inner radius of the outboard leg [m]."""
     r_tf_outboard_out: float
+    """Outer radius of the outboard leg [m]."""
     dx_tf_inboard_out_toroidal: float
+    """Toroidal width of the inboard leg at the outer edge [m]."""
     a_tf_leg_outboard: float
+    """Cross-sectional area of the outboard leg [m²]."""
     dr_tf_full_midplane: float
+    """Full external coil width at mid-plane [m]."""
     dr_tf_internal_midplane: float
+    """Full internal coil width at mid-plane [m]."""
     dr_tf_plasma_case: float
+    """Thickness of the plasma-facing case [m]."""
     dx_tf_side_case_min: float
+    """Minimum thickness of the sidewall case [m]."""
 
 
 class TFCoil(Model):
@@ -268,7 +267,7 @@ class TFCoil(Model):
         Returns
         -------
         TFGlobalGeometry
-                A dataclass containing the calculated global geometry parameters of the TF coil.
+            A dataclass containing the calculated global geometry parameters of the TF coil.
 
         """
         # The angular space of each TF coil in the toroidal direction [rad]

--- a/process/models/tfcoil/base.py
+++ b/process/models/tfcoil/base.py
@@ -239,34 +239,35 @@ class TFCoil(Model):
 
         Parameters
         ----------
-        i_tf_case_geom
+        i_tf_case_geom:
             Geometry type of the TF coil case (e.g., circular or straight plasma-facing front case).
-        i_f_dr_tf_plasma_case
+        i_f_dr_tf_plasma_case:
             Whether the plasma-facing case thickness is specified as a fraction of the inboard thickness.
-        f_dr_tf_plasma_case
+        f_dr_tf_plasma_case:
             Fraction of the inboard thickness used for the plasma-facing case thickness.
-        tfc_sidewall_is_fraction
+        tfc_sidewall_is_fraction:
             Whether the sidewall case thickness is specified as a fraction of the inboard radius.
-        casths_fraction
+        casths_fraction:
             Fraction of the inboard radius used for the sidewall case thickness.
-        n_tf_coils
+        n_tf_coils:
             Number of TF coils.
-        dr_tf_inboard
+        dr_tf_inboard:
             Radial thickness of the inboard leg of the TF coil [m].
-        dr_tf_nose_case
+        dr_tf_nose_case:
             Thickness of the inboard leg case at the nose region [m].
-        r_tf_inboard_out
+        r_tf_inboard_out:
             Outer radius of the inboard leg of the TF coil [m].
-        r_tf_inboard_in
+        r_tf_inboard_in:
             Inner radius of the inboard leg of the TF coil [m].
-        r_tf_outboard_mid
+        r_tf_outboard_mid:
             Mid-plane radius of the outboard leg of the TF coil [m].
-        dr_tf_outboard
+        dr_tf_outboard:
             Radial thickness of the outboard leg of the TF coil [m].
 
         Returns
         -------
-        A dataclass containing the calculated global geometry parameters of the TF coil.
+        :
+            A dataclass containing the calculated global geometry parameters of the TF coil.
 
         """
         # The angular space of each TF coil in the toroidal direction [rad]

--- a/process/models/tfcoil/base.py
+++ b/process/models/tfcoil/base.py
@@ -86,6 +86,21 @@ class TFPlasmaCaseType(IntEnum):
 
 @dataclass
 class TFGlobalGeometry:
+    """
+    A dataclass containing the calculated global geometry parameters of the TF coil.
+        - rad_tf_coil_inboard_toroidal_half: Angular space of each TF coil in the toroidal direction [rad].
+        - tan_theta_coil: Tangent of the angle of the TF coil.
+        - a_tf_inboard_total: Total mid-plane cross-sectional area of the inboard legs [m²].
+        - r_tf_outboard_in: Inner radius of the outboard leg [m].
+        - r_tf_outboard_out: Outer radius of the outboard leg [m].
+        - dx_tf_inboard_out_toroidal: Toroidal width of the inboard leg at the outer edge [m].
+        - a_tf_leg_outboard: Cross-sectional area of the outboard leg [m²].
+        - dr_tf_full_midplane: Full external coil width at mid-plane [m].
+        - dr_tf_internal_midplane: Full internal coil width at mid-plane [m].
+        - dr_tf_plasma_case: Thickness of the plasma-facing case [m].
+        - dx_tf_side_case_min: Minimum thickness of the sidewall case [m].
+    """
+
     rad_tf_coil_inboard_toroidal_half: float
     tan_theta_coil: float
     a_tf_inboard_total: float
@@ -113,9 +128,7 @@ class TFCoil(Model):
 
     def run_base_tf(self):
         """Run main tfcoil subroutine without outputting."""
-        global_tf_geometry = TFGlobalGeometry
-
-        global_tf_geometry = self.tf_global_geometry(
+        global_tf_geometry: TFGlobalGeometry = self.tf_global_geometry(
             i_tf_case_geom=tfcoil_variables.i_tf_case_geom,
             i_f_dr_tf_plasma_case=tfcoil_variables.i_f_dr_tf_plasma_case,
             f_dr_tf_plasma_case=tfcoil_variables.f_dr_tf_plasma_case,
@@ -255,18 +268,7 @@ class TFCoil(Model):
         Returns
         -------
         TFGlobalGeometry
-            A dataclass containing the calculated global geometry parameters of the TF coil.
-            - rad_tf_coil_inboard_toroidal_half: Angular space of each TF coil in the toroidal direction [rad].
-            - tan_theta_coil: Tangent of the angle of the TF coil.
-            - a_tf_inboard_total: Total mid-plane cross-sectional area of the inboard legs [m²].
-            - r_tf_outboard_in: Inner radius of the outboard leg [m].
-            - r_tf_outboard_out: Outer radius of the outboard leg [m].
-            - dx_tf_inboard_out_toroidal: Toroidal width of the inboard leg at the outer edge [m].
-            - a_tf_leg_outboard: Cross-sectional area of the outboard leg [m²].
-            - dr_tf_full_midplane: Full external coil width at mid-plane [m].
-            - dr_tf_internal_midplane: Full internal coil width at mid-plane [m].
-            - dr_tf_plasma_case: Thickness of the plasma-facing case [m].
-            - dx_tf_side_case_min: Minimum thickness of the sidewall case [m].
+                A dataclass containing the calculated global geometry parameters of the TF coil.
 
         """
         # The angular space of each TF coil in the toroidal direction [rad]

--- a/tests/unit/models/tfcoil/test_tfcoil.py
+++ b/tests/unit/models/tfcoil/test_tfcoil.py
@@ -2,7 +2,7 @@
 
 import json
 from collections.abc import Sequence
-from dataclasses import dataclass, fields
+from dataclasses import astuple, dataclass, fields
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -287,7 +287,7 @@ def test_tf_global_geometry(
         r_tf_outboard_mid,
         dr_tf_outboard,
     )
-    assert result == expected
+    assert astuple(result) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/models/tfcoil/test_tfcoil.py
+++ b/tests/unit/models/tfcoil/test_tfcoil.py
@@ -221,6 +221,8 @@ def test_cntrpst(cntrpst_asset, monkeypatch, reinitialise_error_module, tfcoil):
                 pytest.approx(5.15),  # r_tf_outboard_out
                 pytest.approx(0.780361288064513),  # dx_tf_inboard_out_toroidal
                 pytest.approx(0.2341083864193539),  # a_tf_leg_outboard
+                pytest.approx(5.15 - 1.5),  # dr_tf_full_midplane
+                pytest.approx(4.85 - 2.0),  # dr_tf_internal_midplane
                 pytest.approx(0.03842943919353914),  # dr_tf_plasma_case
                 pytest.approx(0.0),  # dx_tf_side_case_min
             ),
@@ -246,6 +248,8 @@ def test_cntrpst(cntrpst_asset, monkeypatch, reinitialise_error_module, tfcoil):
                 pytest.approx(4.625),  # r_tf_outboard_out
                 pytest.approx(0.9317485623690747),  # dx_tf_inboard_out_toroidal
                 pytest.approx(0.23293714059226867),  # a_tf_leg_outboard
+                pytest.approx(4.625 - 1.4),  # dr_tf_full_midplane
+                pytest.approx(4.375 - 1.8),  # dr_tf_internal_midplane
                 pytest.approx(0.04),  # dr_tf_plasma_case
                 pytest.approx(0.019426316451256392),  # dx_tf_side_case_min
             ),


### PR DESCRIPTION
This pull request introduces two new parameters describing the toroidal field (TF) coil's geometry at the midplane—`dr_tf_full_midplane` and `dr_tf_internal_midplane`—and refactors the code to use a dataclass (`TFGlobalGeometry`) for returning TF coil geometry. It updates the calculation, storage, output, and plotting of these new parameters, and adapts related tests accordingly.

**TF coil geometry calculation and data structure refactor:**

* Introduced a `TFGlobalGeometry` dataclass in `process/models/tfcoil/base.py` to encapsulate all global TF coil geometry parameters, replacing the previous tuple return value from `tf_global_geometry`. The dataclass now includes the new `dr_tf_full_midplane` and `dr_tf_internal_midplane` fields.
* Updated `run_base_tf` to use the new dataclass and assign its fields to the appropriate variables. 

**New TF coil midplane width parameters:**

* Added `dr_tf_full_midplane` and `dr_tf_internal_midplane` to `process/data_structure/tfcoil_variables.py`, with initialization and docstrings, and ensured they are initialized in `init_tfcoil_variables`. 
* Calculated these parameters in `tf_global_geometry` as the full external and internal coil widths at the midplane.

**Output and plotting updates:**

* Updated the output routine (`outtf`) to write the new parameters to output files.
* Modified plotting in `process/core/io/plot/summary.py` to use the new parameters for midplane width annotations. 

**Test updates:**

* Updated tests in `tests/unit/models/tfcoil/test_tfcoil.py` to check the new parameters, use the dataclass, and compare results using `astuple`. 

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
