### PR TITLE
make docs logo smaller

### DIFF
--- a/documentation/source/index.md
+++ b/documentation/source/index.md
@@ -5,6 +5,7 @@
     src="images/ukaea-logo.png"
     alt="ukaea-logo.png"
     class="logo"
+    width="200"
     >
 
 PROCESS is a systems code at [UKAEA](https://ccfe.ukaea.uk/) that calculates in a


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
Makes the logo on the first page of the docs smaller.

Before:
<img width="1293" height="910" alt="image" src="https://github.com/user-attachments/assets/d2abec2a-706f-4375-a018-dedd04f963e0" />



After:
<img width="1293" height="910" alt="image" src="https://github.com/user-attachments/assets/90e402a0-b32d-4c69-bbbf-5210a66de7dc" />

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
