### PR TITLE
📐 Add blkt and divertor poloidal angles

### DIFF
--- a/process/core/caller.py
+++ b/process/core/caller.py
@@ -320,6 +320,8 @@ class Caller:
         # Pulsed reactor model
         self.models.pulse.run()
 
+        self.models.divertor.run()
+
         # First wall model
         self.models.fw.run()
 
@@ -344,8 +346,6 @@ class Caller:
         elif self.data.fwbs.i_blanket_type == BlktModelTypes.DCLL:
             # DCLL model
             self.models.dcll.run()
-
-        self.models.divertor.run()
 
         self.models.cryostat.run()
 

--- a/process/core/input.py
+++ b/process/core/input.py
@@ -710,7 +710,6 @@ INPUT_VARIABLES = {
     "fjohc0": InputVariable(
         data_structure.constraint_variables, float, range=(0.001, 1.0)
     ),
-    "f_ster_div_single": InputVariable("fwbs", float, range=(0.0, 1.0)),
     "fdiva": InputVariable(data_structure.divertor_variables, float, range=(0.1, 2.0)),
     "fdivwet": InputVariable(
         data_structure.stellarator_variables, float, range=(0.01, 1.0)

--- a/process/core/input.py
+++ b/process/core/input.py
@@ -430,7 +430,6 @@ INPUT_VARIABLES = {
     "fiooic": InputVariable("constraints", float, range=(0.001, 1.0)),
     "fjohc": InputVariable("constraints", float, range=(0.001, 1.0)),
     "fjohc0": InputVariable("constraints", float, range=(0.001, 1.0)),
-    "f_ster_div_single": InputVariable("fwbs", float, range=(0.0, 1.0)),
     "fdiva": InputVariable("divertor", float, range=(0.1, 2.0)),
     "fdivwet": InputVariable("stellarator", float, range=(0.01, 1.0)),
     "feffcd": InputVariable("current_drive", float, range=(0.0, 20.0)),

--- a/process/core/io/obsolete_vars.py
+++ b/process/core/io/obsolete_vars.py
@@ -448,6 +448,7 @@ OBS_VARS = {
     "vcool": "vel_cp_coolant_midplane",
     "rcool": "radius_cp_coolant_channel",
     "fl_h_threshold": None,
+    "f_ster_div_single": None,
 }
 
 OBS_VARS_HELP = {

--- a/process/core/io/obsolete_vars.py
+++ b/process/core/io/obsolete_vars.py
@@ -242,7 +242,7 @@ OBS_VARS = {
     "divfix": "dz_divertor",
     "coreradius": "radius_plasma_core_norm",
     "maxradwallload": "pflux_fw_rad_max",
-    "fdiv": "f_ster_div_single",
+    "fdiv": None,
     "fhcd": "f_a_fw_outboard_hcd",
     "nblktmodti": "n_blkt_inboard_modules_toroidal",
     "nblktmodpo": "n_blkt_outboard_modules_poloidal",

--- a/process/core/io/obsolete_vars.py
+++ b/process/core/io/obsolete_vars.py
@@ -456,6 +456,7 @@ OBS_VARS = {
     "dx_hts_tape_total": "dx_tf_hts_tape_total",
     "dr_hts_tape": "dr_tf_hts_tape",
     "coppera_m2_max": "tf_coppera_m2_max",
+    "f_ster_div_single": None,
 }
 
 OBS_VARS_HELP = {

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13844,6 +13844,9 @@ def plot_blkt_structure(
     deg_blkt_outboard_poloidal_plasma = m_file.get(
         "deg_blkt_outboard_poloidal_plasma", scan=scan
     )
+    deg_blkt_inboard_poloidal_plasma = m_file.get(
+        "deg_blkt_inboard_poloidal_plasma", scan=scan
+    )
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
     plot_plasma(ax, m_file, scan, colour_scheme)
@@ -13914,7 +13917,7 @@ def plot_blkt_structure(
 
     # Add angle label at the arc
     mid_angle = np.deg2rad((angle_start + angle_end) / 2)
-    label_radius = arc_radius * 1.5
+    label_radius = arc_radius * 1.8
     label_x = rmajor + label_radius * np.cos(mid_angle)
     label_y = label_radius * np.sin(mid_angle)
 
@@ -13922,25 +13925,67 @@ def plot_blkt_structure(
         label_x,
         label_y,
         f"{deg_blkt_outboard_poloidal_plasma:.1f}°",
-        fontsize=10,
+        fontsize=8,
         color="purple",
         ha="center",
         va="center",
         weight="bold",
+        bbox={
+            "boxstyle": "round",
+            "facecolor": "white",
+            "alpha": 0.8,
+            "edgecolor": "purple",
+            "linewidth": 1.5,
+        },
     )
 
     ax.annotate(
         "",
         xy=(rmajor, 0),
-        xytext=(r_blkt_inboard_in, dz_blkt_half),
+        xytext=(r_fw_inboard_out, dz_blkt_half),
         arrowprops={"arrowstyle": "<-", "color": "purple"},
     )
 
     ax.annotate(
         "",
         xy=(rmajor, 0),
-        xytext=(r_blkt_inboard_in, -dz_blkt_half),
+        xytext=(r_fw_inboard_out, -dz_blkt_half),
         arrowprops={"arrowstyle": "<-", "color": "purple"},
+    )
+
+    # Plot arc showing the angle between the two arrows
+    arc_radius = 1.0
+    angle_start = -deg_blkt_inboard_poloidal_plasma / 2
+    angle_end = deg_blkt_inboard_poloidal_plasma / 2
+
+    theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
+    arc_x = rmajor - arc_radius * np.cos(theta)
+    arc_y = arc_radius * np.sin(theta)
+
+    ax.plot(arc_x, arc_y, color="purple", linewidth=2)
+
+    # Add angle label at the arc
+    mid_angle = np.deg2rad((angle_start + angle_end) / 2)
+    label_radius = arc_radius * 1.8
+    label_x = rmajor - label_radius * np.cos(mid_angle)
+    label_y = label_radius * np.sin(mid_angle)
+
+    ax.text(
+        label_x,
+        label_y,
+        f"{deg_blkt_inboard_poloidal_plasma:.1f}°",
+        fontsize=8,
+        color="purple",
+        ha="center",
+        va="center",
+        weight="bold",
+        bbox={
+            "boxstyle": "round",
+            "facecolor": "white",
+            "alpha": 0.8,
+            "edgecolor": "purple",
+            "linewidth": 1.5,
+        },
     )
 
     # Plot vertical lines at the inner and outer radial boundaries of the blanket

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13893,15 +13893,17 @@ def plot_blkt_structure(
     ax.annotate(
         "",
         xy=(rmajor, 0),
-        xytext=(r_blkt_outboard_out, dz_blkt_half),
+        xytext=(rmajor, dz_blkt_half),
         arrowprops={"arrowstyle": "<-", "color": "purple"},
+        zorder=5,
     )
 
     ax.annotate(
         "",
         xy=(rmajor, 0),
-        xytext=(r_blkt_outboard_out, -dz_blkt_half),
+        xytext=(rmajor, -dz_blkt_half),
         arrowprops={"arrowstyle": "<-", "color": "purple"},
+        zorder=5,
     )
 
     # Plot arc showing the angle between the two arrows
@@ -13943,14 +13945,16 @@ def plot_blkt_structure(
         "",
         xy=(rmajor, 0),
         xytext=(r_fw_inboard_out, dz_blkt_half),
-        arrowprops={"arrowstyle": "<-", "color": "purple"},
+        arrowprops={"arrowstyle": "<-", "color": "green"},
+        zorder=5,
     )
 
     ax.annotate(
         "",
         xy=(rmajor, 0),
         xytext=(r_fw_inboard_out, -dz_blkt_half),
-        arrowprops={"arrowstyle": "<-", "color": "purple"},
+        arrowprops={"arrowstyle": "<-", "color": "green"},
+        zorder=5,
     )
 
     # Plot arc showing the angle between the two arrows
@@ -13962,7 +13966,7 @@ def plot_blkt_structure(
     arc_x = rmajor - arc_radius * np.cos(theta)
     arc_y = arc_radius * np.sin(theta)
 
-    ax.plot(arc_x, arc_y, color="purple", linewidth=2)
+    ax.plot(arc_x, arc_y, color="green", linewidth=2)
 
     # Add angle label at the arc
     mid_angle = np.deg2rad((angle_start + angle_end) / 2)
@@ -13975,7 +13979,7 @@ def plot_blkt_structure(
         label_y,
         f"{deg_blkt_inboard_poloidal_plasma:.1f}°",
         fontsize=8,
-        color="purple",
+        color="green",
         ha="center",
         va="center",
         weight="bold",
@@ -13983,7 +13987,7 @@ def plot_blkt_structure(
             "boxstyle": "round",
             "facecolor": "white",
             "alpha": 0.8,
-            "edgecolor": "purple",
+            "edgecolor": "green",
             "linewidth": 1.5,
         },
     )

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13833,14 +13833,36 @@ def plot_blkt_structure(
 ):
     """Plot the BLKT structure on the given axis."""
     rmajor = m_file.get("rmajor", scan=scan)
+    rminor = m_file.get("rminor", scan=scan)
+    dr_fw_plasma_gap_outboard = m_file.get("dr_fw_plasma_gap_outboard", scan=scan)
+    dr_fw_plasma_gap_inboard = m_file.get("dr_fw_plasma_gap_inboard", scan=scan)
+    dr_fw_inboard = m_file.get("dr_fw_inboard", scan=scan)
+    dr_fw_outboard = m_file.get("dr_fw_outboard", scan=scan)
+    dr_blkt_outboard = m_file.get("dr_blkt_outboard", scan=scan)
+    dr_blkt_inboard = m_file.get("dr_blkt_inboard", scan=scan)
+    dz_blkt_half = m_file.get("dz_blkt_half", scan=scan)
+    deg_blkt_outboard_poloidal_plasma = m_file.get(
+        "deg_blkt_outboard_poloidal_plasma", scan=scan
+    )
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
+    plot_plasma(ax, m_file, scan, colour_scheme)
     plot_firstwall(ax, m_file, scan, radial_build, colour_scheme)
     ax.set_xlabel("Radial position [m]")
     ax.set_ylabel("Vertical position [m]")
     ax.set_title("Blanket and First Wall Poloidal Cross-Section")
     ax.minorticks_on()
     ax.grid(which="minor", linestyle=":", linewidth=0.5, alpha=0.5)
+
+    r_blkt_outboard_out = (
+        rmajor + rminor + dr_fw_outboard + dr_fw_plasma_gap_outboard + dr_blkt_outboard
+    )
+    r_blkt_inboard_in = (
+        rmajor - rminor - dr_fw_plasma_gap_inboard - dr_fw_inboard - dr_blkt_inboard
+    )
+    r_fw_outboard_in = r_blkt_outboard_out - dr_blkt_outboard - dr_fw_outboard
+    r_fw_inboard_out = r_blkt_inboard_in + dr_blkt_inboard + dr_fw_inboard
+
     # Plot major radius line (vertical dashed line at rmajor)
     ax.axvline(
         m_file.get("rminor", scan=scan),
@@ -13850,7 +13872,6 @@ def plot_blkt_structure(
         label="Major Radius $R_0$",
     )
     # Plot a horizontal line at dz_blkt_half (blanket half height)
-    dz_blkt_half = m_file.get("dz_blkt_half", scan=scan)
     ax.axhline(
         dz_blkt_half,
         color="purple",
@@ -13868,23 +13889,77 @@ def plot_blkt_structure(
 
     ax.annotate(
         "",
-        xy=(rmajor, dz_blkt_half),
-        xytext=(rmajor, -dz_blkt_half),
-        arrowprops={"arrowstyle": "<->", "color": "black"},
+        xy=(rmajor, 0),
+        xytext=(r_blkt_outboard_out, dz_blkt_half),
+        arrowprops={"arrowstyle": "<-", "color": "purple"},
     )
 
-    # Add a label for the internal coil width
+    ax.annotate(
+        "",
+        xy=(rmajor, 0),
+        xytext=(r_blkt_outboard_out, -dz_blkt_half),
+        arrowprops={"arrowstyle": "<-", "color": "purple"},
+    )
+
+    # Plot arc showing the angle between the two arrows
+    arc_radius = 1.0
+    angle_start = -deg_blkt_outboard_poloidal_plasma / 2
+    angle_end = deg_blkt_outboard_poloidal_plasma / 2
+
+    theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
+    arc_x = rmajor + arc_radius * np.cos(theta)
+    arc_y = arc_radius * np.sin(theta)
+
+    ax.plot(arc_x, arc_y, color="purple", linewidth=2)
+
+    # Add angle label at the arc
+    mid_angle = np.deg2rad((angle_start + angle_end) / 2)
+    label_radius = arc_radius * 1.5
+    label_x = rmajor + label_radius * np.cos(mid_angle)
+    label_y = label_radius * np.sin(mid_angle)
+
     ax.text(
+        label_x,
+        label_y,
+        f"{deg_blkt_outboard_poloidal_plasma:.1f}°",
+        fontsize=10,
+        color="purple",
+        ha="center",
+        va="center",
+        weight="bold",
+    )
+
+    ax.annotate(
+        "",
+        xy=(rmajor, 0),
+        xytext=(r_blkt_inboard_in, dz_blkt_half),
+        arrowprops={"arrowstyle": "<-", "color": "purple"},
+    )
+
+    ax.annotate(
+        "",
+        xy=(rmajor, 0),
+        xytext=(r_blkt_inboard_in, -dz_blkt_half),
+        arrowprops={"arrowstyle": "<-", "color": "purple"},
+    )
+
+    # Plot vertical lines at the inner and outer radial boundaries of the blanket
+    ax.axvline(
+        r_blkt_inboard_in, color="black", linestyle="--", linewidth=1.5, zorder=10
+    )
+    ax.axvline(
+        r_blkt_outboard_out, color="black", linestyle="--", linewidth=1.5, zorder=10
+    )
+    ax.axvline(r_fw_inboard_out, color="black", linestyle="--", linewidth=1.5, zorder=10)
+
+    ax.axvline(r_fw_outboard_in, color="black", linestyle="--", linewidth=1.5, zorder=10)
+
+    ax.axvline(
         rmajor,
-        0.0,
-        f"{2 * dz_blkt_half:.3f} m",
-        fontsize=7,
         color="black",
-        rotation=270,
-        verticalalignment="center",
-        horizontalalignment="center",
-        bbox={"boxstyle": "round", "facecolor": "pink", "alpha": 1.0},
-        zorder=101,  # Ensure label is on top of all plots
+        linestyle="--",
+        linewidth=1.5,
+        label="Major Radius $R_0$",
     )
 
     # Plot midplane line (horizontal dashed line at Z=0)

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13831,7 +13831,8 @@ def plot_blkt_structure(
     radial_build: dict[str, float],
     colour_scheme: Literal[1, 2],
 ):
-    """Plot the BLKT structure on the given axis."""
+    """Plot the blkt structure and relevant angles"""
+    # MFILE variables needed to plot the blkt structure and angles
     rmajor = m_file.get("rmajor", scan=scan)
     rminor = m_file.get("rminor", scan=scan)
     dr_fw_plasma_gap_outboard = m_file.get("dr_fw_plasma_gap_outboard", scan=scan)
@@ -13855,10 +13856,14 @@ def plot_blkt_structure(
     )
     deg_div_poloidal_plasma = m_file.get("deg_div_poloidal_plasma", scan=scan)
     f_ster_div_single = m_file.get("f_ster_div_single", scan=scan)
+    i_single_null = m_file.get("i_single_null", scan=scan)
+
+    # ======================
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
     plot_plasma(ax, m_file, scan, colour_scheme)
     plot_firstwall(ax, m_file, scan, radial_build, colour_scheme)
+
     ax.set_xlabel("Radial position [m]")
     ax.set_ylabel("Vertical position [m]")
     ax.set_title("Blanket and First Wall Poloidal Cross-Section")
@@ -13890,6 +13895,7 @@ def plot_blkt_structure(
         label="Blanket Half Height",
     )
 
+    # Plot arrows for the outboard blanket angles
     ax.annotate(
         "",
         xy=(rmajor, 0),
@@ -13906,7 +13912,7 @@ def plot_blkt_structure(
         zorder=5,
     )
 
-    # Plot arc showing the angle between the two arrows
+    # Plot arc showing the angle between the two outboard blanket arrows
     arc_radius = 1.0
     angle_start = -deg_blkt_outboard_poloidal_plasma / 2
     angle_end = deg_blkt_outboard_poloidal_plasma / 2
@@ -13923,6 +13929,7 @@ def plot_blkt_structure(
     label_x = rmajor + label_radius * np.cos(mid_angle)
     label_y = label_radius * np.sin(mid_angle)
 
+    # Plot the info box for the outboard blanket
     ax.text(
         label_x,
         label_y,
@@ -13941,6 +13948,7 @@ def plot_blkt_structure(
         },
     )
 
+    # Plot arrows for the inboard blanket angles
     ax.annotate(
         "",
         xy=(rmajor, 0),
@@ -13957,7 +13965,7 @@ def plot_blkt_structure(
         zorder=5,
     )
 
-    # Plot arc showing the angle between the two arrows
+    # Plot arc showing the angle between the two inboard blanket arrows
     arc_radius = 1.0
     angle_start = -deg_blkt_inboard_poloidal_plasma / 2
     angle_end = deg_blkt_inboard_poloidal_plasma / 2
@@ -13974,6 +13982,7 @@ def plot_blkt_structure(
     label_x = rmajor - label_radius * np.cos(mid_angle)
     label_y = label_radius * np.sin(mid_angle)
 
+    # Plot the info box for the inboard blanket
     ax.text(
         label_x,
         label_y,
@@ -13993,7 +14002,46 @@ def plot_blkt_structure(
         zorder=5,
     )
 
-    # Plot arc showing the angle between the two arrows (divertor angle)
+    # Plot arrows for the divertor angles
+    # If double null then plot the upper also
+    if i_single_null == 0:
+        # Plot arc showing the angle between the two arrows (divertor angle)
+        arc_radius = 1.5
+        angle_start = deg_blkt_outboard_poloidal_plasma / 2 + deg_div_poloidal_plasma
+        angle_end = deg_blkt_inboard_poloidal_plasma / 2 + deg_div_poloidal_plasma
+
+        theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
+        arc_x = rmajor + arc_radius * np.cos(theta)
+        arc_y = arc_radius * np.sin(theta)
+
+        ax.plot(arc_x, arc_y, color="black", linewidth=2)
+
+        # Add angle label at the arc
+        mid_angle = np.deg2rad((angle_start + angle_end) / 2)
+        label_radius = arc_radius * 1.8
+        label_x = rmajor + label_radius * np.cos(mid_angle)
+        label_y = label_radius * np.sin(mid_angle)
+
+        ax.text(
+            label_x,
+            label_y,
+            f"{deg_div_poloidal_plasma:.1f}°\n({f_ster_div_single * 100:.1f}%)",
+            fontsize=7,
+            color="black",
+            ha="center",
+            va="center",
+            weight="bold",
+            bbox={
+                "boxstyle": "round",
+                "facecolor": "white",
+                "alpha": 0.8,
+                "edgecolor": "black",
+                "linewidth": 1.5,
+            },
+            zorder=5,
+        )
+
+    # Plot arc showing the angle between the two arrows for the lower divertor (divertor angle)
     arc_radius = 1.5
     angle_start = -deg_blkt_outboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
     angle_end = -deg_blkt_inboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
@@ -14010,6 +14058,7 @@ def plot_blkt_structure(
     label_x = rmajor + label_radius * np.cos(mid_angle)
     label_y = label_radius * np.sin(mid_angle)
 
+    # Plot the info box for the lower divertor angle
     ax.text(
         label_x,
         label_y,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13867,14 +13867,6 @@ def plot_blkt_structure(
     r_fw_outboard_in = r_blkt_outboard_out - dr_blkt_outboard - dr_fw_outboard
     r_fw_inboard_out = r_blkt_inboard_in + dr_blkt_inboard + dr_fw_inboard
 
-    # Plot major radius line (vertical dashed line at rmajor)
-    ax.axvline(
-        m_file.get("rminor", scan=scan),
-        color="black",
-        linestyle="--",
-        linewidth=1.5,
-        label="Major Radius $R_0$",
-    )
     # Plot a horizontal line at dz_blkt_half (blanket half height)
     ax.axhline(
         dz_blkt_half,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13895,15 +13895,16 @@ def plot_blkt_structure(
         label="Blanket Half Height",
     )
 
-    # Plot arrows for the outboard blanket angles
-    ax.annotate(
-        "",
-        xy=(rmajor, 0),
-        xytext=(rmajor, dz_blkt_half),
-        arrowprops={"arrowstyle": "<-", "color": "purple"},
-        zorder=5,
-    )
-
+    if i_single_null == 0:
+        # Plot arrows for the outboard blanket angles
+        ax.annotate(
+            "",
+            xy=(rmajor, 0),
+            xytext=(rmajor, dz_blkt_half),
+            arrowprops={"arrowstyle": "<-", "color": "purple"},
+            zorder=5,
+        )
+    # If single null then only plot the lower arrow for the outboard blanket angle
     ax.annotate(
         "",
         xy=(rmajor, 0),
@@ -13914,8 +13915,14 @@ def plot_blkt_structure(
 
     # Plot arc showing the angle between the two outboard blanket arrows
     arc_radius = 1.0
-    angle_start = -deg_blkt_outboard_poloidal_plasma / 2
-    angle_end = deg_blkt_outboard_poloidal_plasma / 2
+
+    # 3 to 6 o'clock position is -90 degrees,
+    angle_start = -90.0
+    if i_single_null == 1:
+        angle_end = 90.0 + deg_div_poloidal_plasma
+    elif i_single_null == 0:
+        # 3 to 12 o'clock position is +90 degrees
+        angle_end = 90.0
 
     theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
     arc_x = rmajor + arc_radius * np.cos(theta)
@@ -14007,8 +14014,9 @@ def plot_blkt_structure(
     if i_single_null == 0:
         # Plot arc showing the angle between the two arrows (divertor angle)
         arc_radius = 1.5
-        angle_start = deg_blkt_outboard_poloidal_plasma / 2 + deg_div_poloidal_plasma
-        angle_end = deg_blkt_inboard_poloidal_plasma / 2 + deg_div_poloidal_plasma
+        # 3 to 12 o'clock position is +90 degrees,
+        angle_start = 90.0
+        angle_end = 90.0 + deg_div_poloidal_plasma
 
         theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
         arc_x = rmajor + arc_radius * np.cos(theta)
@@ -14043,8 +14051,9 @@ def plot_blkt_structure(
 
     # Plot arc showing the angle between the two arrows for the lower divertor (divertor angle)
     arc_radius = 1.5
-    angle_start = -deg_blkt_outboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
-    angle_end = -deg_blkt_inboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
+    # 3 to 6 o'clock is -90 degrees
+    angle_start = -90.0
+    angle_end = -90.0 - deg_div_poloidal_plasma
 
     theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
     arc_x = rmajor + arc_radius * np.cos(theta)

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13927,7 +13927,7 @@ def plot_blkt_structure(
         label_x,
         label_y,
         f"{deg_blkt_outboard_poloidal_plasma:.1f}°\n({f_deg_blkt_outboard_poloidal_plasma * 100:.1f}%)",
-        fontsize=8,
+        fontsize=7,
         color="purple",
         ha="center",
         va="center",
@@ -13978,7 +13978,7 @@ def plot_blkt_structure(
         label_x,
         label_y,
         f"{deg_blkt_inboard_poloidal_plasma:.1f}°\n({f_deg_blkt_inboard_poloidal_plasma * 100:.1f}%)",
-        fontsize=8,
+        fontsize=7,
         color="green",
         ha="center",
         va="center",
@@ -13990,6 +13990,7 @@ def plot_blkt_structure(
             "edgecolor": "green",
             "linewidth": 1.5,
         },
+        zorder=5,
     )
 
     # Plot arc showing the angle between the two arrows (divertor angle)
@@ -14013,7 +14014,7 @@ def plot_blkt_structure(
         label_x,
         label_y,
         f"{deg_div_poloidal_plasma:.1f}°\n({f_ster_div_single * 100:.1f}%)",
-        fontsize=8,
+        fontsize=7,
         color="black",
         ha="center",
         va="center",
@@ -14025,6 +14026,7 @@ def plot_blkt_structure(
             "edgecolor": "black",
             "linewidth": 1.5,
         },
+        zorder=5,
     )
 
     # Plot vertical lines at the inner and outer radial boundaries of the blanket

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13847,6 +13847,7 @@ def plot_blkt_structure(
     deg_blkt_inboard_poloidal_plasma = m_file.get(
         "deg_blkt_inboard_poloidal_plasma", scan=scan
     )
+    deg_div_poloidal_plasma = m_file.get("deg_div_poloidal_plasma", scan=scan)
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
     plot_plasma(ax, m_file, scan, colour_scheme)
@@ -13988,6 +13989,41 @@ def plot_blkt_structure(
             "facecolor": "white",
             "alpha": 0.8,
             "edgecolor": "green",
+            "linewidth": 1.5,
+        },
+    )
+
+    # Plot arc showing the angle between the two arrows (divertor angle)
+    arc_radius = 1.5
+    angle_start = -deg_blkt_outboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
+    angle_end = -deg_blkt_inboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
+
+    theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
+    arc_x = rmajor + arc_radius * np.cos(theta)
+    arc_y = arc_radius * np.sin(theta)
+
+    ax.plot(arc_x, arc_y, color="black", linewidth=2)
+
+    # Add angle label at the arc
+    mid_angle = np.deg2rad((angle_start + angle_end) / 2)
+    label_radius = arc_radius * 1.8
+    label_x = rmajor + label_radius * np.cos(mid_angle)
+    label_y = label_radius * np.sin(mid_angle)
+
+    ax.text(
+        label_x,
+        label_y,
+        f"{deg_div_poloidal_plasma:.1f}°",
+        fontsize=8,
+        color="black",
+        ha="center",
+        va="center",
+        weight="bold",
+        bbox={
+            "boxstyle": "round",
+            "facecolor": "white",
+            "alpha": 0.8,
+            "edgecolor": "black",
             "linewidth": 1.5,
         },
     )

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -13847,7 +13847,14 @@ def plot_blkt_structure(
     deg_blkt_inboard_poloidal_plasma = m_file.get(
         "deg_blkt_inboard_poloidal_plasma", scan=scan
     )
+    f_deg_blkt_outboard_poloidal_plasma = m_file.get(
+        "f_deg_blkt_outboard_poloidal_plasma", scan=scan
+    )
+    f_deg_blkt_inboard_poloidal_plasma = m_file.get(
+        "f_deg_blkt_inboard_poloidal_plasma", scan=scan
+    )
     deg_div_poloidal_plasma = m_file.get("deg_div_poloidal_plasma", scan=scan)
+    f_ster_div_single = m_file.get("f_ster_div_single", scan=scan)
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
     plot_plasma(ax, m_file, scan, colour_scheme)
@@ -13919,7 +13926,7 @@ def plot_blkt_structure(
     ax.text(
         label_x,
         label_y,
-        f"{deg_blkt_outboard_poloidal_plasma:.1f}°",
+        f"{deg_blkt_outboard_poloidal_plasma:.1f}°\n({f_deg_blkt_outboard_poloidal_plasma * 100:.1f}%)",
         fontsize=8,
         color="purple",
         ha="center",
@@ -13970,7 +13977,7 @@ def plot_blkt_structure(
     ax.text(
         label_x,
         label_y,
-        f"{deg_blkt_inboard_poloidal_plasma:.1f}°",
+        f"{deg_blkt_inboard_poloidal_plasma:.1f}°\n({f_deg_blkt_inboard_poloidal_plasma * 100:.1f}%)",
         fontsize=8,
         color="green",
         ha="center",
@@ -14005,7 +14012,7 @@ def plot_blkt_structure(
     ax.text(
         label_x,
         label_y,
-        f"{deg_div_poloidal_plasma:.1f}°",
+        f"{deg_div_poloidal_plasma:.1f}°\n({f_ster_div_single * 100:.1f}%)",
         fontsize=8,
         color="black",
         ha="center",

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14331,6 +14331,7 @@ def plot_blkt_structure(
     deg_blkt_inboard_poloidal_plasma = m_file.get(
         "deg_blkt_inboard_poloidal_plasma", scan=scan
     )
+    deg_div_poloidal_plasma = m_file.get("deg_div_poloidal_plasma", scan=scan)
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
     plot_plasma(ax, m_file, scan, colour_scheme)
@@ -14472,6 +14473,41 @@ def plot_blkt_structure(
             "facecolor": "white",
             "alpha": 0.8,
             "edgecolor": "green",
+            "linewidth": 1.5,
+        },
+    )
+
+    # Plot arc showing the angle between the two arrows (divertor angle)
+    arc_radius = 1.5
+    angle_start = -deg_blkt_outboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
+    angle_end = -deg_blkt_inboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
+
+    theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
+    arc_x = rmajor + arc_radius * np.cos(theta)
+    arc_y = arc_radius * np.sin(theta)
+
+    ax.plot(arc_x, arc_y, color="black", linewidth=2)
+
+    # Add angle label at the arc
+    mid_angle = np.deg2rad((angle_start + angle_end) / 2)
+    label_radius = arc_radius * 1.8
+    label_x = rmajor + label_radius * np.cos(mid_angle)
+    label_y = label_radius * np.sin(mid_angle)
+
+    ax.text(
+        label_x,
+        label_y,
+        f"{deg_div_poloidal_plasma:.1f}°",
+        fontsize=8,
+        color="black",
+        ha="center",
+        va="center",
+        weight="bold",
+        bbox={
+            "boxstyle": "round",
+            "facecolor": "white",
+            "alpha": 0.8,
+            "edgecolor": "black",
             "linewidth": 1.5,
         },
     )

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14328,6 +14328,9 @@ def plot_blkt_structure(
     deg_blkt_outboard_poloidal_plasma = m_file.get(
         "deg_blkt_outboard_poloidal_plasma", scan=scan
     )
+    deg_blkt_inboard_poloidal_plasma = m_file.get(
+        "deg_blkt_inboard_poloidal_plasma", scan=scan
+    )
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
     plot_plasma(ax, m_file, scan, colour_scheme)
@@ -14398,7 +14401,7 @@ def plot_blkt_structure(
 
     # Add angle label at the arc
     mid_angle = np.deg2rad((angle_start + angle_end) / 2)
-    label_radius = arc_radius * 1.5
+    label_radius = arc_radius * 1.8
     label_x = rmajor + label_radius * np.cos(mid_angle)
     label_y = label_radius * np.sin(mid_angle)
 
@@ -14406,25 +14409,67 @@ def plot_blkt_structure(
         label_x,
         label_y,
         f"{deg_blkt_outboard_poloidal_plasma:.1f}°",
-        fontsize=10,
+        fontsize=8,
         color="purple",
         ha="center",
         va="center",
         weight="bold",
+        bbox={
+            "boxstyle": "round",
+            "facecolor": "white",
+            "alpha": 0.8,
+            "edgecolor": "purple",
+            "linewidth": 1.5,
+        },
     )
 
     ax.annotate(
         "",
         xy=(rmajor, 0),
-        xytext=(r_blkt_inboard_in, dz_blkt_half),
+        xytext=(r_fw_inboard_out, dz_blkt_half),
         arrowprops={"arrowstyle": "<-", "color": "purple"},
     )
 
     ax.annotate(
         "",
         xy=(rmajor, 0),
-        xytext=(r_blkt_inboard_in, -dz_blkt_half),
+        xytext=(r_fw_inboard_out, -dz_blkt_half),
         arrowprops={"arrowstyle": "<-", "color": "purple"},
+    )
+
+    # Plot arc showing the angle between the two arrows
+    arc_radius = 1.0
+    angle_start = -deg_blkt_inboard_poloidal_plasma / 2
+    angle_end = deg_blkt_inboard_poloidal_plasma / 2
+
+    theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
+    arc_x = rmajor - arc_radius * np.cos(theta)
+    arc_y = arc_radius * np.sin(theta)
+
+    ax.plot(arc_x, arc_y, color="purple", linewidth=2)
+
+    # Add angle label at the arc
+    mid_angle = np.deg2rad((angle_start + angle_end) / 2)
+    label_radius = arc_radius * 1.8
+    label_x = rmajor - label_radius * np.cos(mid_angle)
+    label_y = label_radius * np.sin(mid_angle)
+
+    ax.text(
+        label_x,
+        label_y,
+        f"{deg_blkt_inboard_poloidal_plasma:.1f}°",
+        fontsize=8,
+        color="purple",
+        ha="center",
+        va="center",
+        weight="bold",
+        bbox={
+            "boxstyle": "round",
+            "facecolor": "white",
+            "alpha": 0.8,
+            "edgecolor": "purple",
+            "linewidth": 1.5,
+        },
     )
 
     # Plot vertical lines at the inner and outer radial boundaries of the blanket

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14411,7 +14411,7 @@ def plot_blkt_structure(
         label_x,
         label_y,
         f"{deg_blkt_outboard_poloidal_plasma:.1f}°\n({f_deg_blkt_outboard_poloidal_plasma * 100:.1f}%)",
-        fontsize=8,
+        fontsize=7,
         color="purple",
         ha="center",
         va="center",
@@ -14462,7 +14462,7 @@ def plot_blkt_structure(
         label_x,
         label_y,
         f"{deg_blkt_inboard_poloidal_plasma:.1f}°\n({f_deg_blkt_inboard_poloidal_plasma * 100:.1f}%)",
-        fontsize=8,
+        fontsize=7,
         color="green",
         ha="center",
         va="center",
@@ -14474,6 +14474,7 @@ def plot_blkt_structure(
             "edgecolor": "green",
             "linewidth": 1.5,
         },
+        zorder=5,
     )
 
     # Plot arc showing the angle between the two arrows (divertor angle)
@@ -14497,7 +14498,7 @@ def plot_blkt_structure(
         label_x,
         label_y,
         f"{deg_div_poloidal_plasma:.1f}°\n({f_ster_div_single * 100:.1f}%)",
-        fontsize=8,
+        fontsize=7,
         color="black",
         ha="center",
         va="center",
@@ -14509,6 +14510,7 @@ def plot_blkt_structure(
             "edgecolor": "black",
             "linewidth": 1.5,
         },
+        zorder=5,
     )
 
     # Plot vertical lines at the inner and outer radial boundaries of the blanket

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14377,15 +14377,17 @@ def plot_blkt_structure(
     ax.annotate(
         "",
         xy=(rmajor, 0),
-        xytext=(r_blkt_outboard_out, dz_blkt_half),
+        xytext=(rmajor, dz_blkt_half),
         arrowprops={"arrowstyle": "<-", "color": "purple"},
+        zorder=5,
     )
 
     ax.annotate(
         "",
         xy=(rmajor, 0),
-        xytext=(r_blkt_outboard_out, -dz_blkt_half),
+        xytext=(rmajor, -dz_blkt_half),
         arrowprops={"arrowstyle": "<-", "color": "purple"},
+        zorder=5,
     )
 
     # Plot arc showing the angle between the two arrows
@@ -14427,14 +14429,16 @@ def plot_blkt_structure(
         "",
         xy=(rmajor, 0),
         xytext=(r_fw_inboard_out, dz_blkt_half),
-        arrowprops={"arrowstyle": "<-", "color": "purple"},
+        arrowprops={"arrowstyle": "<-", "color": "green"},
+        zorder=5,
     )
 
     ax.annotate(
         "",
         xy=(rmajor, 0),
         xytext=(r_fw_inboard_out, -dz_blkt_half),
-        arrowprops={"arrowstyle": "<-", "color": "purple"},
+        arrowprops={"arrowstyle": "<-", "color": "green"},
+        zorder=5,
     )
 
     # Plot arc showing the angle between the two arrows
@@ -14446,7 +14450,7 @@ def plot_blkt_structure(
     arc_x = rmajor - arc_radius * np.cos(theta)
     arc_y = arc_radius * np.sin(theta)
 
-    ax.plot(arc_x, arc_y, color="purple", linewidth=2)
+    ax.plot(arc_x, arc_y, color="green", linewidth=2)
 
     # Add angle label at the arc
     mid_angle = np.deg2rad((angle_start + angle_end) / 2)
@@ -14459,7 +14463,7 @@ def plot_blkt_structure(
         label_y,
         f"{deg_blkt_inboard_poloidal_plasma:.1f}°",
         fontsize=8,
-        color="purple",
+        color="green",
         ha="center",
         va="center",
         weight="bold",
@@ -14467,7 +14471,7 @@ def plot_blkt_structure(
             "boxstyle": "round",
             "facecolor": "white",
             "alpha": 0.8,
-            "edgecolor": "purple",
+            "edgecolor": "green",
             "linewidth": 1.5,
         },
     )

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14379,15 +14379,16 @@ def plot_blkt_structure(
         label="Blanket Half Height",
     )
 
-    # Plot arrows for the outboard blanket angles
-    ax.annotate(
-        "",
-        xy=(rmajor, 0),
-        xytext=(rmajor, dz_blkt_half),
-        arrowprops={"arrowstyle": "<-", "color": "purple"},
-        zorder=5,
-    )
-
+    if i_single_null == 0:
+        # Plot arrows for the outboard blanket angles
+        ax.annotate(
+            "",
+            xy=(rmajor, 0),
+            xytext=(rmajor, dz_blkt_half),
+            arrowprops={"arrowstyle": "<-", "color": "purple"},
+            zorder=5,
+        )
+    # If single null then only plot the lower arrow for the outboard blanket angle
     ax.annotate(
         "",
         xy=(rmajor, 0),
@@ -14398,8 +14399,14 @@ def plot_blkt_structure(
 
     # Plot arc showing the angle between the two outboard blanket arrows
     arc_radius = 1.0
-    angle_start = -deg_blkt_outboard_poloidal_plasma / 2
-    angle_end = deg_blkt_outboard_poloidal_plasma / 2
+
+    # 3 to 6 o'clock position is -90 degrees,
+    angle_start = -90.0
+    if i_single_null == 1:
+        angle_end = 90.0 + deg_div_poloidal_plasma
+    elif i_single_null == 0:
+        # 3 to 12 o'clock position is +90 degrees
+        angle_end = 90.0
 
     theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
     arc_x = rmajor + arc_radius * np.cos(theta)
@@ -14491,8 +14498,9 @@ def plot_blkt_structure(
     if i_single_null == 0:
         # Plot arc showing the angle between the two arrows (divertor angle)
         arc_radius = 1.5
-        angle_start = deg_blkt_outboard_poloidal_plasma / 2 + deg_div_poloidal_plasma
-        angle_end = deg_blkt_inboard_poloidal_plasma / 2 + deg_div_poloidal_plasma
+        # 3 to 12 o'clock position is +90 degrees,
+        angle_start = 90.0
+        angle_end = 90.0 + deg_div_poloidal_plasma
 
         theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
         arc_x = rmajor + arc_radius * np.cos(theta)
@@ -14527,8 +14535,9 @@ def plot_blkt_structure(
 
     # Plot arc showing the angle between the two arrows for the lower divertor (divertor angle)
     arc_radius = 1.5
-    angle_start = -deg_blkt_outboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
-    angle_end = -deg_blkt_inboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
+    # 3 to 6 o'clock is -90 degrees
+    angle_start = -90.0
+    angle_end = -90.0 - deg_div_poloidal_plasma
 
     theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
     arc_x = rmajor + arc_radius * np.cos(theta)

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14315,7 +14315,8 @@ def plot_blkt_structure(
     radial_build: dict[str, float],
     colour_scheme: Literal[1, 2],
 ):
-    """Plot the BLKT structure on the given axis."""
+    """Plot the blkt structure and relevant angles"""
+    # MFILE variables needed to plot the blkt structure and angles
     rmajor = m_file.get("rmajor", scan=scan)
     rminor = m_file.get("rminor", scan=scan)
     dr_fw_plasma_gap_outboard = m_file.get("dr_fw_plasma_gap_outboard", scan=scan)
@@ -14339,10 +14340,14 @@ def plot_blkt_structure(
     )
     deg_div_poloidal_plasma = m_file.get("deg_div_poloidal_plasma", scan=scan)
     f_ster_div_single = m_file.get("f_ster_div_single", scan=scan)
+    i_single_null = m_file.get("i_single_null", scan=scan)
+
+    # ======================
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
     plot_plasma(ax, m_file, scan, colour_scheme)
     plot_firstwall(ax, m_file, scan, radial_build, colour_scheme)
+
     ax.set_xlabel("Radial position [m]")
     ax.set_ylabel("Vertical position [m]")
     ax.set_title("Blanket and First Wall Poloidal Cross-Section")
@@ -14374,6 +14379,7 @@ def plot_blkt_structure(
         label="Blanket Half Height",
     )
 
+    # Plot arrows for the outboard blanket angles
     ax.annotate(
         "",
         xy=(rmajor, 0),
@@ -14390,7 +14396,7 @@ def plot_blkt_structure(
         zorder=5,
     )
 
-    # Plot arc showing the angle between the two arrows
+    # Plot arc showing the angle between the two outboard blanket arrows
     arc_radius = 1.0
     angle_start = -deg_blkt_outboard_poloidal_plasma / 2
     angle_end = deg_blkt_outboard_poloidal_plasma / 2
@@ -14407,6 +14413,7 @@ def plot_blkt_structure(
     label_x = rmajor + label_radius * np.cos(mid_angle)
     label_y = label_radius * np.sin(mid_angle)
 
+    # Plot the info box for the outboard blanket
     ax.text(
         label_x,
         label_y,
@@ -14425,6 +14432,7 @@ def plot_blkt_structure(
         },
     )
 
+    # Plot arrows for the inboard blanket angles
     ax.annotate(
         "",
         xy=(rmajor, 0),
@@ -14441,7 +14449,7 @@ def plot_blkt_structure(
         zorder=5,
     )
 
-    # Plot arc showing the angle between the two arrows
+    # Plot arc showing the angle between the two inboard blanket arrows
     arc_radius = 1.0
     angle_start = -deg_blkt_inboard_poloidal_plasma / 2
     angle_end = deg_blkt_inboard_poloidal_plasma / 2
@@ -14458,6 +14466,7 @@ def plot_blkt_structure(
     label_x = rmajor - label_radius * np.cos(mid_angle)
     label_y = label_radius * np.sin(mid_angle)
 
+    # Plot the info box for the inboard blanket
     ax.text(
         label_x,
         label_y,
@@ -14477,7 +14486,46 @@ def plot_blkt_structure(
         zorder=5,
     )
 
-    # Plot arc showing the angle between the two arrows (divertor angle)
+    # Plot arrows for the divertor angles
+    # If double null then plot the upper also
+    if i_single_null == 0:
+        # Plot arc showing the angle between the two arrows (divertor angle)
+        arc_radius = 1.5
+        angle_start = deg_blkt_outboard_poloidal_plasma / 2 + deg_div_poloidal_plasma
+        angle_end = deg_blkt_inboard_poloidal_plasma / 2 + deg_div_poloidal_plasma
+
+        theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
+        arc_x = rmajor + arc_radius * np.cos(theta)
+        arc_y = arc_radius * np.sin(theta)
+
+        ax.plot(arc_x, arc_y, color="black", linewidth=2)
+
+        # Add angle label at the arc
+        mid_angle = np.deg2rad((angle_start + angle_end) / 2)
+        label_radius = arc_radius * 1.8
+        label_x = rmajor + label_radius * np.cos(mid_angle)
+        label_y = label_radius * np.sin(mid_angle)
+
+        ax.text(
+            label_x,
+            label_y,
+            f"{deg_div_poloidal_plasma:.1f}°\n({f_ster_div_single * 100:.1f}%)",
+            fontsize=7,
+            color="black",
+            ha="center",
+            va="center",
+            weight="bold",
+            bbox={
+                "boxstyle": "round",
+                "facecolor": "white",
+                "alpha": 0.8,
+                "edgecolor": "black",
+                "linewidth": 1.5,
+            },
+            zorder=5,
+        )
+
+    # Plot arc showing the angle between the two arrows for the lower divertor (divertor angle)
     arc_radius = 1.5
     angle_start = -deg_blkt_outboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
     angle_end = -deg_blkt_inboard_poloidal_plasma / 2 - deg_div_poloidal_plasma
@@ -14494,6 +14542,7 @@ def plot_blkt_structure(
     label_x = rmajor + label_radius * np.cos(mid_angle)
     label_y = label_radius * np.sin(mid_angle)
 
+    # Plot the info box for the lower divertor angle
     ax.text(
         label_x,
         label_y,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14331,7 +14331,14 @@ def plot_blkt_structure(
     deg_blkt_inboard_poloidal_plasma = m_file.get(
         "deg_blkt_inboard_poloidal_plasma", scan=scan
     )
+    f_deg_blkt_outboard_poloidal_plasma = m_file.get(
+        "f_deg_blkt_outboard_poloidal_plasma", scan=scan
+    )
+    f_deg_blkt_inboard_poloidal_plasma = m_file.get(
+        "f_deg_blkt_inboard_poloidal_plasma", scan=scan
+    )
     deg_div_poloidal_plasma = m_file.get("deg_div_poloidal_plasma", scan=scan)
+    f_ster_div_single = m_file.get("f_ster_div_single", scan=scan)
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
     plot_plasma(ax, m_file, scan, colour_scheme)
@@ -14403,7 +14410,7 @@ def plot_blkt_structure(
     ax.text(
         label_x,
         label_y,
-        f"{deg_blkt_outboard_poloidal_plasma:.1f}°",
+        f"{deg_blkt_outboard_poloidal_plasma:.1f}°\n({f_deg_blkt_outboard_poloidal_plasma * 100:.1f}%)",
         fontsize=8,
         color="purple",
         ha="center",
@@ -14454,7 +14461,7 @@ def plot_blkt_structure(
     ax.text(
         label_x,
         label_y,
-        f"{deg_blkt_inboard_poloidal_plasma:.1f}°",
+        f"{deg_blkt_inboard_poloidal_plasma:.1f}°\n({f_deg_blkt_inboard_poloidal_plasma * 100:.1f}%)",
         fontsize=8,
         color="green",
         ha="center",
@@ -14489,7 +14496,7 @@ def plot_blkt_structure(
     ax.text(
         label_x,
         label_y,
-        f"{deg_div_poloidal_plasma:.1f}°",
+        f"{deg_div_poloidal_plasma:.1f}°\n({f_ster_div_single * 100:.1f}%)",
         fontsize=8,
         color="black",
         ha="center",

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14351,14 +14351,6 @@ def plot_blkt_structure(
     r_fw_outboard_in = r_blkt_outboard_out - dr_blkt_outboard - dr_fw_outboard
     r_fw_inboard_out = r_blkt_inboard_in + dr_blkt_inboard + dr_fw_inboard
 
-    # Plot major radius line (vertical dashed line at rmajor)
-    ax.axvline(
-        m_file.get("rminor", scan=scan),
-        color="black",
-        linestyle="--",
-        linewidth=1.5,
-        label="Major Radius $R_0$",
-    )
     # Plot a horizontal line at dz_blkt_half (blanket half height)
     ax.axhline(
         dz_blkt_half,

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14317,14 +14317,36 @@ def plot_blkt_structure(
 ):
     """Plot the BLKT structure on the given axis."""
     rmajor = m_file.get("rmajor", scan=scan)
+    rminor = m_file.get("rminor", scan=scan)
+    dr_fw_plasma_gap_outboard = m_file.get("dr_fw_plasma_gap_outboard", scan=scan)
+    dr_fw_plasma_gap_inboard = m_file.get("dr_fw_plasma_gap_inboard", scan=scan)
+    dr_fw_inboard = m_file.get("dr_fw_inboard", scan=scan)
+    dr_fw_outboard = m_file.get("dr_fw_outboard", scan=scan)
+    dr_blkt_outboard = m_file.get("dr_blkt_outboard", scan=scan)
+    dr_blkt_inboard = m_file.get("dr_blkt_inboard", scan=scan)
+    dz_blkt_half = m_file.get("dz_blkt_half", scan=scan)
+    deg_blkt_outboard_poloidal_plasma = m_file.get(
+        "deg_blkt_outboard_poloidal_plasma", scan=scan
+    )
 
     plot_blanket(ax, m_file, scan, radial_build, colour_scheme)
+    plot_plasma(ax, m_file, scan, colour_scheme)
     plot_firstwall(ax, m_file, scan, radial_build, colour_scheme)
     ax.set_xlabel("Radial position [m]")
     ax.set_ylabel("Vertical position [m]")
     ax.set_title("Blanket and First Wall Poloidal Cross-Section")
     ax.minorticks_on()
     ax.grid(which="minor", linestyle=":", linewidth=0.5, alpha=0.5)
+
+    r_blkt_outboard_out = (
+        rmajor + rminor + dr_fw_outboard + dr_fw_plasma_gap_outboard + dr_blkt_outboard
+    )
+    r_blkt_inboard_in = (
+        rmajor - rminor - dr_fw_plasma_gap_inboard - dr_fw_inboard - dr_blkt_inboard
+    )
+    r_fw_outboard_in = r_blkt_outboard_out - dr_blkt_outboard - dr_fw_outboard
+    r_fw_inboard_out = r_blkt_inboard_in + dr_blkt_inboard + dr_fw_inboard
+
     # Plot major radius line (vertical dashed line at rmajor)
     ax.axvline(
         m_file.get("rminor", scan=scan),
@@ -14334,7 +14356,6 @@ def plot_blkt_structure(
         label="Major Radius $R_0$",
     )
     # Plot a horizontal line at dz_blkt_half (blanket half height)
-    dz_blkt_half = m_file.get("dz_blkt_half", scan=scan)
     ax.axhline(
         dz_blkt_half,
         color="purple",
@@ -14352,23 +14373,77 @@ def plot_blkt_structure(
 
     ax.annotate(
         "",
-        xy=(rmajor, dz_blkt_half),
-        xytext=(rmajor, -dz_blkt_half),
-        arrowprops={"arrowstyle": "<->", "color": "black"},
+        xy=(rmajor, 0),
+        xytext=(r_blkt_outboard_out, dz_blkt_half),
+        arrowprops={"arrowstyle": "<-", "color": "purple"},
     )
 
-    # Add a label for the internal coil width
+    ax.annotate(
+        "",
+        xy=(rmajor, 0),
+        xytext=(r_blkt_outboard_out, -dz_blkt_half),
+        arrowprops={"arrowstyle": "<-", "color": "purple"},
+    )
+
+    # Plot arc showing the angle between the two arrows
+    arc_radius = 1.0
+    angle_start = -deg_blkt_outboard_poloidal_plasma / 2
+    angle_end = deg_blkt_outboard_poloidal_plasma / 2
+
+    theta = np.linspace(np.deg2rad(angle_start), np.deg2rad(angle_end), 50)
+    arc_x = rmajor + arc_radius * np.cos(theta)
+    arc_y = arc_radius * np.sin(theta)
+
+    ax.plot(arc_x, arc_y, color="purple", linewidth=2)
+
+    # Add angle label at the arc
+    mid_angle = np.deg2rad((angle_start + angle_end) / 2)
+    label_radius = arc_radius * 1.5
+    label_x = rmajor + label_radius * np.cos(mid_angle)
+    label_y = label_radius * np.sin(mid_angle)
+
     ax.text(
+        label_x,
+        label_y,
+        f"{deg_blkt_outboard_poloidal_plasma:.1f}°",
+        fontsize=10,
+        color="purple",
+        ha="center",
+        va="center",
+        weight="bold",
+    )
+
+    ax.annotate(
+        "",
+        xy=(rmajor, 0),
+        xytext=(r_blkt_inboard_in, dz_blkt_half),
+        arrowprops={"arrowstyle": "<-", "color": "purple"},
+    )
+
+    ax.annotate(
+        "",
+        xy=(rmajor, 0),
+        xytext=(r_blkt_inboard_in, -dz_blkt_half),
+        arrowprops={"arrowstyle": "<-", "color": "purple"},
+    )
+
+    # Plot vertical lines at the inner and outer radial boundaries of the blanket
+    ax.axvline(
+        r_blkt_inboard_in, color="black", linestyle="--", linewidth=1.5, zorder=10
+    )
+    ax.axvline(
+        r_blkt_outboard_out, color="black", linestyle="--", linewidth=1.5, zorder=10
+    )
+    ax.axvline(r_fw_inboard_out, color="black", linestyle="--", linewidth=1.5, zorder=10)
+
+    ax.axvline(r_fw_outboard_in, color="black", linestyle="--", linewidth=1.5, zorder=10)
+
+    ax.axvline(
         rmajor,
-        0.0,
-        f"{2 * dz_blkt_half:.3f} m",
-        fontsize=7,
         color="black",
-        rotation=270,
-        verticalalignment="center",
-        horizontalalignment="center",
-        bbox={"boxstyle": "round", "facecolor": "pink", "alpha": 1.0},
-        zorder=101,  # Ensure label is on top of all plots
+        linestyle="--",
+        linewidth=1.5,
+        label="Major Radius $R_0$",
     )
 
     # Plot midplane line (horizontal dashed line at Z=0)

--- a/process/data_structure/blanket_variables.py
+++ b/process/data_structure/blanket_variables.py
@@ -186,5 +186,17 @@ class BlanketData:
     dz_vv_half: float = 0.0
     """Vacuum vessel internal half-height (m)"""
 
+    deg_blkt_outboard_poloidal_plasma: float = 0.0
+    """Outboard blanket poloidal angle subtended by plasma (degrees)"""
+
+    f_deg_blkt_outboard_poloidal_plasma: float = 0.0
+    """Fraction of outboard blanket poloidal angle subtended by plasma (degrees)"""
+
+    deg_blkt_inboard_poloidal_plasma: float = 0.0
+    """Inboard blanket poloidal angle subtended by plasma (degrees)"""
+
+    f_deg_blkt_inboard_poloidal_plasma: float = 0.0
+    """Fraction of inboard blanket poloidal angle subtended by plasma (degrees)"""
+
 
 CREATE_DICTS_FROM_DATACLASS = BlanketData

--- a/process/data_structure/blanket_variables.py
+++ b/process/data_structure/blanket_variables.py
@@ -194,5 +194,17 @@ class BlanketData:
     dz_vv_half: float = 0.0
     """Vacuum vessel internal half-height (m)"""
 
+    deg_blkt_outboard_poloidal_plasma: float = 0.0
+    """Outboard blanket poloidal angle subtended by plasma (degrees)"""
+
+    f_deg_blkt_outboard_poloidal_plasma: float = 0.0
+    """Fraction of outboard blanket poloidal angle subtended by plasma (degrees)"""
+
+    deg_blkt_inboard_poloidal_plasma: float = 0.0
+    """Inboard blanket poloidal angle subtended by plasma (degrees)"""
+
+    f_deg_blkt_inboard_poloidal_plasma: float = 0.0
+    """Fraction of inboard blanket poloidal angle subtended by plasma (degrees)"""
+
 
 CREATE_DICTS_FROM_DATACLASS = BlanketData

--- a/process/data_structure/divertor_variables.py
+++ b/process/data_structure/divertor_variables.py
@@ -71,6 +71,9 @@ p_div_lower_rad_mw: float = None
 n_divertors: int = None
 """Number of divertors (calculated from `i_single_null`)"""
 
+deg_div_poloidal_plasma: float = None
+"""Divertor poloidal angle subtended by plasma (degrees)"""
+
 
 def init_divertor_variables():
     global \
@@ -96,7 +99,8 @@ def init_divertor_variables():
         p_div_upper_nuclear_heat_mw, \
         p_div_upper_rad_mw, \
         p_div_lower_rad_mw, \
-        n_divertors
+        n_divertors, \
+        deg_div_poloidal_plasma
 
     anginc = 0.262
     deg_div_field_plate = 1.0
@@ -121,3 +125,4 @@ def init_divertor_variables():
     p_div_upper_rad_mw = 0.0
     p_div_lower_rad_mw = 0.0
     n_divertors = 2
+    deg_div_poloidal_plasma = 0.0

--- a/process/data_structure/divertor_variables.py
+++ b/process/data_structure/divertor_variables.py
@@ -78,5 +78,8 @@ class DivertorData:
     n_divertors: int = 2
     """Number of divertors (calculated from `i_single_null`)"""
 
+deg_div_poloidal_plasma: float = None
+"""Divertor poloidal angle subtended by plasma (degrees)"""
+
 
 CREATE_DICTS_FROM_DATACLASS = DivertorData

--- a/process/data_structure/divertor_variables.py
+++ b/process/data_structure/divertor_variables.py
@@ -78,8 +78,8 @@ class DivertorData:
     n_divertors: int = 2
     """Number of divertors (calculated from `i_single_null`)"""
 
-deg_div_poloidal_plasma: float = None
-"""Divertor poloidal angle subtended by plasma (degrees)"""
+    deg_div_poloidal_plasma: float = 0.0
+    """Divertor poloidal angle subtended by plasma (degrees)"""
 
 
 CREATE_DICTS_FROM_DATACLASS = DivertorData

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -667,6 +667,12 @@ class BlanketLibrary(Model):
             "(deg_blkt_outboard_poloidal_plasma)",
             blanket_library.deg_blkt_outboard_poloidal_plasma,
         )
+        po.ovarre(
+            self.outfile,
+            "Inboard blanket poloidal angle subtended by plasma (degrees)",
+            "(deg_blkt_inboard_poloidal_plasma)",
+            blanket_library.deg_blkt_inboard_poloidal_plasma,
+        )
 
     def primary_coolant_properties(self, output: bool):
         """Calculates the fluid properties of the Primary Coolant in the FW and BZ.
@@ -3564,6 +3570,34 @@ class InboardBlanket(BlanketLibrary):
         )
 
         self.set_blanket_module_geometry()
+
+    @staticmethod
+    def calculate_blkt_inboard_poloidal_plasma_angle(
+        rminor: float,
+        dz_blkt_half: float,
+        dr_fw_plasma_gap_inboard: float,
+    ) -> float:
+        """Calculate the poloidal angle subtended by the inboard blanket at the plasma mid-plane.
+
+        Angle is taken from the FW surface
+
+        Parameters
+        ----------
+        rminor :
+            Plasma minor radius (m).
+        dz_blkt_half :
+            Vertical half-height of inboard blanket (m).
+        dr_fw_plasma_gap_inboard :
+            Inboard first wall to plasma gap (m).
+
+        Returns
+        -------
+        deg_blkt_inboard_poloidal_plasma :
+            Poloidal angle subtended by inboard blanket at plasma mid-plane (degrees).
+        """
+        return np.degrees(
+            2.0 * np.arctan(dz_blkt_half / (rminor + dr_fw_plasma_gap_inboard))
+        )
 
     def calculate_blanket_inboard_module_geometry(
         self,

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -665,25 +665,25 @@ class BlanketLibrary(Model):
             self.outfile,
             "Outboard blanket poloidal angle subtended by plasma (degrees)",
             "(deg_blkt_outboard_poloidal_plasma)",
-            blanket_library.deg_blkt_outboard_poloidal_plasma,
+            self.data.blanket.deg_blkt_outboard_poloidal_plasma,
         )
         po.ovarre(
             self.outfile,
             "Angle fraction of outboard blanket poloidal angle subtended by plasma",
             "(f_deg_blkt_outboard_poloidal_plasma)",
-            blanket_library.f_deg_blkt_outboard_poloidal_plasma,
+            self.data.blanket.f_deg_blkt_outboard_poloidal_plasma,
         )
         po.ovarre(
             self.outfile,
             "Inboard blanket poloidal angle subtended by plasma (degrees)",
             "(deg_blkt_inboard_poloidal_plasma)",
-            blanket_library.deg_blkt_inboard_poloidal_plasma,
+            self.data.blanket.deg_blkt_inboard_poloidal_plasma,
         )
         po.ovarre(
             self.outfile,
             "Angle fraction of inboard blanket poloidal angle subtended by plasma",
             "(f_deg_blkt_inboard_poloidal_plasma)",
-            blanket_library.f_deg_blkt_inboard_poloidal_plasma,
+            self.data.blanket.f_deg_blkt_inboard_poloidal_plasma,
         )
 
     def primary_coolant_properties(self, output: bool):

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -3483,6 +3483,11 @@ class OutboardBlanket(BlanketLibrary):
             b_bz_liq=self.data.fwbs.b_bz_liq,
         )
 
+    @property
+    def blkt_outboard_poloidal_plasma_angle(self) -> float:
+        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
+        return 180.0
+
     @staticmethod
     def calculate_blkt_outboard_poloidal_plasma_angle(
         rminor: float,

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -669,9 +669,21 @@ class BlanketLibrary(Model):
         )
         po.ovarre(
             self.outfile,
+            "Angle fraction of outboard blanket poloidal angle subtended by plasma",
+            "(f_deg_blkt_outboard_poloidal_plasma)",
+            blanket_library.f_deg_blkt_outboard_poloidal_plasma,
+        )
+        po.ovarre(
+            self.outfile,
             "Inboard blanket poloidal angle subtended by plasma (degrees)",
             "(deg_blkt_inboard_poloidal_plasma)",
             blanket_library.deg_blkt_inboard_poloidal_plasma,
+        )
+        po.ovarre(
+            self.outfile,
+            "Angle fraction of inboard blanket poloidal angle subtended by plasma",
+            "(f_deg_blkt_inboard_poloidal_plasma)",
+            blanket_library.f_deg_blkt_inboard_poloidal_plasma,
         )
 
     def primary_coolant_properties(self, output: bool):
@@ -3487,6 +3499,11 @@ class OutboardBlanket(BlanketLibrary):
     def blkt_outboard_poloidal_plasma_angle(self) -> float:
         """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
         return 180.0
+
+    @property
+    def f_deg_blkt_outboard_poloidal_plasma(self) -> float:
+        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
+        return self.blkt_outboard_poloidal_plasma_angle / 360.0
 
     @staticmethod
     def calculate_blkt_outboard_poloidal_plasma_angle(

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -3495,15 +3495,44 @@ class OutboardBlanket(BlanketLibrary):
             b_bz_liq=self.data.fwbs.b_bz_liq,
         )
 
-    @property
-    def blkt_outboard_poloidal_plasma_angle(self) -> float:
-        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
-        return 180.0
+    def blkt_outboard_poloidal_plasma_angle(
+        self, n_divertors: int, deg_div_poloidal_plasma: float
+    ) -> float:
+        """Calculate the poloidal angle subtended by the outboard blanket at the
+        plasma mid-plane.
+
+        Parameters
+        ----------
+        n_divertors : int
+            Number of divertors in the design (1 or 2).
+        deg_div_poloidal_plasma : float
+            Poloidal angle subtended by the divertor at the plasma mid-plane (degrees).
+
+        Returns
+        -------
+        float
+            Poloidal angle subtended by outboard blanket at plasma mid-plane (degrees).
+
+        Raises
+        ------
+        ProcessValueError
+            If n_divertors is not 1 or 2.
+        """
+        if n_divertors == 1:
+            return 180.0 + deg_div_poloidal_plasma
+        if n_divertors == 2:
+            return 180.0
+        raise ProcessValueError(
+            f"n_divertors = {n_divertors} is an invalid option. Only 1 or 2 divertors "
+            f"are supported."
+        )
 
     @property
     def f_deg_blkt_outboard_poloidal_plasma(self) -> float:
-        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
-        return self.blkt_outboard_poloidal_plasma_angle / 360.0
+        """Calculate the poloidal angle subtended by the outboard blanket at the
+        plasma mid-plane.
+        """
+        return self.data.blanket.deg_blkt_outboard_poloidal_plasma / 360.0
 
     @staticmethod
     def calculate_blkt_outboard_poloidal_plasma_angle(
@@ -3513,7 +3542,8 @@ class OutboardBlanket(BlanketLibrary):
         dr_fw_plasma_gap_outboard: float,
         dr_fw_outboard: float,
     ) -> float:
-        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane.
+        """Calculate the poloidal angle subtended by the outboard blanket at the
+        plasma mid-plane.
 
         Parameters
         ----------
@@ -3553,7 +3583,8 @@ class OutboardBlanket(BlanketLibrary):
         rminor: float,
         dr_fw_plasma_gap_outboard: float,
     ) -> float:
-        """Calculate the mid-plane toroidal circumference and segment length of the outboard blanket.
+        """Calculate the mid-plane toroidal circumference and segment length of the
+        outboard blanket.
 
         Parameters
         ----------

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -660,6 +660,13 @@ class BlanketLibrary(Model):
             "(a_blkt_total_surface_full_coverage)",
             build_variables.a_blkt_total_surface_full_coverage,
         )
+        po.oblnkl(self.outfile)
+        po.ovarre(
+            self.outfile,
+            "Outboard blanket poloidal angle subtended by plasma (degrees)",
+            "(deg_blkt_outboard_poloidal_plasma)",
+            blanket_library.deg_blkt_outboard_poloidal_plasma,
+        )
 
     def primary_coolant_properties(self, output: bool):
         """Calculates the fluid properties of the Primary Coolant in the FW and BZ.
@@ -3468,6 +3475,47 @@ class OutboardBlanket(BlanketLibrary):
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,
+        )
+
+    @staticmethod
+    def calculate_blkt_outboard_poloidal_plasma_angle(
+        rminor: float,
+        dr_blkt_outboard: float,
+        dz_blkt_half: float,
+        dr_fw_plasma_gap_outboard: float,
+        dr_fw_outboard: float,
+    ) -> float:
+        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane.
+
+        Parameters
+        ----------
+        rminor :
+            Plasma minor radius (m).
+        dr_blkt_outboard :
+            Radial thickness of outboard blanket (m).
+        dz_blkt_half :
+            Vertical half-height of outboard blanket (m).
+        dr_fw_plasma_gap_outboard :
+            Outboard first wall to plasma gap (m).
+        dr_fw_outboard :
+            Radial thickness of outboard first wall (m).
+
+        Returns
+        -------
+        deg_blkt_outboard_poloidal_plasma :
+            Poloidal angle subtended by outboard blanket at plasma mid-plane (degrees).
+        """
+        return np.degrees(
+            2.0
+            * np.arctan(
+                dz_blkt_half
+                / (
+                    rminor
+                    + dr_blkt_outboard
+                    + dr_fw_plasma_gap_outboard
+                    + dr_fw_outboard
+                )
+            )
         )
 
     def calculate_blanket_outboard_module_geometry(

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -663,9 +663,21 @@ class BlanketLibrary(Model):
         )
         po.ovarre(
             self.outfile,
+            "Angle fraction of outboard blanket poloidal angle subtended by plasma",
+            "(f_deg_blkt_outboard_poloidal_plasma)",
+            blanket_library.f_deg_blkt_outboard_poloidal_plasma,
+        )
+        po.ovarre(
+            self.outfile,
             "Inboard blanket poloidal angle subtended by plasma (degrees)",
             "(deg_blkt_inboard_poloidal_plasma)",
             blanket_library.deg_blkt_inboard_poloidal_plasma,
+        )
+        po.ovarre(
+            self.outfile,
+            "Angle fraction of inboard blanket poloidal angle subtended by plasma",
+            "(f_deg_blkt_inboard_poloidal_plasma)",
+            blanket_library.f_deg_blkt_inboard_poloidal_plasma,
         )
 
     def primary_coolant_properties(self, output: bool):
@@ -3482,6 +3494,11 @@ class OutboardBlanket(BlanketLibrary):
     def blkt_outboard_poloidal_plasma_angle(self) -> float:
         """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
         return 180.0
+
+    @property
+    def f_deg_blkt_outboard_poloidal_plasma(self) -> float:
+        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
+        return self.blkt_outboard_poloidal_plasma_angle / 360.0
 
     @staticmethod
     def calculate_blkt_outboard_poloidal_plasma_angle(

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -654,6 +654,13 @@ class BlanketLibrary(Model):
             "(a_blkt_total_surface_full_coverage)",
             self.data.build.a_blkt_total_surface_full_coverage,
         )
+        po.oblnkl(self.outfile)
+        po.ovarre(
+            self.outfile,
+            "Outboard blanket poloidal angle subtended by plasma (degrees)",
+            "(deg_blkt_outboard_poloidal_plasma)",
+            blanket_library.deg_blkt_outboard_poloidal_plasma,
+        )
 
     def primary_coolant_properties(self, output: bool):
         """Calculates the fluid properties of the Primary Coolant in the FW and BZ.
@@ -3463,6 +3470,47 @@ class OutboardBlanket(BlanketLibrary):
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,
+        )
+
+    @staticmethod
+    def calculate_blkt_outboard_poloidal_plasma_angle(
+        rminor: float,
+        dr_blkt_outboard: float,
+        dz_blkt_half: float,
+        dr_fw_plasma_gap_outboard: float,
+        dr_fw_outboard: float,
+    ) -> float:
+        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane.
+
+        Parameters
+        ----------
+        rminor :
+            Plasma minor radius (m).
+        dr_blkt_outboard :
+            Radial thickness of outboard blanket (m).
+        dz_blkt_half :
+            Vertical half-height of outboard blanket (m).
+        dr_fw_plasma_gap_outboard :
+            Outboard first wall to plasma gap (m).
+        dr_fw_outboard :
+            Radial thickness of outboard first wall (m).
+
+        Returns
+        -------
+        deg_blkt_outboard_poloidal_plasma :
+            Poloidal angle subtended by outboard blanket at plasma mid-plane (degrees).
+        """
+        return np.degrees(
+            2.0
+            * np.arctan(
+                dz_blkt_half
+                / (
+                    rminor
+                    + dr_blkt_outboard
+                    + dr_fw_plasma_gap_outboard
+                    + dr_fw_outboard
+                )
+            )
         )
 
     def calculate_blanket_outboard_module_geometry(

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -661,6 +661,12 @@ class BlanketLibrary(Model):
             "(deg_blkt_outboard_poloidal_plasma)",
             blanket_library.deg_blkt_outboard_poloidal_plasma,
         )
+        po.ovarre(
+            self.outfile,
+            "Inboard blanket poloidal angle subtended by plasma (degrees)",
+            "(deg_blkt_inboard_poloidal_plasma)",
+            blanket_library.deg_blkt_inboard_poloidal_plasma,
+        )
 
     def primary_coolant_properties(self, output: bool):
         """Calculates the fluid properties of the Primary Coolant in the FW and BZ.
@@ -3559,6 +3565,34 @@ class InboardBlanket(BlanketLibrary):
         )
 
         self.set_blanket_module_geometry()
+
+    @staticmethod
+    def calculate_blkt_inboard_poloidal_plasma_angle(
+        rminor: float,
+        dz_blkt_half: float,
+        dr_fw_plasma_gap_inboard: float,
+    ) -> float:
+        """Calculate the poloidal angle subtended by the inboard blanket at the plasma mid-plane.
+
+        Angle is taken from the FW surface
+
+        Parameters
+        ----------
+        rminor :
+            Plasma minor radius (m).
+        dz_blkt_half :
+            Vertical half-height of inboard blanket (m).
+        dr_fw_plasma_gap_inboard :
+            Inboard first wall to plasma gap (m).
+
+        Returns
+        -------
+        deg_blkt_inboard_poloidal_plasma :
+            Poloidal angle subtended by inboard blanket at plasma mid-plane (degrees).
+        """
+        return np.degrees(
+            2.0 * np.arctan(dz_blkt_half / (rminor + dr_fw_plasma_gap_inboard))
+        )
 
     def calculate_blanket_inboard_module_geometry(
         self,

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -3490,15 +3490,44 @@ class OutboardBlanket(BlanketLibrary):
             b_bz_liq=self.data.fwbs.b_bz_liq,
         )
 
-    @property
-    def blkt_outboard_poloidal_plasma_angle(self) -> float:
-        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
-        return 180.0
+    def blkt_outboard_poloidal_plasma_angle(
+        self, n_divertors: int, deg_div_poloidal_plasma: float
+    ) -> float:
+        """Calculate the poloidal angle subtended by the outboard blanket at the
+        plasma mid-plane.
+
+        Parameters
+        ----------
+        n_divertors : int
+            Number of divertors in the design (1 or 2).
+        deg_div_poloidal_plasma : float
+            Poloidal angle subtended by the divertor at the plasma mid-plane (degrees).
+
+        Returns
+        -------
+        float
+            Poloidal angle subtended by outboard blanket at plasma mid-plane (degrees).
+
+        Raises
+        ------
+        ProcessValueError
+            If n_divertors is not 1 or 2.
+        """
+        if n_divertors == 1:
+            return 180.0 + deg_div_poloidal_plasma
+        if n_divertors == 2:
+            return 180.0
+        raise ProcessValueError(
+            f"n_divertors = {n_divertors} is an invalid option. Only 1 or 2 divertors "
+            f"are supported."
+        )
 
     @property
     def f_deg_blkt_outboard_poloidal_plasma(self) -> float:
-        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
-        return self.blkt_outboard_poloidal_plasma_angle / 360.0
+        """Calculate the poloidal angle subtended by the outboard blanket at the
+        plasma mid-plane.
+        """
+        return self.data.blanket.deg_blkt_outboard_poloidal_plasma / 360.0
 
     @staticmethod
     def calculate_blkt_outboard_poloidal_plasma_angle(
@@ -3508,7 +3537,8 @@ class OutboardBlanket(BlanketLibrary):
         dr_fw_plasma_gap_outboard: float,
         dr_fw_outboard: float,
     ) -> float:
-        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane.
+        """Calculate the poloidal angle subtended by the outboard blanket at the
+        plasma mid-plane.
 
         Parameters
         ----------
@@ -3548,7 +3578,8 @@ class OutboardBlanket(BlanketLibrary):
         rminor: float,
         dr_fw_plasma_gap_outboard: float,
     ) -> float:
-        """Calculate the mid-plane toroidal circumference and segment length of the outboard blanket.
+        """Calculate the mid-plane toroidal circumference and segment length of the
+        outboard blanket.
 
         Parameters
         ----------

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -659,25 +659,25 @@ class BlanketLibrary(Model):
             self.outfile,
             "Outboard blanket poloidal angle subtended by plasma (degrees)",
             "(deg_blkt_outboard_poloidal_plasma)",
-            blanket_library.deg_blkt_outboard_poloidal_plasma,
+            self.data.blanket.deg_blkt_outboard_poloidal_plasma,
         )
         po.ovarre(
             self.outfile,
             "Angle fraction of outboard blanket poloidal angle subtended by plasma",
             "(f_deg_blkt_outboard_poloidal_plasma)",
-            blanket_library.f_deg_blkt_outboard_poloidal_plasma,
+            self.data.blanket.f_deg_blkt_outboard_poloidal_plasma,
         )
         po.ovarre(
             self.outfile,
             "Inboard blanket poloidal angle subtended by plasma (degrees)",
             "(deg_blkt_inboard_poloidal_plasma)",
-            blanket_library.deg_blkt_inboard_poloidal_plasma,
+            self.data.blanket.deg_blkt_inboard_poloidal_plasma,
         )
         po.ovarre(
             self.outfile,
             "Angle fraction of inboard blanket poloidal angle subtended by plasma",
             "(f_deg_blkt_inboard_poloidal_plasma)",
-            blanket_library.f_deg_blkt_inboard_poloidal_plasma,
+            self.data.blanket.f_deg_blkt_inboard_poloidal_plasma,
         )
 
     def primary_coolant_properties(self, output: bool):

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -3478,6 +3478,11 @@ class OutboardBlanket(BlanketLibrary):
             b_bz_liq=self.data.fwbs.b_bz_liq,
         )
 
+    @property
+    def blkt_outboard_poloidal_plasma_angle(self) -> float:
+        """Calculate the poloidal angle subtended by the outboard blanket at the plasma mid-plane."""
+        return 180.0
+
     @staticmethod
     def calculate_blkt_outboard_poloidal_plasma_angle(
         rminor: float,

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -2,7 +2,6 @@ from process.core import constants
 from process.core import (
     process_output as po,
 )
-from process.data_structure import blanket_library as blanket_vars
 from process.data_structure import (
     build_variables,
     current_drive_variables,
@@ -99,23 +98,23 @@ class DCLL(InboardBlanket, OutboardBlanket):
         self.component_volumes()
 
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
-        blanket_vars.deg_blkt_outboard_poloidal_plasma = (
+        self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
             self.blkt_outboard_poloidal_plasma_angle
         )
-        blanket_vars.f_deg_blkt_outboard_poloidal_plasma = (
+        self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
             self.f_deg_blkt_outboard_poloidal_plasma
         )
 
-        blanket_vars.deg_blkt_inboard_poloidal_plasma = (
+        self.data.blanket.deg_blkt_inboard_poloidal_plasma = (
             self.calculate_blkt_inboard_poloidal_plasma_angle(
                 rminor=physics_variables.rminor,
-                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dz_blkt_half=self.data.blanket.dz_blkt_half,
                 dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
             )
         )
 
-        blanket_vars.f_deg_blkt_inboard_poloidal_plasma = (
-            blanket_vars.deg_blkt_inboard_poloidal_plasma / 360.0
+        self.data.blanket.f_deg_blkt_inboard_poloidal_plasma = (
+            self.data.blanket.deg_blkt_inboard_poloidal_plasma / 360.0
         )
 
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -2,6 +2,7 @@ from process.core import constants
 from process.core import (
     process_output as po,
 )
+from process.data_structure import blanket_library as blanket_vars
 from process.data_structure import (
     build_variables,
     current_drive_variables,
@@ -96,6 +97,27 @@ class DCLL(InboardBlanket, OutboardBlanket):
 
     def run(self, output: bool = False):
         self.component_volumes()
+
+        # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
+        blanket_vars.deg_blkt_outboard_poloidal_plasma = (
+            self.blkt_outboard_poloidal_plasma_angle
+        )
+        blanket_vars.f_deg_blkt_outboard_poloidal_plasma = (
+            self.f_deg_blkt_outboard_poloidal_plasma
+        )
+
+        blanket_vars.deg_blkt_inboard_poloidal_plasma = (
+            self.calculate_blkt_inboard_poloidal_plasma_angle(
+                rminor=physics_variables.rminor,
+                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
+            )
+        )
+
+        blanket_vars.f_deg_blkt_inboard_poloidal_plasma = (
+            blanket_vars.deg_blkt_inboard_poloidal_plasma / 360.0
+        )
+
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)
         self.data.fwbs.radius_blkt_channel = dia_blkt_channel / 2
         (

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -99,7 +99,10 @@ class DCLL(InboardBlanket, OutboardBlanket):
 
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
         self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
-            self.blkt_outboard_poloidal_plasma_angle
+            self.blkt_outboard_poloidal_plasma_angle(
+                n_divertors=divertor_variables.n_divertors,
+                deg_div_poloidal_plasma=divertor_variables.deg_div_poloidal_plasma,
+            )
         )
         self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
             self.f_deg_blkt_outboard_poloidal_plasma

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -91,8 +91,8 @@ class DCLL(InboardBlanket, OutboardBlanket):
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
         self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
             self.blkt_outboard_poloidal_plasma_angle(
-                n_divertors=divertor_variables.n_divertors,
-                deg_div_poloidal_plasma=divertor_variables.deg_div_poloidal_plasma,
+                n_divertors=self.data.divertor.n_divertors,
+                deg_div_poloidal_plasma=self.data.divertor.deg_div_poloidal_plasma,
             )
         )
         self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
@@ -103,7 +103,7 @@ class DCLL(InboardBlanket, OutboardBlanket):
             self.calculate_blkt_inboard_poloidal_plasma_angle(
                 rminor=physics_variables.rminor,
                 dz_blkt_half=self.data.blanket.dz_blkt_half,
-                dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
+                dr_fw_plasma_gap_inboard=self.data.build.dr_fw_plasma_gap_inboard,
             )
         )
 

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -2,6 +2,7 @@ from process.core import constants
 from process.core import (
     process_output as po,
 )
+from process.data_structure import blanket_library as blanket_vars
 from process.models.blankets.blanket_library import InboardBlanket, OutboardBlanket
 from process.models.engineering.ivc_functions import (
     calculate_pipe_bend_radius,
@@ -87,6 +88,27 @@ class DCLL(InboardBlanket, OutboardBlanket):
 
     def run(self, output: bool = False):
         self.component_volumes()
+
+        # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
+        blanket_vars.deg_blkt_outboard_poloidal_plasma = (
+            self.blkt_outboard_poloidal_plasma_angle
+        )
+        blanket_vars.f_deg_blkt_outboard_poloidal_plasma = (
+            self.f_deg_blkt_outboard_poloidal_plasma
+        )
+
+        blanket_vars.deg_blkt_inboard_poloidal_plasma = (
+            self.calculate_blkt_inboard_poloidal_plasma_angle(
+                rminor=physics_variables.rminor,
+                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
+            )
+        )
+
+        blanket_vars.f_deg_blkt_inboard_poloidal_plasma = (
+            blanket_vars.deg_blkt_inboard_poloidal_plasma / 360.0
+        )
+
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)
         self.data.fwbs.radius_blkt_channel = dia_blkt_channel / 2
         (

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -101,7 +101,7 @@ class DCLL(InboardBlanket, OutboardBlanket):
 
         self.data.blanket.deg_blkt_inboard_poloidal_plasma = (
             self.calculate_blkt_inboard_poloidal_plasma_angle(
-                rminor=physics_variables.rminor,
+                rminor=self.data.physics.rminor,
                 dz_blkt_half=self.data.blanket.dz_blkt_half,
                 dr_fw_plasma_gap_inboard=self.data.build.dr_fw_plasma_gap_inboard,
             )

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -2,7 +2,6 @@ from process.core import constants
 from process.core import (
     process_output as po,
 )
-from process.data_structure import blanket_library as blanket_vars
 from process.models.blankets.blanket_library import InboardBlanket, OutboardBlanket
 from process.models.engineering.ivc_functions import (
     calculate_pipe_bend_radius,
@@ -90,23 +89,23 @@ class DCLL(InboardBlanket, OutboardBlanket):
         self.component_volumes()
 
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
-        blanket_vars.deg_blkt_outboard_poloidal_plasma = (
+        self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
             self.blkt_outboard_poloidal_plasma_angle
         )
-        blanket_vars.f_deg_blkt_outboard_poloidal_plasma = (
+        self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
             self.f_deg_blkt_outboard_poloidal_plasma
         )
 
-        blanket_vars.deg_blkt_inboard_poloidal_plasma = (
+        self.data.blanket.deg_blkt_inboard_poloidal_plasma = (
             self.calculate_blkt_inboard_poloidal_plasma_angle(
                 rminor=physics_variables.rminor,
-                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dz_blkt_half=self.data.blanket.dz_blkt_half,
                 dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
             )
         )
 
-        blanket_vars.f_deg_blkt_inboard_poloidal_plasma = (
-            blanket_vars.deg_blkt_inboard_poloidal_plasma / 360.0
+        self.data.blanket.f_deg_blkt_inboard_poloidal_plasma = (
+            self.data.blanket.deg_blkt_inboard_poloidal_plasma / 360.0
         )
 
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -90,7 +90,10 @@ class DCLL(InboardBlanket, OutboardBlanket):
 
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
         self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
-            self.blkt_outboard_poloidal_plasma_angle
+            self.blkt_outboard_poloidal_plasma_angle(
+                n_divertors=divertor_variables.n_divertors,
+                deg_div_poloidal_plasma=divertor_variables.deg_div_poloidal_plasma,
+            )
         )
         self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
             self.f_deg_blkt_outboard_poloidal_plasma

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -62,6 +62,14 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
             )
         )
 
+        blanket_vars.deg_blkt_inboard_poloidal_plasma = (
+            self.calculate_blkt_inboard_poloidal_plasma_angle(
+                rminor=physics_variables.rminor,
+                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
+            )
+        )
+
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)
         self.data.fwbs.radius_blkt_channel = dia_blkt_channel / 2
         (

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -52,6 +52,16 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         # Calculate blanket, shield, vacuum vessel and cryostat volumes
         self.component_volumes()
 
+        blanket_vars.deg_blkt_outboard_poloidal_plasma = (
+            self.calculate_blkt_outboard_poloidal_plasma_angle(
+                rminor=physics_variables.rminor,
+                dr_blkt_outboard=build_variables.dr_blkt_outboard,
+                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dr_fw_plasma_gap_outboard=build_variables.dr_fw_plasma_gap_outboard,
+                dr_fw_outboard=build_variables.dr_fw_outboard,
+            )
+        )
+
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)
         self.data.fwbs.radius_blkt_channel = dia_blkt_channel / 2
         (

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -53,23 +53,23 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         self.component_volumes()
 
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
-        blanket_vars.deg_blkt_outboard_poloidal_plasma = (
+        self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
             self.blkt_outboard_poloidal_plasma_angle
         )
-        blanket_vars.f_deg_blkt_outboard_poloidal_plasma = (
+        self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
             self.f_deg_blkt_outboard_poloidal_plasma
         )
 
-        blanket_vars.deg_blkt_inboard_poloidal_plasma = (
+        self.data.blanket.deg_blkt_inboard_poloidal_plasma = (
             self.calculate_blkt_inboard_poloidal_plasma_angle(
                 rminor=physics_variables.rminor,
-                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dz_blkt_half=self.data.blanket.dz_blkt_half,
                 dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
             )
         )
 
-        blanket_vars.f_deg_blkt_inboard_poloidal_plasma = (
-            blanket_vars.deg_blkt_inboard_poloidal_plasma / 360.0
+        self.data.blanket.f_deg_blkt_inboard_poloidal_plasma = (
+            self.data.blanket.deg_blkt_inboard_poloidal_plasma / 360.0
         )
 
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -54,7 +54,10 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
 
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
         self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
-            self.blkt_outboard_poloidal_plasma_angle
+            self.blkt_outboard_poloidal_plasma_angle(
+                n_divertors=divertor_variables.n_divertors,
+                deg_div_poloidal_plasma=divertor_variables.deg_div_poloidal_plasma,
+            )
         )
         self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
             self.f_deg_blkt_outboard_poloidal_plasma

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -52,14 +52,9 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         # Calculate blanket, shield, vacuum vessel and cryostat volumes
         self.component_volumes()
 
+        # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
         blanket_vars.deg_blkt_outboard_poloidal_plasma = (
-            self.calculate_blkt_outboard_poloidal_plasma_angle(
-                rminor=physics_variables.rminor,
-                dr_blkt_outboard=build_variables.dr_blkt_outboard,
-                dz_blkt_half=blanket_vars.dz_blkt_half,
-                dr_fw_plasma_gap_outboard=build_variables.dr_fw_plasma_gap_outboard,
-                dr_fw_outboard=build_variables.dr_fw_outboard,
-            )
+            self.blkt_outboard_poloidal_plasma_angle
         )
 
         blanket_vars.deg_blkt_inboard_poloidal_plasma = (

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -56,6 +56,9 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         blanket_vars.deg_blkt_outboard_poloidal_plasma = (
             self.blkt_outboard_poloidal_plasma_angle
         )
+        blanket_vars.f_deg_blkt_outboard_poloidal_plasma = (
+            self.f_deg_blkt_outboard_poloidal_plasma
+        )
 
         blanket_vars.deg_blkt_inboard_poloidal_plasma = (
             self.calculate_blkt_inboard_poloidal_plasma_angle(
@@ -63,6 +66,10 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
                 dz_blkt_half=blanket_vars.dz_blkt_half,
                 dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
             )
+        )
+
+        blanket_vars.f_deg_blkt_inboard_poloidal_plasma = (
+            blanket_vars.deg_blkt_inboard_poloidal_plasma / 360.0
         )
 
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -45,8 +45,8 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
         self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
             self.blkt_outboard_poloidal_plasma_angle(
-                n_divertors=divertor_variables.n_divertors,
-                deg_div_poloidal_plasma=divertor_variables.deg_div_poloidal_plasma,
+                n_divertors=self.data.divertor.n_divertors,
+                deg_div_poloidal_plasma=self.data.divertor.deg_div_poloidal_plasma,
             )
         )
         self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
@@ -57,7 +57,7 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
             self.calculate_blkt_inboard_poloidal_plasma_angle(
                 rminor=physics_variables.rminor,
                 dz_blkt_half=self.data.blanket.dz_blkt_half,
-                dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
+                dr_fw_plasma_gap_inboard=self.data.build.dr_fw_plasma_gap_inboard,
             )
         )
 

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -52,6 +52,14 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
             )
         )
 
+        blanket_vars.deg_blkt_inboard_poloidal_plasma = (
+            self.calculate_blkt_inboard_poloidal_plasma_angle(
+                rminor=physics_variables.rminor,
+                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
+            )
+        )
+
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)
         self.data.fwbs.radius_blkt_channel = dia_blkt_channel / 2
         (

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -46,6 +46,9 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         blanket_vars.deg_blkt_outboard_poloidal_plasma = (
             self.blkt_outboard_poloidal_plasma_angle
         )
+        blanket_vars.f_deg_blkt_outboard_poloidal_plasma = (
+            self.f_deg_blkt_outboard_poloidal_plasma
+        )
 
         blanket_vars.deg_blkt_inboard_poloidal_plasma = (
             self.calculate_blkt_inboard_poloidal_plasma_angle(
@@ -53,6 +56,10 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
                 dz_blkt_half=blanket_vars.dz_blkt_half,
                 dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
             )
+        )
+
+        blanket_vars.f_deg_blkt_inboard_poloidal_plasma = (
+            blanket_vars.deg_blkt_inboard_poloidal_plasma / 360.0
         )
 
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -42,6 +42,16 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         # Calculate blanket, shield, vacuum vessel and cryostat volumes
         self.component_volumes()
 
+        blanket_vars.deg_blkt_outboard_poloidal_plasma = (
+            self.calculate_blkt_outboard_poloidal_plasma_angle(
+                rminor=physics_variables.rminor,
+                dr_blkt_outboard=build_variables.dr_blkt_outboard,
+                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dr_fw_plasma_gap_outboard=build_variables.dr_fw_plasma_gap_outboard,
+                dr_fw_outboard=build_variables.dr_fw_outboard,
+            )
+        )
+
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)
         self.data.fwbs.radius_blkt_channel = dia_blkt_channel / 2
         (

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -43,23 +43,23 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         self.component_volumes()
 
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
-        blanket_vars.deg_blkt_outboard_poloidal_plasma = (
+        self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
             self.blkt_outboard_poloidal_plasma_angle
         )
-        blanket_vars.f_deg_blkt_outboard_poloidal_plasma = (
+        self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
             self.f_deg_blkt_outboard_poloidal_plasma
         )
 
-        blanket_vars.deg_blkt_inboard_poloidal_plasma = (
+        self.data.blanket.deg_blkt_inboard_poloidal_plasma = (
             self.calculate_blkt_inboard_poloidal_plasma_angle(
                 rminor=physics_variables.rminor,
-                dz_blkt_half=blanket_vars.dz_blkt_half,
+                dz_blkt_half=self.data.blanket.dz_blkt_half,
                 dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
             )
         )
 
-        blanket_vars.f_deg_blkt_inboard_poloidal_plasma = (
-            blanket_vars.deg_blkt_inboard_poloidal_plasma / 360.0
+        self.data.blanket.f_deg_blkt_inboard_poloidal_plasma = (
+            self.data.blanket.deg_blkt_inboard_poloidal_plasma / 360.0
         )
 
         dia_blkt_channel = self.pipe_hydraulic_diameter(i_channel_shape=1)

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -42,14 +42,9 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         # Calculate blanket, shield, vacuum vessel and cryostat volumes
         self.component_volumes()
 
+        # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
         blanket_vars.deg_blkt_outboard_poloidal_plasma = (
-            self.calculate_blkt_outboard_poloidal_plasma_angle(
-                rminor=physics_variables.rminor,
-                dr_blkt_outboard=build_variables.dr_blkt_outboard,
-                dz_blkt_half=blanket_vars.dz_blkt_half,
-                dr_fw_plasma_gap_outboard=build_variables.dr_fw_plasma_gap_outboard,
-                dr_fw_outboard=build_variables.dr_fw_outboard,
-            )
+            self.blkt_outboard_poloidal_plasma_angle
         )
 
         blanket_vars.deg_blkt_inboard_poloidal_plasma = (

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -55,7 +55,7 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
 
         self.data.blanket.deg_blkt_inboard_poloidal_plasma = (
             self.calculate_blkt_inboard_poloidal_plasma_angle(
-                rminor=physics_variables.rminor,
+                rminor=self.data.physics.rminor,
                 dz_blkt_half=self.data.blanket.dz_blkt_half,
                 dr_fw_plasma_gap_inboard=self.data.build.dr_fw_plasma_gap_inboard,
             )

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -44,7 +44,10 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
 
         # If Shfranov shift is added, the angle formula can be used where the shift is added to the minor radius. For now, the shift is neglected and the angle is calculated using the minor radius only.
         self.data.blanket.deg_blkt_outboard_poloidal_plasma = (
-            self.blkt_outboard_poloidal_plasma_angle
+            self.blkt_outboard_poloidal_plasma_angle(
+                n_divertors=divertor_variables.n_divertors,
+                deg_div_poloidal_plasma=divertor_variables.deg_div_poloidal_plasma,
+            )
         )
         self.data.blanket.f_deg_blkt_outboard_poloidal_plasma = (
             self.f_deg_blkt_outboard_poloidal_plasma

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -1147,13 +1147,6 @@ class Build(Model):
                     divht,
                     "OP ",
                 )
-                po.ovarrf(
-                    self.outfile,
-                    "Divertor poloidal angle subtended by plasma (degrees)",
-                    "(deg_div_poloidal_plasma)",
-                    divertor_variables.deg_div_poloidal_plasma,
-                    "OP ",
-                )
 
             elif divertor_variables.n_divertors == 2:
                 po.oheadr(self.outfile, "Divertor build and plasma position")
@@ -1462,13 +1455,6 @@ class Build(Model):
                     "Calculated maximum divertor height (m)",
                     "(divht)",
                     divht,
-                    "OP ",
-                )
-                po.ovarrf(
-                    self.outfile,
-                    "Divertor poloidal angle subtended by plasma (degrees)",
-                    "(deg_div_poloidal_plasma)",
-                    divertor_variables.deg_div_poloidal_plasma,
                     "OP ",
                 )
             else:

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -1147,6 +1147,13 @@ class Build(Model):
                     divht,
                     "OP ",
                 )
+                po.ovarrf(
+                    self.outfile,
+                    "Divertor poloidal angle subtended by plasma (degrees)",
+                    "(deg_div_poloidal_plasma)",
+                    divertor_variables.deg_div_poloidal_plasma,
+                    "OP ",
+                )
 
             elif divertor_variables.n_divertors == 2:
                 po.oheadr(self.outfile, "Divertor build and plasma position")
@@ -1455,6 +1462,13 @@ class Build(Model):
                     "Calculated maximum divertor height (m)",
                     "(divht)",
                     divht,
+                    "OP ",
+                )
+                po.ovarrf(
+                    self.outfile,
+                    "Divertor poloidal angle subtended by plasma (degrees)",
+                    "(deg_div_poloidal_plasma)",
+                    divertor_variables.deg_div_poloidal_plasma,
                     "OP ",
                 )
             else:

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -1140,6 +1140,13 @@ class Build(Model):
                     divht,
                     "OP ",
                 )
+                po.ovarrf(
+                    self.outfile,
+                    "Divertor poloidal angle subtended by plasma (degrees)",
+                    "(deg_div_poloidal_plasma)",
+                    divertor_variables.deg_div_poloidal_plasma,
+                    "OP ",
+                )
 
             elif self.data.divertor.n_divertors == 2:
                 po.oheadr(self.outfile, "Divertor build and plasma position")
@@ -1448,6 +1455,13 @@ class Build(Model):
                     "Calculated maximum divertor height (m)",
                     "(divht)",
                     divht,
+                    "OP ",
+                )
+                po.ovarrf(
+                    self.outfile,
+                    "Divertor poloidal angle subtended by plasma (degrees)",
+                    "(deg_div_poloidal_plasma)",
+                    divertor_variables.deg_div_poloidal_plasma,
                     "OP ",
                 )
             else:

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -1140,13 +1140,6 @@ class Build(Model):
                     divht,
                     "OP ",
                 )
-                po.ovarrf(
-                    self.outfile,
-                    "Divertor poloidal angle subtended by plasma (degrees)",
-                    "(deg_div_poloidal_plasma)",
-                    divertor_variables.deg_div_poloidal_plasma,
-                    "OP ",
-                )
 
             elif self.data.divertor.n_divertors == 2:
                 po.oheadr(self.outfile, "Divertor build and plasma position")
@@ -1455,13 +1448,6 @@ class Build(Model):
                     "Calculated maximum divertor height (m)",
                     "(divht)",
                     divht,
-                    "OP ",
-                )
-                po.ovarrf(
-                    self.outfile,
-                    "Divertor poloidal angle subtended by plasma (degrees)",
-                    "(deg_div_poloidal_plasma)",
-                    divertor_variables.deg_div_poloidal_plasma,
                     "OP ",
                 )
             else:

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -39,6 +39,7 @@ class Divertor(Model):
             indicate whether output should be written to the output file, or not
         """
         dv.deg_div_poloidal_plasma = self.single_divertor_angle
+        fwbs.f_ster_div_single = dv.deg_div_poloidal_plasma / 360.0
 
         self.data.fwbs.p_div_nuclear_heat_total_mw = self.incident_neutron_power(
             p_plasma_neutron_mw=pv.p_plasma_neutron_mw,

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -6,6 +6,7 @@ from process.core import constants
 from process.core import process_output as po
 from process.core.exceptions import ProcessValueError
 from process.core.model import Model
+from process.data_structure import blanket_library
 from process.data_structure import build_variables as bv
 from process.data_structure import divertor_variables as dv
 from process.data_structure import physics_variables as pv
@@ -37,6 +38,8 @@ class Divertor(Model):
         output :
             indicate whether output should be written to the output file, or not
         """
+        dv.deg_div_poloidal_plasma = self.single_divertor_angle
+
         self.data.fwbs.p_div_nuclear_heat_total_mw = self.incident_neutron_power(
             p_plasma_neutron_mw=pv.p_plasma_neutron_mw,
             f_ster_div_single=self.data.fwbs.f_ster_div_single,
@@ -86,6 +89,21 @@ class Divertor(Model):
                 output=output,
             )
             return
+
+    @property
+    def single_divertor_angle(self):
+        """
+        Calculate the angle subtended by a single divertor.
+        Angle is calculated as 360 degrees minus the sum of the inboard
+        and outboard blanket poloidal angles, divided by 2 (for two divertors).
+        """
+        return (
+            360.0
+            - (
+                blanket_library.deg_blkt_inboard_poloidal_plasma
+                + blanket_library.deg_blkt_outboard_poloidal_plasma
+            )
+        ) / 2.0
 
     def divtart(
         self,

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -95,16 +95,10 @@ class Divertor(Model):
     def single_divertor_angle(self):
         """
         Calculate the angle subtended by a single divertor.
-        Angle is calculated as 360 degrees minus the sum of the inboard
-        and outboard blanket poloidal angles, divided by 2 (for two divertors).
+        Angle is calculated as 180 degrees minus the inboard
+        blanket poloidal angle, divided by 2 (for two divertors).
         """
-        return (
-            360.0
-            - (
-                blanket_library.deg_blkt_inboard_poloidal_plasma
-                + blanket_library.deg_blkt_outboard_poloidal_plasma
-            )
-        ) / 2.0
+        return (180.0 - blanket_library.deg_blkt_inboard_poloidal_plasma) / 2.0
 
     def divtart(
         self,

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -6,7 +6,6 @@ from process.core import constants
 from process.core import process_output as po
 from process.core.exceptions import ProcessValueError
 from process.core.model import Model
-from process.data_structure import blanket_library
 from process.data_structure import build_variables as bv
 from process.data_structure import divertor_variables as dv
 from process.data_structure import physics_variables as pv
@@ -39,7 +38,7 @@ class Divertor(Model):
             indicate whether output should be written to the output file, or not
         """
         dv.deg_div_poloidal_plasma = self.single_divertor_angle
-        fwbs.f_ster_div_single = dv.deg_div_poloidal_plasma / 360.0
+        self.data.fwbs.f_ster_div_single = dv.deg_div_poloidal_plasma / 360.0
 
         self.data.fwbs.p_div_nuclear_heat_total_mw = self.incident_neutron_power(
             p_plasma_neutron_mw=pv.p_plasma_neutron_mw,
@@ -98,7 +97,7 @@ class Divertor(Model):
         Angle is calculated as 180 degrees minus the inboard
         blanket poloidal angle, divided by 2 (for two divertors).
         """
-        return (180.0 - blanket_library.deg_blkt_inboard_poloidal_plasma) / 2.0
+        return (180.0 - self.data.blanket.deg_blkt_inboard_poloidal_plasma) / 2.0
 
     def divtart(
         self,

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -34,8 +34,10 @@ class Divertor(Model):
         output :
             indicate whether output should be written to the output file, or not
         """
-        dv.deg_div_poloidal_plasma = self.single_divertor_angle
-        self.data.fwbs.f_ster_div_single = dv.deg_div_poloidal_plasma / 360.0
+        self.data.divertor.deg_div_poloidal_plasma = self.single_divertor_angle
+        self.data.fwbs.f_ster_div_single = (
+            self.data.divertor.deg_div_poloidal_plasma / 360.0
+        )
 
         self.data.fwbs.p_div_nuclear_heat_total_mw = self.incident_neutron_power(
             p_plasma_neutron_mw=self.data.physics.p_plasma_neutron_mw,

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -92,16 +92,10 @@ class Divertor(Model):
     def single_divertor_angle(self):
         """
         Calculate the angle subtended by a single divertor.
-        Angle is calculated as 360 degrees minus the sum of the inboard
-        and outboard blanket poloidal angles, divided by 2 (for two divertors).
+        Angle is calculated as 180 degrees minus the inboard
+        blanket poloidal angle, divided by 2 (for two divertors).
         """
-        return (
-            360.0
-            - (
-                blanket_library.deg_blkt_inboard_poloidal_plasma
-                + blanket_library.deg_blkt_outboard_poloidal_plasma
-            )
-        ) / 2.0
+        return (180.0 - blanket_library.deg_blkt_inboard_poloidal_plasma) / 2.0
 
     def divtart(
         self,

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -6,6 +6,7 @@ from process.core import constants
 from process.core import process_output as po
 from process.core.exceptions import ProcessValueError
 from process.core.model import Model
+from process.data_structure import blanket_library
 from process.data_structure.physics_variables import DivertorNumberModels
 
 
@@ -34,6 +35,8 @@ class Divertor(Model):
         output :
             indicate whether output should be written to the output file, or not
         """
+        dv.deg_div_poloidal_plasma = self.single_divertor_angle
+
         self.data.fwbs.p_div_nuclear_heat_total_mw = self.incident_neutron_power(
             p_plasma_neutron_mw=self.data.physics.p_plasma_neutron_mw,
             f_ster_div_single=self.data.fwbs.f_ster_div_single,
@@ -83,6 +86,21 @@ class Divertor(Model):
                 output=output,
             )
             return
+
+    @property
+    def single_divertor_angle(self):
+        """
+        Calculate the angle subtended by a single divertor.
+        Angle is calculated as 360 degrees minus the sum of the inboard
+        and outboard blanket poloidal angles, divided by 2 (for two divertors).
+        """
+        return (
+            360.0
+            - (
+                blanket_library.deg_blkt_inboard_poloidal_plasma
+                + blanket_library.deg_blkt_outboard_poloidal_plasma
+            )
+        ) / 2.0
 
     def divtart(
         self,

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -6,7 +6,6 @@ from process.core import constants
 from process.core import process_output as po
 from process.core.exceptions import ProcessValueError
 from process.core.model import Model
-from process.data_structure import blanket_library
 from process.data_structure.physics_variables import DivertorNumberModels
 
 
@@ -36,7 +35,7 @@ class Divertor(Model):
             indicate whether output should be written to the output file, or not
         """
         dv.deg_div_poloidal_plasma = self.single_divertor_angle
-        fwbs.f_ster_div_single = dv.deg_div_poloidal_plasma / 360.0
+        self.data.fwbs.f_ster_div_single = dv.deg_div_poloidal_plasma / 360.0
 
         self.data.fwbs.p_div_nuclear_heat_total_mw = self.incident_neutron_power(
             p_plasma_neutron_mw=self.data.physics.p_plasma_neutron_mw,
@@ -95,7 +94,7 @@ class Divertor(Model):
         Angle is calculated as 180 degrees minus the inboard
         blanket poloidal angle, divided by 2 (for two divertors).
         """
-        return (180.0 - blanket_library.deg_blkt_inboard_poloidal_plasma) / 2.0
+        return (180.0 - self.data.blanket.deg_blkt_inboard_poloidal_plasma) / 2.0
 
     def divtart(
         self,

--- a/process/models/divertor.py
+++ b/process/models/divertor.py
@@ -36,6 +36,7 @@ class Divertor(Model):
             indicate whether output should be written to the output file, or not
         """
         dv.deg_div_poloidal_plasma = self.single_divertor_angle
+        fwbs.f_ster_div_single = dv.deg_div_poloidal_plasma / 360.0
 
         self.data.fwbs.p_div_nuclear_heat_total_mw = self.incident_neutron_power(
             p_plasma_neutron_mw=self.data.physics.p_plasma_neutron_mw,

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2102,6 +2102,13 @@ class Physics(Model):
                 physics_variables.ptarmw,
                 "OP ",
             )
+            po.ovarrf(
+                self.outfile,
+                "Divertor poloidal angle subtended by plasma (degrees)",
+                "(deg_div_poloidal_plasma)",
+                divertor_variables.deg_div_poloidal_plasma,
+                "OP ",
+            )
             po.ovarre(
                 self.outfile,
                 "Fraction of power to the lower divertor",

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2117,6 +2117,13 @@ class Physics(Model):
                 self.data.physics.ptarmw,
                 "OP ",
             )
+            po.ovarrf(
+                self.outfile,
+                "Divertor poloidal angle subtended by plasma (degrees)",
+                "(deg_div_poloidal_plasma)",
+                divertor_variables.deg_div_poloidal_plasma,
+                "OP ",
+            )
             po.ovarre(
                 self.outfile,
                 "Fraction of power to the lower divertor",

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -2121,7 +2121,7 @@ class Physics(Model):
                 self.outfile,
                 "Divertor poloidal angle subtended by plasma (degrees)",
                 "(deg_div_poloidal_plasma)",
-                divertor_variables.deg_div_poloidal_plasma,
+                self.data.divertor.deg_div_poloidal_plasma,
                 "OP ",
             )
             po.ovarre(

--- a/tests/unit/models/blankets/test_blanket_library.py
+++ b/tests/unit/models/blankets/test_blanket_library.py
@@ -8,6 +8,11 @@ from process.data_structure import (
     divertor_variables,
     physics_variables,
 )
+from process.data_structure import build_variables as bv
+from process.data_structure import fwbs_variables as fwbs
+from process.data_structure import physics_variables as pv
+from process.models.blankets.blanket_library import BlanketLibrary, InboardBlanket
+from process.models.fw import FirstWall
 
 
 @pytest.fixture
@@ -1795,3 +1800,48 @@ def test_liquid_breeder_properties_part_3(monkeypatch, blanket_library_fixture):
 
     blanket_library_fixture.liquid_breeder_properties()
     assert pytest.approx(blanket_library_fixture.data.fwbs.den_liq, rel=1e-3) == 504.0
+
+
+class CalculateBlktInboardPoloidalPlasmaAngleParam(NamedTuple):
+    rminor: Any = None
+    dz_blkt_half: Any = None
+    dr_fw_plasma_gap_inboard: Any = None
+    expected_angle: Any = None
+
+
+@pytest.mark.parametrize(
+    "calculate_blkt_inboard_poloidal_plasma_angle_param",
+    [
+        CalculateBlktInboardPoloidalPlasmaAngleParam(
+            rminor=2.0,
+            dz_blkt_half=0.0,
+            dr_fw_plasma_gap_inboard=0.25,
+            expected_angle=0.0,
+        ),
+        CalculateBlktInboardPoloidalPlasmaAngleParam(
+            rminor=2.0,
+            dz_blkt_half=2.25,  # dz = rminor + gap -> 2 * atan(1) = 90 deg
+            dr_fw_plasma_gap_inboard=0.25,
+            expected_angle=90.0,
+        ),
+        CalculateBlktInboardPoloidalPlasmaAngleParam(
+            rminor=2.0,
+            dz_blkt_half=np.sqrt(3.0) * 2.25,  # dz = sqrt(3) * (rminor + gap) -> 120 deg
+            dr_fw_plasma_gap_inboard=0.25,
+            expected_angle=120.0,
+        ),
+    ],
+)
+def test_calculate_blkt_inboard_poloidal_plasma_angle(
+    calculate_blkt_inboard_poloidal_plasma_angle_param,
+):
+    """Test for calculate_blkt_inboard_poloidal_plasma_angle."""
+    result = InboardBlanket.calculate_blkt_inboard_poloidal_plasma_angle(
+        rminor=calculate_blkt_inboard_poloidal_plasma_angle_param.rminor,
+        dz_blkt_half=calculate_blkt_inboard_poloidal_plasma_angle_param.dz_blkt_half,
+        dr_fw_plasma_gap_inboard=calculate_blkt_inboard_poloidal_plasma_angle_param.dr_fw_plasma_gap_inboard,
+    )
+
+    assert result == pytest.approx(
+        calculate_blkt_inboard_poloidal_plasma_angle_param.expected_angle
+    )

--- a/tests/unit/models/blankets/test_blanket_library.py
+++ b/tests/unit/models/blankets/test_blanket_library.py
@@ -8,11 +8,7 @@ from process.data_structure import (
     divertor_variables,
     physics_variables,
 )
-from process.data_structure import build_variables as bv
-from process.data_structure import fwbs_variables as fwbs
-from process.data_structure import physics_variables as pv
-from process.models.blankets.blanket_library import BlanketLibrary, InboardBlanket
-from process.models.fw import FirstWall
+from process.models.blankets.blanket_library import InboardBlanket
 
 
 @pytest.fixture

--- a/tests/unit/models/blankets/test_blanket_library.py
+++ b/tests/unit/models/blankets/test_blanket_library.py
@@ -2,6 +2,7 @@ from typing import Any, NamedTuple
 
 import numpy as np
 import pytest
+
 from process.models.blankets.blanket_library import InboardBlanket
 
 

--- a/tests/unit/models/blankets/test_blanket_library.py
+++ b/tests/unit/models/blankets/test_blanket_library.py
@@ -2,6 +2,11 @@ from typing import Any, NamedTuple
 
 import numpy as np
 import pytest
+from process.data_structure import build_variables as bv
+from process.data_structure import fwbs_variables as fwbs
+from process.data_structure import physics_variables as pv
+from process.models.blankets.blanket_library import BlanketLibrary, InboardBlanket
+from process.models.fw import FirstWall
 
 
 @pytest.fixture
@@ -1758,3 +1763,48 @@ def test_liquid_breeder_properties_part_3(monkeypatch, blanket_library):
 
     blanket_library.liquid_breeder_properties()
     assert pytest.approx(blanket_library.data.fwbs.den_liq, rel=1e-3) == 504.0
+
+
+class CalculateBlktInboardPoloidalPlasmaAngleParam(NamedTuple):
+    rminor: Any = None
+    dz_blkt_half: Any = None
+    dr_fw_plasma_gap_inboard: Any = None
+    expected_angle: Any = None
+
+
+@pytest.mark.parametrize(
+    "calculate_blkt_inboard_poloidal_plasma_angle_param",
+    [
+        CalculateBlktInboardPoloidalPlasmaAngleParam(
+            rminor=2.0,
+            dz_blkt_half=0.0,
+            dr_fw_plasma_gap_inboard=0.25,
+            expected_angle=0.0,
+        ),
+        CalculateBlktInboardPoloidalPlasmaAngleParam(
+            rminor=2.0,
+            dz_blkt_half=2.25,  # dz = rminor + gap -> 2 * atan(1) = 90 deg
+            dr_fw_plasma_gap_inboard=0.25,
+            expected_angle=90.0,
+        ),
+        CalculateBlktInboardPoloidalPlasmaAngleParam(
+            rminor=2.0,
+            dz_blkt_half=np.sqrt(3.0) * 2.25,  # dz = sqrt(3) * (rminor + gap) -> 120 deg
+            dr_fw_plasma_gap_inboard=0.25,
+            expected_angle=120.0,
+        ),
+    ],
+)
+def test_calculate_blkt_inboard_poloidal_plasma_angle(
+    calculate_blkt_inboard_poloidal_plasma_angle_param,
+):
+    """Test for calculate_blkt_inboard_poloidal_plasma_angle."""
+    result = InboardBlanket.calculate_blkt_inboard_poloidal_plasma_angle(
+        rminor=calculate_blkt_inboard_poloidal_plasma_angle_param.rminor,
+        dz_blkt_half=calculate_blkt_inboard_poloidal_plasma_angle_param.dz_blkt_half,
+        dr_fw_plasma_gap_inboard=calculate_blkt_inboard_poloidal_plasma_angle_param.dr_fw_plasma_gap_inboard,
+    )
+
+    assert result == pytest.approx(
+        calculate_blkt_inboard_poloidal_plasma_angle_param.expected_angle
+    )

--- a/tests/unit/models/blankets/test_blanket_library.py
+++ b/tests/unit/models/blankets/test_blanket_library.py
@@ -2,11 +2,7 @@ from typing import Any, NamedTuple
 
 import numpy as np
 import pytest
-from process.data_structure import build_variables as bv
-from process.data_structure import fwbs_variables as fwbs
-from process.data_structure import physics_variables as pv
-from process.models.blankets.blanket_library import BlanketLibrary, InboardBlanket
-from process.models.fw import FirstWall
+from process.models.blankets.blanket_library import InboardBlanket
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request introduces new calculations and visualizations for the poloidal angles subtended by the outboard and inboard blankets, as well as the divertor, in the plasma cross-section plots. It adds new variables to store these angles and their fractions, integrates their calculation into the blanket and divertor models, and updates plotting and output routines to display these geometric relationships.

The main change is that `f_ster_div_single` is no longer an input and is calculated from the geometry. This is a necessary step in having seperate blankets and divertors as the specific flux to each component can now be calculated so they can have their own cooling requirements.

**New blanket and divertor angle calculations and variables:**

* Added variables to `blanket_library.py` and `divertor_variables.py` to store outboard/inboard blanket poloidal angles, their fractions, and divertor poloidal angle. 
* Implemented calculation methods for outboard/inboard blanket poloidal angles and their fractions in `BlanketLibrary`, and for the divertor angle in the divertor model, referencing the blanket geometry. 

**Integration into model execution:**

* Updated `hcpb.py` and `divertor.py` to set the new angle variables during model runs, ensuring these values are available for output and further calculations. 

**Enhanced output and visualization:**

* Modified output routines to write the new angle variables and their fractions to output files for both blanket and divertor. 
* Significantly improved the `plot_blkt_structure` function to display the blanket and divertor angles visually, including annotated arcs, arrows, and info boxes for each angle on the cross-section plot. 

**Data initialization and test updates:**

* Updated initialization routines to handle new variables and set default values. 
* Minor test import update to reflect new class usage.

## ✍🏻 Plotting outputs
Large tokamak

<img width="447" height="770" alt="image" src="https://github.com/user-attachments/assets/6546f588-7ae2-4a87-bd26-33e3a2ab9802" />

ST

<img width="297" height="667" alt="image" src="https://github.com/user-attachments/assets/dc98be11-866a-4b2e-b78d-c0a0832a9c08" />




These changes improve the geometric fidelity of the model and enhance the clarity of output visualizations, making it easier to interpret the physical relationships between the plasma, blankets, and divertor.

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
