### PR TITLE
Remove circular FW and blanket, and create ivc_tools.py for common fns

### DIFF
--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -23,6 +23,13 @@ from process.models.engineering.pumping import (
     calculate_reynolds_number,
     darcy_friction_haaland,
 )
+from process.models.ivc_tools import (
+    calculate_pipe_bend_radius,
+    dshellarea,
+    dshellvol,
+    eshellarea,
+    eshellvol,
+)
 from process.models.power import PumpingPowerModelTypes
 
 logger = logging.getLogger(__name__)
@@ -1350,7 +1357,7 @@ class BlanketLibrary(Model):
         (
             self.data.fwbs.radius_blkt_channel_90_bend,
             self.data.fwbs.radius_blkt_channel_180_bend,
-        ) = self.calculate_pipe_bend_radius(
+        ) = calculate_pipe_bend_radius(
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,
@@ -1390,7 +1397,7 @@ class BlanketLibrary(Model):
         (
             self.data.fwbs.radius_blkt_channel_90_bend,
             self.data.fwbs.radius_blkt_channel_180_bend,
-        ) = self.calculate_pipe_bend_radius(
+        ) = calculate_pipe_bend_radius(
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,
@@ -2795,12 +2802,10 @@ class BlanketLibrary(Model):
         float
             Total pressure drop (Pa).
         """
-        radius_pipe_90_deg_bend, radius_pipe_180_deg_bend = (
-            self.calculate_pipe_bend_radius(
-                i_ps=icoolpump,
-                radius_fw_channel=self.data.fwbs.radius_fw_channel,
-                b_bz_liq=self.data.fwbs.b_bz_liq,
-            )
+        radius_pipe_90_deg_bend, radius_pipe_180_deg_bend = calculate_pipe_bend_radius(
+            i_ps=icoolpump,
+            radius_fw_channel=self.data.fwbs.radius_fw_channel,
+            b_bz_liq=self.data.fwbs.b_bz_liq,
         )
 
         # Friction - for all coolants
@@ -3004,27 +3009,6 @@ class BlanketLibrary(Model):
             )
 
         return liquid_breeder_pressure_drop_mhd
-
-    @staticmethod
-    def calculate_pipe_bend_radius(i_ps: int, radius_fw_channel: float, b_bz_liq: float):
-        """Set the pipe bend radius based on the coolant type.
-
-        Parameters
-        ----------
-        i_ps : int
-            switch for primary or secondary coolant
-        radius_fw_channel: float
-            radius of first wall cooling channels [m]
-        b_bz_liq: float
-            radial width of the rectangular cooling channel [m]
-            for long poloidal sections of blanket breeding zone
-
-        """
-        # If primary coolant or secondary coolant (See DCLL)
-        radius_pipe_90_deg_bend = (3 * radius_fw_channel) if (i_ps == 1) else b_bz_liq
-        radius_pipe_180_deg_bend = radius_pipe_90_deg_bend / 2
-
-        return radius_pipe_90_deg_bend, radius_pipe_180_deg_bend
 
     def coolant_friction_pressure_drop(
         self,
@@ -3467,289 +3451,6 @@ class BlanketLibrary(Model):
         return pumppower
 
 
-def set_pumping_powers_as_fractions(
-    f_p_fw_coolant_pump_total_heat: float,
-    f_p_blkt_coolant_pump_total_heat: float,
-    f_p_shld_coolant_pump_total_heat: float,
-    f_p_div_coolant_pump_total_heat: float,
-    p_fw_nuclear_heat_total_mw: float,
-    psurffwi: float,
-    psurffwo: float,
-    p_blkt_nuclear_heat_total_mw: float,
-    p_shld_nuclear_heat_mw: float,
-    p_cp_shield_nuclear_heat_mw: float,
-    p_plasma_separatrix_mw: float,
-    p_div_nuclear_heat_total_mw: float,
-    p_div_rad_total_mw: float,
-) -> tuple[float, float, float, float]:
-    """Calculate mechanical pumping powers as fractions of thermal power in each component.
-
-    Parameters
-    ----------
-    f_p_fw_coolant_pump_total_heat : float
-        Fraction for FW coolant pump.
-    f_p_blkt_coolant_pump_total_heat : float
-        Fraction for blanket coolant pump.
-    f_p_shld_coolant_pump_total_heat : float
-        Fraction for shield coolant pump.
-    f_p_div_coolant_pump_total_heat : float
-        Fraction for divertor coolant pump.
-    p_fw_nuclear_heat_total_mw : float
-        Total FW nuclear heating (MW).
-    psurffwi : float
-        Inboard FW surface heating (MW).
-    psurffwo : float
-        Outboard FW surface heating (MW).
-    p_blkt_nuclear_heat_total_mw : float
-        Total blanket nuclear heating (MW).
-    p_shld_nuclear_heat_mw : float
-        Shield nuclear heating (MW).
-    p_cp_shield_nuclear_heat_mw : float
-        CP shield nuclear heating (MW).
-    p_plasma_separatrix_mw : float
-        Plasma separatrix power (MW).
-    p_div_nuclear_heat_total_mw : float
-        Divertor nuclear heating (MW).
-    p_div_rad_total_mw : float
-        Divertor radiative power (MW).
-
-    Returns
-    -------
-    tuple[float, float, float, float]
-        Tuple of pumping powers (MW) for FW, blanket, shield, and divertor.
-    """
-    p_fw_coolant_pump_mw = f_p_fw_coolant_pump_total_heat * (
-        p_fw_nuclear_heat_total_mw + psurffwi + psurffwo
-    )
-    p_blkt_coolant_pump_mw = (
-        f_p_blkt_coolant_pump_total_heat * p_blkt_nuclear_heat_total_mw
-    )
-    p_shld_coolant_pump_mw = f_p_shld_coolant_pump_total_heat * (
-        p_shld_nuclear_heat_mw + p_cp_shield_nuclear_heat_mw
-    )
-    p_div_coolant_pump_mw = f_p_div_coolant_pump_total_heat * (
-        p_plasma_separatrix_mw + p_div_nuclear_heat_total_mw + p_div_rad_total_mw
-    )
-    return (
-        p_fw_coolant_pump_mw,
-        p_blkt_coolant_pump_mw,
-        p_shld_coolant_pump_mw,
-        p_div_coolant_pump_mw,
-    )
-
-
-def eshellarea(rshell, rmini, rmino, zminor):
-    """Routine to calculate the inboard, outboard and total surface areas
-    of a toroidal shell comprising two elliptical sections
-
-    rshell : input real : major radius of centre of both ellipses (m)
-    rmini  : input real : horizontal distance from rshell to
-    inboard elliptical shell (m)
-    rmino  : input real : horizontal distance from rshell to
-    outboard elliptical shell (m)
-    zminor : input real : vertical internal half-height of shell (m)
-    ain    : output real : surface area of inboard section (m3)
-    aout   : output real : surface area of outboard section (m3)
-    atot   : output real : total surface area of shell (m3)
-    This routine calculates the surface area of the inboard and outboard
-    sections of a toroidal shell defined by two co-centred semi-ellipses.
-
-    Parameters
-    ----------
-    rshell :
-
-    rmini :
-
-    rmino :
-
-    zminor :
-
-    """
-    # Inboard section
-    elong = zminor / rmini
-    ain = 2.0 * np.pi * elong * (np.pi * rshell * rmini - 2.0 * rmini * rmini)
-
-    # Outboard section
-    elong = zminor / rmino
-    aout = 2.0 * np.pi * elong * (np.pi * rshell * rmino + 2.0 * rmino * rmino)
-
-    return ain, aout, ain + aout
-
-
-def dshellarea(
-    rmajor: float, rminor: float, zminor: float
-) -> tuple[float, float, float]:
-    """Calculate the inboard, outboard, and total surface areas of a D-shaped toroidal shell.
-
-    The inboard section is assumed to be a cylinder.
-    The outboard section is defined by a semi-ellipse, centred on the major radius of the inboard section.
-
-    Parameters
-    ----------
-    rmajor : float
-        Major radius of inboard straight section (m)
-    rminor : float
-        Horizontal width of shell (m)
-    zminor : float
-        Vertical half-height of shell (m)
-
-    Returns
-    -------
-    tuple[float, float, float]
-        Tuple containing:
-        - ain: Surface area of inboard straight section (m²)
-        - aout: Surface area of outboard curved section (m²)
-        - atot: Total surface area of shell (m²)
-    """
-    # Area of inboard cylindrical shell
-    ain = 4.0 * zminor * np.pi * rmajor
-
-    # Area of elliptical outboard section
-    elong = zminor / rminor
-    aout = 2.0 * np.pi * elong * (np.pi * rmajor * rminor + 2.0 * rminor * rminor)
-
-    return ain, aout, ain + aout
-
-
-def eshellvol(rshell, rmini, rmino, zminor, drin, drout, dz):
-    """Routine to calculate the inboard, outboard and total volumes
-    of a toroidal shell comprising two elliptical sections
-
-    This routine calculates the volume of the inboard and outboard sections
-    of a toroidal shell defined by two co-centred semi-ellipses.
-    Each section's internal and external surfaces are in turn defined
-    by two semi-ellipses. The volumes of each section are calculated as
-    the difference in those of the volumes of revolution enclosed by their
-    inner and outer surfaces.
-
-    Parameters
-    ----------
-    rshell :
-        major radius of centre of both ellipses (m)
-    rmini :
-        horizontal distance from rshell to outer edge of inboard elliptical shell (m)
-    rmino :
-        horizontal distance from rshell to inner edge of outboard elliptical shell (m)
-    zminor :
-        vertical internal half-height of shell (m)
-    drin :
-        horiz. thickness of inboard shell at midplane (m)
-    drout :
-        horiz. thickness of outboard shell at midplane (m)
-    dz :
-        vertical thickness of shell at top/bottom (m)
-
-    Returns
-    -------
-    vin :
-        volume of inboard section (m3)
-    vout:
-        volume of outboard section (m3)
-    vtot:
-        total volume of shell (m3)
-    -------
-    """
-    # Inboard section
-
-    # Volume enclosed by outer (higher R) surface of elliptical section
-    # and the vertical straight line joining its ends
-    a = rmini
-    b = zminor
-    elong = b / a
-    v1 = 2.0 * np.pi * elong * (0.5 * np.pi * rshell * a**2 - (2.0 / 3.0) * a**3)
-
-    # Volume enclosed by inner (lower R) surface of elliptical section
-    # and the vertical straight line joining its ends
-    a = rmini + drin
-    b = zminor + dz
-    elong = b / a
-    v2 = 2.0 * np.pi * elong * (0.5 * np.pi * rshell * a**2 - (2.0 / 3.0) * a**3)
-
-    # Volume of inboard section of shell
-    vin = v2 - v1
-
-    # Outboard section
-
-    # Volume enclosed by inner (lower R) surface of elliptical section
-    # and the vertical straight line joining its ends
-    a = rmino
-    b = zminor
-    elong = b / a
-    v1 = 2.0 * np.pi * elong * (0.5 * np.pi * rshell * a**2 + (2.0 / 3.0) * a**3)
-
-    # Volume enclosed by outer (higher R) surface of elliptical section
-    # and the vertical straight line joining its ends
-    a = rmino + drout
-    b = zminor + dz
-    elong = b / a
-    v2 = 2.0 * np.pi * elong * (0.5 * np.pi * rshell * a**2 + (2.0 / 3.0) * a**3)
-
-    # Volume of outboard section of shell
-    vout = v2 - v1
-
-    return vin, vout, vin + vout
-
-
-def dshellvol(rmajor, rminor, zminor, drin, drout, dz):
-    """Routine to calculate the inboard, outboard and total volumes
-    of a D-shaped toroidal shell
-
-    This routine calculates the volume of the inboard and outboard sections
-    of a D-shaped toroidal shell defined by the above input parameters.
-    The inboard section is assumed to be a cylinder of uniform thickness.
-    The outboard section's internal and external surfaces are defined
-    by two semi-ellipses, centred on the outer edge of the inboard section;
-    its volume is calculated as the difference in those of the volumes of
-    revolution enclosed by the two surfaces.
-
-    Parameters
-    ----------
-    rmajor :
-        major radius to outer point of inboardstraight section of shell (m)
-    rminor :
-        horizontal internal width of shell (m)
-    zminor :
-        vertical internal half-height of shell (m)
-    drin :
-        horiz. thickness of inboard shell at midplane (m)
-    drout :
-        horiz. thickness of outboard shell at midplane (m)
-    dz :
-        vertical thickness of shell at top/bottom (m)
-
-    Returns
-    -------
-    vin :
-        volume of inboard straight section (m3)
-    vout:
-        volume of outboard curved section (m3)
-    vtot:
-        total volume of shell (m3)
-
-    """
-    # Volume of inboard cylindrical shell
-    vin = 2.0 * (zminor + dz) * np.pi * (rmajor**2 - (rmajor - drin) ** 2)
-
-    # Volume enclosed by inner surface of elliptical outboard section
-    # and the vertical straight line joining its ends
-    a = rminor
-    b = zminor
-    elong = b / a
-    v1 = 2.0 * np.pi * elong * (0.5 * np.pi * rmajor * a**2 + (2.0 / 3.0) * a**3)
-
-    # Volume enclosed by outer surface of elliptical outboard section
-    # and the vertical straight line joining its ends
-    a = rminor + drout
-    b = zminor + dz
-    elong = b / a
-    v2 = 2.0 * np.pi * elong * (0.5 * np.pi * rmajor * a**2 + (2.0 / 3.0) * a**3)
-
-    # Volume of elliptical outboard shell
-    vout = v2 - v1
-
-    return vin, vout, vin + vout
-
-
 class OutboardBlanket(BlanketLibrary):
     def calculate_basic_geometry(self):
         self.component_volumes()
@@ -3759,7 +3460,7 @@ class OutboardBlanket(BlanketLibrary):
         (
             self.data.fwbs.radius_blkt_channel_90_bend,
             self.data.fwbs.radius_blkt_channel_180_bend,
-        ) = self.calculate_pipe_bend_radius(
+        ) = calculate_pipe_bend_radius(
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,
@@ -3804,7 +3505,7 @@ class InboardBlanket(BlanketLibrary):
         (
             self.data.fwbs.radius_blkt_channel_90_bend,
             self.data.fwbs.radius_blkt_channel_180_bend,
-        ) = self.calculate_pipe_bend_radius(
+        ) = calculate_pipe_bend_radius(
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -19,16 +19,16 @@ from process.data_structure import (
     primary_pumping_variables,
 )
 from process.models.build import FwBlktVVShape
-from process.models.engineering.pumping import (
-    calculate_reynolds_number,
-    darcy_friction_haaland,
-)
-from process.models.ivc_tools import (
+from process.models.engineering.ivc_functions import (
     calculate_pipe_bend_radius,
     dshellarea,
     dshellvol,
     eshellarea,
     eshellvol,
+)
+from process.models.engineering.pumping import (
+    calculate_reynolds_number,
+    darcy_friction_haaland,
 )
 from process.models.power import PumpingPowerModelTypes
 

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -2,6 +2,7 @@ from process.core import constants
 from process.core import (
     process_output as po,
 )
+from process.data_structure import blanket_library as blanket_variables
 from process.data_structure import (
     build_variables,
     current_drive_variables,
@@ -11,8 +12,11 @@ from process.data_structure import (
     physics_variables,
     primary_pumping_variables,
 )
-from process.models.blankets import blanket_library
 from process.models.blankets.blanket_library import InboardBlanket, OutboardBlanket
+from process.models.ivc_tools import (
+    calculate_pipe_bend_radius,
+    set_pumping_powers_as_fractions,
+)
 from process.models.power import PumpingPowerModelTypes
 
 
@@ -98,7 +102,7 @@ class DCLL(InboardBlanket, OutboardBlanket):
         (
             self.data.fwbs.radius_blkt_channel_90_bend,
             self.data.fwbs.radius_blkt_channel_180_bend,
-        ) = self.calculate_pipe_bend_radius(
+        ) = calculate_pipe_bend_radius(
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,
@@ -106,13 +110,13 @@ class DCLL(InboardBlanket, OutboardBlanket):
 
         self.set_blanket_module_geometry()
 
-        blanket_library.len_blkt_inboard_segment_toroidal = self.calculate_blanket_inboard_module_geometry(
+        blanket_variables.len_blkt_inboard_segment_toroidal = self.calculate_blanket_inboard_module_geometry(
             n_blkt_inboard_modules_toroidal=self.data.fwbs.n_blkt_inboard_modules_toroidal,
             rmajor=physics_variables.rmajor,
             rminor=physics_variables.rminor,
             dr_fw_plasma_gap_inboard=build_variables.dr_fw_plasma_gap_inboard,
         )
-        blanket_library.len_blkt_outboard_segment_toroidal = self.calculate_blanket_outboard_module_geometry(
+        blanket_variables.len_blkt_outboard_segment_toroidal = self.calculate_blanket_outboard_module_geometry(
             n_blkt_outboard_modules_toroidal=self.data.fwbs.n_blkt_outboard_modules_toroidal,
             rmajor=physics_variables.rmajor,
             rminor=physics_variables.rminor,
@@ -314,7 +318,7 @@ class DCLL(InboardBlanket, OutboardBlanket):
                 heat_transport_variables.p_blkt_coolant_pump_mw,
                 heat_transport_variables.p_shld_coolant_pump_mw,
                 heat_transport_variables.p_div_coolant_pump_mw,
-            ) = blanket_library.set_pumping_powers_as_fractions(
+            ) = set_pumping_powers_as_fractions(
                 f_p_fw_coolant_pump_total_heat=heat_transport_variables.f_p_fw_coolant_pump_total_heat,
                 f_p_blkt_coolant_pump_total_heat=heat_transport_variables.f_p_blkt_coolant_pump_total_heat,
                 f_p_shld_coolant_pump_total_heat=heat_transport_variables.f_p_shld_coolant_pump_total_heat,

--- a/process/models/blankets/dcll.py
+++ b/process/models/blankets/dcll.py
@@ -13,9 +13,9 @@ from process.data_structure import (
     primary_pumping_variables,
 )
 from process.models.blankets.blanket_library import InboardBlanket, OutboardBlanket
-from process.models.ivc_tools import (
+from process.models.engineering.ivc_functions import (
     calculate_pipe_bend_radius,
-    set_pumping_powers_as_fractions,
+    pumping_powers_as_fractions,
 )
 from process.models.power import PumpingPowerModelTypes
 
@@ -318,7 +318,7 @@ class DCLL(InboardBlanket, OutboardBlanket):
                 heat_transport_variables.p_blkt_coolant_pump_mw,
                 heat_transport_variables.p_shld_coolant_pump_mw,
                 heat_transport_variables.p_div_coolant_pump_mw,
-            ) = set_pumping_powers_as_fractions(
+            ) = pumping_powers_as_fractions(
                 f_p_fw_coolant_pump_total_heat=heat_transport_variables.f_p_fw_coolant_pump_total_heat,
                 f_p_blkt_coolant_pump_total_heat=heat_transport_variables.f_p_blkt_coolant_pump_total_heat,
                 f_p_shld_coolant_pump_total_heat=heat_transport_variables.f_p_shld_coolant_pump_total_heat,

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -20,9 +20,9 @@ from process.data_structure import (
     tfcoil_variables,
 )
 from process.models.blankets.blanket_library import InboardBlanket, OutboardBlanket
-from process.models.ivc_tools import (
+from process.models.engineering.ivc_functions import (
     calculate_pipe_bend_radius,
-    set_pumping_powers_as_fractions,
+    pumping_powers_as_fractions,
 )
 from process.models.power import PumpingPowerModelTypes
 from process.models.tfcoil.base import TFConductorModel
@@ -791,7 +791,7 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
                 heat_transport_variables.p_blkt_coolant_pump_mw,
                 heat_transport_variables.p_shld_coolant_pump_mw,
                 heat_transport_variables.p_div_coolant_pump_mw,
-            ) = set_pumping_powers_as_fractions(
+            ) = pumping_powers_as_fractions(
                 f_p_fw_coolant_pump_total_heat=heat_transport_variables.f_p_fw_coolant_pump_total_heat,
                 f_p_blkt_coolant_pump_total_heat=heat_transport_variables.f_p_blkt_coolant_pump_total_heat,
                 f_p_shld_coolant_pump_total_heat=heat_transport_variables.f_p_shld_coolant_pump_total_heat,

--- a/process/models/blankets/hcpb.py
+++ b/process/models/blankets/hcpb.py
@@ -19,8 +19,11 @@ from process.data_structure import (
     primary_pumping_variables,
     tfcoil_variables,
 )
-from process.models.blankets import blanket_library
 from process.models.blankets.blanket_library import InboardBlanket, OutboardBlanket
+from process.models.ivc_tools import (
+    calculate_pipe_bend_radius,
+    set_pumping_powers_as_fractions,
+)
 from process.models.power import PumpingPowerModelTypes
 from process.models.tfcoil.base import TFConductorModel
 
@@ -55,7 +58,7 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
         (
             self.data.fwbs.radius_blkt_channel_90_bend,
             self.data.fwbs.radius_blkt_channel_180_bend,
-        ) = self.calculate_pipe_bend_radius(
+        ) = calculate_pipe_bend_radius(
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,
@@ -788,7 +791,7 @@ class CCFE_HCPB(OutboardBlanket, InboardBlanket):
                 heat_transport_variables.p_blkt_coolant_pump_mw,
                 heat_transport_variables.p_shld_coolant_pump_mw,
                 heat_transport_variables.p_div_coolant_pump_mw,
-            ) = blanket_library.set_pumping_powers_as_fractions(
+            ) = set_pumping_powers_as_fractions(
                 f_p_fw_coolant_pump_total_heat=heat_transport_variables.f_p_fw_coolant_pump_total_heat,
                 f_p_blkt_coolant_pump_total_heat=heat_transport_variables.f_p_blkt_coolant_pump_total_heat,
                 f_p_shld_coolant_pump_total_heat=heat_transport_variables.f_p_shld_coolant_pump_total_heat,

--- a/process/models/engineering/ivc_functions.py
+++ b/process/models/engineering/ivc_functions.py
@@ -24,7 +24,7 @@ def calculate_pipe_bend_radius(i_ps: int, radius_fw_channel: float, b_bz_liq: fl
     return radius_pipe_90_deg_bend, radius_pipe_180_deg_bend
 
 
-def set_pumping_powers_as_fractions(
+def pumping_powers_as_fractions(
     f_p_fw_coolant_pump_total_heat: float,
     f_p_blkt_coolant_pump_total_heat: float,
     f_p_shld_coolant_pump_total_heat: float,
@@ -99,28 +99,24 @@ def eshellarea(rshell, rmini, rmino, zminor):
     """Routine to calculate the inboard, outboard and total surface areas
     of a toroidal shell comprising two elliptical sections
 
-    rshell : input real : major radius of centre of both ellipses (m)
-    rmini  : input real : horizontal distance from rshell to
-    inboard elliptical shell (m)
-    rmino  : input real : horizontal distance from rshell to
-    outboard elliptical shell (m)
-    zminor : input real : vertical internal half-height of shell (m)
-    ain    : output real : surface area of inboard section (m3)
-    aout   : output real : surface area of outboard section (m3)
-    atot   : output real : total surface area of shell (m3)
-    This routine calculates the surface area of the inboard and outboard
-    sections of a toroidal shell defined by two co-centred semi-ellipses.
-
     Parameters
     ----------
-    rshell :
+    rshell : float
+        major radius of centre of both ellipses [m]
+    rmini : float
+        horizontal distance from rshell to inboard elliptical shell [m]
+    rmino : float
+        horizontal distance from rshell to outboard elliptical shell [m]
+    zminor : float
+        vertical internal half-height of shell [m]
 
-    rmini :
-
-    rmino :
-
-    zminor :
-
+    Returns
+    -------
+    tuple[float, float, float]
+        Tuple containing:
+        - ain: Surface area of inboard straight section (m²)
+        - aout: Surface area of outboard curved section (m²)
+        - atot: Total surface area of shell (m²)
     """
     # Inboard section
     elong = zminor / rmini

--- a/process/models/fw.py
+++ b/process/models/fw.py
@@ -15,11 +15,15 @@ from process.data_structure import (
     physics_variables,
 )
 from process.models.build import FwBlktVVShape
+from process.models.engineering.ivc_functions import (
+    calculate_pipe_bend_radius,
+    dshellarea,
+    eshellarea,
+)
 from process.models.engineering.materials import eurofer97_thermal_conductivity
 from process.models.engineering.pumping import (
     gnielinski_heat_transfer_coefficient,
 )
-from process.models.ivc_tools import calculate_pipe_bend_radius, dshellarea, eshellarea
 
 logger = logging.getLogger(__name__)
 

--- a/process/models/fw.py
+++ b/process/models/fw.py
@@ -14,16 +14,12 @@ from process.data_structure import (
     divertor_variables,
     physics_variables,
 )
-from process.models.blankets.blanket_library import (
-    BlanketLibrary,
-    dshellarea,
-    eshellarea,
-)
 from process.models.build import FwBlktVVShape
 from process.models.engineering.materials import eurofer97_thermal_conductivity
 from process.models.engineering.pumping import (
     gnielinski_heat_transfer_coefficient,
 )
+from process.models.ivc_tools import calculate_pipe_bend_radius, dshellarea, eshellarea
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +27,6 @@ logger = logging.getLogger(__name__)
 class FirstWall(Model):
     def __init__(self):
         self.outfile = constants.NOUT
-        self.blanket_library = BlanketLibrary(fw=self)
 
     def output(self):
         # First wall geometry
@@ -113,7 +108,7 @@ class FirstWall(Model):
         (
             self.data.fwbs.radius_fw_channel_90_bend,
             self.data.fwbs.radius_fw_channel_180_bend,
-        ) = self.blanket_library.calculate_pipe_bend_radius(
+        ) = calculate_pipe_bend_radius(
             i_ps=1,
             radius_fw_channel=self.data.fwbs.radius_fw_channel,
             b_bz_liq=self.data.fwbs.b_bz_liq,

--- a/process/models/ivc_tools.py
+++ b/process/models/ivc_tools.py
@@ -1,0 +1,307 @@
+"""Module containing functions common to multiple in vessel components"""
+
+import numpy as np
+
+
+def calculate_pipe_bend_radius(i_ps: int, radius_fw_channel: float, b_bz_liq: float):
+    """Set the pipe bend radius based on the coolant type.
+
+    Parameters
+    ----------
+    i_ps : int
+        switch for primary or secondary coolant
+    radius_fw_channel: float
+        radius of first wall cooling channels [m]
+    b_bz_liq: float
+        radial width of the rectangular cooling channel [m]
+        for long poloidal sections of blanket breeding zone
+
+    """
+    # If primary coolant or secondary coolant (See DCLL)
+    radius_pipe_90_deg_bend = (3 * radius_fw_channel) if (i_ps == 1) else b_bz_liq
+    radius_pipe_180_deg_bend = radius_pipe_90_deg_bend / 2
+
+    return radius_pipe_90_deg_bend, radius_pipe_180_deg_bend
+
+
+def set_pumping_powers_as_fractions(
+    f_p_fw_coolant_pump_total_heat: float,
+    f_p_blkt_coolant_pump_total_heat: float,
+    f_p_shld_coolant_pump_total_heat: float,
+    f_p_div_coolant_pump_total_heat: float,
+    p_fw_nuclear_heat_total_mw: float,
+    psurffwi: float,
+    psurffwo: float,
+    p_blkt_nuclear_heat_total_mw: float,
+    p_shld_nuclear_heat_mw: float,
+    p_cp_shield_nuclear_heat_mw: float,
+    p_plasma_separatrix_mw: float,
+    p_div_nuclear_heat_total_mw: float,
+    p_div_rad_total_mw: float,
+) -> tuple[float, float, float, float]:
+    """Calculate mechanical pumping powers as fractions of thermal power in each component.
+
+    Parameters
+    ----------
+    f_p_fw_coolant_pump_total_heat : float
+        Fraction for FW coolant pump.
+    f_p_blkt_coolant_pump_total_heat : float
+        Fraction for blanket coolant pump.
+    f_p_shld_coolant_pump_total_heat : float
+        Fraction for shield coolant pump.
+    f_p_div_coolant_pump_total_heat : float
+        Fraction for divertor coolant pump.
+    p_fw_nuclear_heat_total_mw : float
+        Total FW nuclear heating (MW).
+    psurffwi : float
+        Inboard FW surface heating (MW).
+    psurffwo : float
+        Outboard FW surface heating (MW).
+    p_blkt_nuclear_heat_total_mw : float
+        Total blanket nuclear heating (MW).
+    p_shld_nuclear_heat_mw : float
+        Shield nuclear heating (MW).
+    p_cp_shield_nuclear_heat_mw : float
+        CP shield nuclear heating (MW).
+    p_plasma_separatrix_mw : float
+        Plasma separatrix power (MW).
+    p_div_nuclear_heat_total_mw : float
+        Divertor nuclear heating (MW).
+    p_div_rad_total_mw : float
+        Divertor radiative power (MW).
+
+    Returns
+    -------
+    tuple[float, float, float, float]
+        Tuple of pumping powers (MW) for FW, blanket, shield, and divertor.
+    """
+    p_fw_coolant_pump_mw = f_p_fw_coolant_pump_total_heat * (
+        p_fw_nuclear_heat_total_mw + psurffwi + psurffwo
+    )
+    p_blkt_coolant_pump_mw = (
+        f_p_blkt_coolant_pump_total_heat * p_blkt_nuclear_heat_total_mw
+    )
+    p_shld_coolant_pump_mw = f_p_shld_coolant_pump_total_heat * (
+        p_shld_nuclear_heat_mw + p_cp_shield_nuclear_heat_mw
+    )
+    p_div_coolant_pump_mw = f_p_div_coolant_pump_total_heat * (
+        p_plasma_separatrix_mw + p_div_nuclear_heat_total_mw + p_div_rad_total_mw
+    )
+    return (
+        p_fw_coolant_pump_mw,
+        p_blkt_coolant_pump_mw,
+        p_shld_coolant_pump_mw,
+        p_div_coolant_pump_mw,
+    )
+
+
+def eshellarea(rshell, rmini, rmino, zminor):
+    """Routine to calculate the inboard, outboard and total surface areas
+    of a toroidal shell comprising two elliptical sections
+
+    rshell : input real : major radius of centre of both ellipses (m)
+    rmini  : input real : horizontal distance from rshell to
+    inboard elliptical shell (m)
+    rmino  : input real : horizontal distance from rshell to
+    outboard elliptical shell (m)
+    zminor : input real : vertical internal half-height of shell (m)
+    ain    : output real : surface area of inboard section (m3)
+    aout   : output real : surface area of outboard section (m3)
+    atot   : output real : total surface area of shell (m3)
+    This routine calculates the surface area of the inboard and outboard
+    sections of a toroidal shell defined by two co-centred semi-ellipses.
+
+    Parameters
+    ----------
+    rshell :
+
+    rmini :
+
+    rmino :
+
+    zminor :
+
+    """
+    # Inboard section
+    elong = zminor / rmini
+    ain = 2.0 * np.pi * elong * (np.pi * rshell * rmini - 2.0 * rmini * rmini)
+
+    # Outboard section
+    elong = zminor / rmino
+    aout = 2.0 * np.pi * elong * (np.pi * rshell * rmino + 2.0 * rmino * rmino)
+
+    return ain, aout, ain + aout
+
+
+def dshellarea(
+    rmajor: float, rminor: float, zminor: float
+) -> tuple[float, float, float]:
+    """Calculate the inboard, outboard, and total surface areas of a D-shaped toroidal shell.
+
+    The inboard section is assumed to be a cylinder.
+    The outboard section is defined by a semi-ellipse, centred on the major radius of the inboard section.
+
+    Parameters
+    ----------
+    rmajor : float
+        Major radius of inboard straight section (m)
+    rminor : float
+        Horizontal width of shell (m)
+    zminor : float
+        Vertical half-height of shell (m)
+
+    Returns
+    -------
+    tuple[float, float, float]
+        Tuple containing:
+        - ain: Surface area of inboard straight section (m²)
+        - aout: Surface area of outboard curved section (m²)
+        - atot: Total surface area of shell (m²)
+    """
+    # Area of inboard cylindrical shell
+    ain = 4.0 * zminor * np.pi * rmajor
+
+    # Area of elliptical outboard section
+    elong = zminor / rminor
+    aout = 2.0 * np.pi * elong * (np.pi * rmajor * rminor + 2.0 * rminor * rminor)
+
+    return ain, aout, ain + aout
+
+
+def eshellvol(rshell, rmini, rmino, zminor, drin, drout, dz):
+    """Routine to calculate the inboard, outboard and total volumes
+    of a toroidal shell comprising two elliptical sections
+
+    This routine calculates the volume of the inboard and outboard sections
+    of a toroidal shell defined by two co-centred semi-ellipses.
+    Each section's internal and external surfaces are in turn defined
+    by two semi-ellipses. The volumes of each section are calculated as
+    the difference in those of the volumes of revolution enclosed by their
+    inner and outer surfaces.
+
+    Parameters
+    ----------
+    rshell :
+        major radius of centre of both ellipses (m)
+    rmini :
+        horizontal distance from rshell to outer edge of inboard elliptical shell (m)
+    rmino :
+        horizontal distance from rshell to inner edge of outboard elliptical shell (m)
+    zminor :
+        vertical internal half-height of shell (m)
+    drin :
+        horiz. thickness of inboard shell at midplane (m)
+    drout :
+        horiz. thickness of outboard shell at midplane (m)
+    dz :
+        vertical thickness of shell at top/bottom (m)
+
+    Returns
+    -------
+    vin :
+        volume of inboard section (m3)
+    vout:
+        volume of outboard section (m3)
+    vtot:
+        total volume of shell (m3)
+    -------
+    """
+    # Inboard section
+
+    # Volume enclosed by outer (higher R) surface of elliptical section
+    # and the vertical straight line joining its ends
+    a = rmini
+    b = zminor
+    elong = b / a
+    v1 = 2.0 * np.pi * elong * (0.5 * np.pi * rshell * a**2 - (2.0 / 3.0) * a**3)
+
+    # Volume enclosed by inner (lower R) surface of elliptical section
+    # and the vertical straight line joining its ends
+    a = rmini + drin
+    b = zminor + dz
+    elong = b / a
+    v2 = 2.0 * np.pi * elong * (0.5 * np.pi * rshell * a**2 - (2.0 / 3.0) * a**3)
+
+    # Volume of inboard section of shell
+    vin = v2 - v1
+
+    # Outboard section
+
+    # Volume enclosed by inner (lower R) surface of elliptical section
+    # and the vertical straight line joining its ends
+    a = rmino
+    b = zminor
+    elong = b / a
+    v1 = 2.0 * np.pi * elong * (0.5 * np.pi * rshell * a**2 + (2.0 / 3.0) * a**3)
+
+    # Volume enclosed by outer (higher R) surface of elliptical section
+    # and the vertical straight line joining its ends
+    a = rmino + drout
+    b = zminor + dz
+    elong = b / a
+    v2 = 2.0 * np.pi * elong * (0.5 * np.pi * rshell * a**2 + (2.0 / 3.0) * a**3)
+
+    # Volume of outboard section of shell
+    vout = v2 - v1
+
+    return vin, vout, vin + vout
+
+
+def dshellvol(rmajor, rminor, zminor, drin, drout, dz):
+    """Routine to calculate the inboard, outboard and total volumes
+    of a D-shaped toroidal shell
+
+    This routine calculates the volume of the inboard and outboard sections
+    of a D-shaped toroidal shell defined by the above input parameters.
+    The inboard section is assumed to be a cylinder of uniform thickness.
+    The outboard section's internal and external surfaces are defined
+    by two semi-ellipses, centred on the outer edge of the inboard section;
+    its volume is calculated as the difference in those of the volumes of
+    revolution enclosed by the two surfaces.
+
+    Parameters
+    ----------
+    rmajor :
+        major radius to outer point of inboardstraight section of shell (m)
+    rminor :
+        horizontal internal width of shell (m)
+    zminor :
+        vertical internal half-height of shell (m)
+    drin :
+        horiz. thickness of inboard shell at midplane (m)
+    drout :
+        horiz. thickness of outboard shell at midplane (m)
+    dz :
+        vertical thickness of shell at top/bottom (m)
+
+    Returns
+    -------
+    vin :
+        volume of inboard straight section (m3)
+    vout:
+        volume of outboard curved section (m3)
+    vtot:
+        total volume of shell (m3)
+
+    """
+    # Volume of inboard cylindrical shell
+    vin = 2.0 * (zminor + dz) * np.pi * (rmajor**2 - (rmajor - drin) ** 2)
+
+    # Volume enclosed by inner surface of elliptical outboard section
+    # and the vertical straight line joining its ends
+    a = rminor
+    b = zminor
+    elong = b / a
+    v1 = 2.0 * np.pi * elong * (0.5 * np.pi * rmajor * a**2 + (2.0 / 3.0) * a**3)
+
+    # Volume enclosed by outer surface of elliptical outboard section
+    # and the vertical straight line joining its ends
+    a = rminor + drout
+    b = zminor + dz
+    elong = b / a
+    v2 = 2.0 * np.pi * elong * (0.5 * np.pi * rmajor * a**2 + (2.0 / 3.0) * a**3)
+
+    # Volume of elliptical outboard shell
+    vout = v2 - v1
+
+    return vin, vout, vin + vout

--- a/process/models/shield.py
+++ b/process/models/shield.py
@@ -10,7 +10,7 @@ from process.data_structure import (
     physics_variables,
 )
 from process.models.build import FwBlktVVShape
-from process.models.ivc_tools import (
+from process.models.engineering.ivc_functions import (
     dshellarea,
     dshellvol,
     eshellarea,

--- a/process/models/shield.py
+++ b/process/models/shield.py
@@ -9,13 +9,13 @@ from process.data_structure import (
     divertor_variables,
     physics_variables,
 )
-from process.models.blankets.blanket_library import (
+from process.models.build import FwBlktVVShape
+from process.models.ivc_tools import (
     dshellarea,
     dshellvol,
     eshellarea,
     eshellvol,
 )
-from process.models.build import FwBlktVVShape
 
 logger = logging.getLogger(__name__)
 

--- a/process/models/vacuum.py
+++ b/process/models/vacuum.py
@@ -14,8 +14,8 @@ from process.data_structure import (
     tfcoil_variables,
     times_variables,
 )
-from process.models.blankets.blanket_library import dshellvol, eshellvol
 from process.models.build import FwBlktVVShape
+from process.models.ivc_tools import dshellvol, eshellvol
 
 logger = logging.getLogger(__name__)
 

--- a/process/models/vacuum.py
+++ b/process/models/vacuum.py
@@ -15,7 +15,7 @@ from process.data_structure import (
     times_variables,
 )
 from process.models.build import FwBlktVVShape
-from process.models.ivc_tools import dshellvol, eshellvol
+from process.models.engineering.ivc_functions import dshellvol, eshellvol
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

Removes circular imports of blanket and first wall
Moves functions common to IVCs into separate file, instead of being within the blanket_library.py:
`calculate_pipe_bend_radius`, `dshellarea`, `dshellvol`, `eshellarea`, `eshellvol`

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
