### PR TITLE
Correct output_prefix when bare IN.DAT used

### DIFF
--- a/process/main.py
+++ b/process/main.py
@@ -363,8 +363,13 @@ class SingleRun:
             Path(filepath_out or self.input_file)
             .name.replace("IN.DAT", "")
             .replace("MFILE.DAT", "")
-        )
+        ).strip()
         self.set_input()
+        data_structure.global_variables.output_prefix = (
+            ""
+            if not self.filename_prefix
+            else Path(self.filepath, self.filename_prefix).as_posix().strip()
+        )
         self.set_output()
         self.set_mfile()
 
@@ -396,14 +401,15 @@ class SingleRun:
 
         Set Path object on the Process object, and set the prefix in the Fortran.
         """
-        self.output_path = Path(self.filepath, self.filename_prefix.strip() + "OUT.DAT")
-        data_structure.global_variables.output_prefix = (
-            Path(self.filepath, self.filename_prefix).as_posix().strip()
+        self.output_path = Path(
+            data_structure.global_variables.output_prefix + "OUT.DAT"
         )
 
     def set_mfile(self):
         """Set the mfile filename."""
-        self.mfile_path = Path(self.filepath, self.filename_prefix.strip() + "MFILE.DAT")
+        self.mfile_path = Path(
+            data_structure.global_variables.output_prefix + "MFILE.DAT"
+        )
 
     def initialise(self):
         """Run the init module to call all initialisation routines."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -85,7 +85,7 @@ def test_set_output(single_run, monkeypatch):
     # Expected output prefix
     expected = "output_prefix"
     # Mock self.filename_prefix on single_run with the value of expected
-    monkeypatch.setattr(single_run, "filename_prefix", expected, raising=False)
+    monkeypatch.setattr(data_structure.global_variables, "output_prefix", expected)
 
     # Mocking undo trys to set the value as none
     # monkeypatch.setattr(data_structure.global_variables, "output_prefix", None)
@@ -117,7 +117,7 @@ def test_set_mfile(single_run, monkeypatch):
     prefix = "test"
     expected = Path(prefix + "MFILE.DAT")
     # Mock filename_prefix and run
-    monkeypatch.setattr(single_run, "filename_prefix", prefix, raising=False)
+    monkeypatch.setattr(data_structure.global_variables, "output_prefix", prefix)
     single_run.set_mfile()
     assert single_run.mfile_path.name == expected.name
 


### PR DESCRIPTION
Ensures that:
1. Two MFILES/OUTDAT's can never be created for one input file
2. The MFILE/OUTDAT are correctly named when a `IN.DAT` input file is used