### PR TITLE
Update of documentation for #4223

### DIFF
--- a/documentation/source/io/input-guide.md
+++ b/documentation/source/io/input-guide.md
@@ -13,9 +13,8 @@ indication of where in the input file the problem lies.
 
 ## File Naming Convention
 
-The default PROCESS input file name is `IN.DAT`. The user can provide a named 
-input file, that will produce named output files, provided the last 6 characters 
-of the input file name are `IN.DAT`.
+The user can provide a named input file, that will produce named output files, 
+provided the last 6 characters of the input file name are `IN.DAT`.
 
 ```bash
 process -i [path-to-file]/my_file_name_IN.DAT

--- a/documentation/source/usage/running-process.md
+++ b/documentation/source/usage/running-process.md
@@ -14,12 +14,9 @@ A SCAN is available in any of these modes.  One input variable can be scanned (`
 
 ## To run PROCESS
 
-The default PROCESS input file name is IN.DAT. If no input file name is given as an argument in the command line, it assumes an IN.DAT file is present in the current directory:
-```bash
-# Use an IN.DAT file in the current directory
-process
-```
-In this case the output files will be `OUT.DAT` and `MFILE.DAT`.
+PROCESS input file names end in IN.DAT. If no input file name is given as an argument in the command line, PROCESS will run `process --help`. 
+
+The `examples/data` folder in the repository has the commonly used `large_tokamak_IN.DAT` input file, which can be a useful starting point for new users.
 
 The user can provide a named input file, provided the last 6 characters of the input file name are IN.DAT.
 ```bash

--- a/documentation/source/usage/running-process.md
+++ b/documentation/source/usage/running-process.md
@@ -16,8 +16,6 @@ A SCAN is available in any of these modes.  One input variable can be scanned (`
 
 PROCESS input file names end in IN.DAT. If no input file name is given as an argument in the command line, PROCESS will run `process --help`. 
 
-The `examples/data` folder in the repository has the commonly used `large_tokamak_IN.DAT` input file, which can be a useful starting point for new users.
-
 The user can provide a named input file, provided the last 6 characters of the input file name are IN.DAT.
 ```bash
 process -i path/to/my_file_name_IN.DAT
@@ -26,6 +24,8 @@ will produce the following output files in the same directory as the input file:
 ```
     my_file_name_OUT.DAT
     my_file_name_MFILE.DAT
+    my_file_name_SIG_TF.json
+    my_file_name_process.log
 ```
 
 It may be convenient to automatically generate the summary plots after the `PROCESS` run has finished.
@@ -38,12 +38,15 @@ process -i path/to/my_file_name_IN.DAT --full-output
 will produce the following output files in the same directory as the input file:
 
 ```
-    my_file_name_OUT.DAT
-    my_file_name_MFILE.DAT
-    SankeyPowerFlow.pdf
-    my_file_name.MFILE.DATSUMMARY.pdf
-    my_file_name.MFILE_radial_build.pdf
+    large_tokamak_MFILE.DAT
+    large_tokamak_MFILE.DATSUMMARY.pdf
+    large_tokamak_OUT.DAT
+    large_tokamak_SIG_TF.json
+    large_tokamak_plotly_sankey.html
+    large_tokamak_process.log
 ```
+
+The `examples/data` folder in the repository has the commonly used `large_tokamak_IN.DAT` input file, which can be a useful starting point for new users.
 
 ---------------
 
@@ -77,6 +80,12 @@ The full set of command line arguments is available with:
 
 ```bash
 process --help
+```
+
+or
+
+```bash
+process
 ```
 
 ------------

--- a/documentation/source/usage/running-process.md
+++ b/documentation/source/usage/running-process.md
@@ -38,12 +38,12 @@ process -i path/to/my_file_name_IN.DAT --full-output
 will produce the following output files in the same directory as the input file:
 
 ```
-    large_tokamak_MFILE.DAT
-    large_tokamak_MFILE.DATSUMMARY.pdf
-    large_tokamak_OUT.DAT
-    large_tokamak_SIG_TF.json
-    large_tokamak_plotly_sankey.html
-    large_tokamak_process.log
+    my_file_name_MFILE.DAT
+    my_file_name_MFILE.DATSUMMARY.pdf
+    my_file_name_OUT.DAT
+    my_file_name_SIG_TF.json
+    my_file_name_plotly_sankey.html
+    my_file_name_process.log
 ```
 
 The `examples/data` folder in the repository has the commonly used `large_tokamak_IN.DAT` input file, which can be a useful starting point for new users.

--- a/documentation/source/usage/running-process.md
+++ b/documentation/source/usage/running-process.md
@@ -14,9 +14,8 @@ A SCAN is available in any of these modes.  One input variable can be scanned (`
 
 ## To run PROCESS
 
-PROCESS input file names end in IN.DAT. If no input file name is given as an argument in the command line, PROCESS will run `process --help`. 
+PROCESS input file names end in `IN.DAT`. The user can provide a named input file, provided the last 6 characters of the input file name are `IN.DAT`.
 
-The user can provide a named input file, provided the last 6 characters of the input file name are IN.DAT.
 ```bash
 process -i path/to/my_file_name_IN.DAT
 ```
@@ -82,7 +81,7 @@ The full set of command line arguments is available with:
 process --help
 ```
 
-or
+or equivalently with:
 
 ```bash
 process

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,4 @@
+
 # Process Jupyter notebook examples
 
 Examples of how to use Process are provided in the form of Jupyter notebooks. These provide a convenient way of explaining Process usage alongside runnable code cells, as well as displaying some types of output.


### PR DESCRIPTION
## Description

Minor change to documentation pages to reflect:

- there is no longer a "default" process `IN.DAT` and
- if process is run with no input file given it no longer will look for a file called `IN.DAT`, it will run `process --help`.

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
