### PR TITLE
Corrected input variable file assignments

### DIFF
--- a/process/core/input.py
+++ b/process/core/input.py
@@ -239,7 +239,9 @@ INPUT_VARIABLES = {
     "conv": InputVariable("buildings", float, range=(10000.0, 1000000.0)),
     "coolp": InputVariable("fwbs", float, range=(100000.0, 100000000.0)),
     "copper_rrr": InputVariable("rebco", float, range=(1.0, 10000.0)),
-    "dx_tf_hts_tape_copper": InputVariable("rebco", float, range=(0.0, 0.001)),
+    "dx_tf_hts_tape_copper": InputVariable(
+        "superconducting_tfcoil", float, range=(0.0, 0.001)
+    ),
     "copperaoh_m2": InputVariable("rebco", float, range=(1.0, 10000000000.0)),
     "copperaoh_m2_max": InputVariable("rebco", float, range=(10000.0, 10000000000.0)),
     "cost_factor_bop": InputVariable("costs", float, range=(0.1, 10.0)),
@@ -492,7 +494,9 @@ INPUT_VARIABLES = {
     "gas_buildings_w": InputVariable("buildings", float, range=(10.0, 1000.0)),
     "ground_clrnc": InputVariable("buildings", float, range=(0.0, 10.0)),
     "n_ecrh_harmonic": InputVariable("current_drive", float, range=(1.0, 10.0)),
-    "dx_tf_hts_tape_hastelloy": InputVariable("rebco", float, range=(1e-08, 0.001)),
+    "dx_tf_hts_tape_hastelloy": InputVariable(
+        "superconducting_tfcoil", float, range=(1e-08, 0.001)
+    ),
     "hccl": InputVariable("buildings", float, range=(0.0, 10.0)),
     "hcd_building_h": InputVariable("buildings", float, range=(1.0, 100.0)),
     "hcd_building_l": InputVariable("buildings", float, range=(10.0, 1000.0)),
@@ -665,7 +669,7 @@ INPUT_VARIABLES = {
     "reactor_roof_thk": InputVariable("buildings", float, range=(0.25, 25.0)),
     "reactor_wall_thk": InputVariable("buildings", float, range=(0.25, 25.0)),
     "dx_tf_hts_tape_rebco": InputVariable(
-        "rebco",
+        "superconducting_tfcoil",
         float,
         range=(1e-08, 0.0001),
         additional_actions=lambda _n, rt, _i, _c: (
@@ -759,8 +763,10 @@ INPUT_VARIABLES = {
     "dz_cs_turn_conduit": InputVariable("cs_fatigue", float, range=(0.001, 1.0)),
     "dx_tf_turn_general": InputVariable("tfcoil", float, range=(0.0, 0.1)),
     "t_turn_tf_max": InputVariable("tfcoil", float, range=(0.0, 1.0)),
-    "dx_tf_hts_tape_total": InputVariable("rebco", float, range=(0.0, 0.1)),
-    "dr_tf_hts_tape": InputVariable("rebco", float, range=(0.0, 0.1)),
+    "dx_tf_hts_tape_total": InputVariable(
+        "superconducting_tfcoil", float, range=(0.0, 0.1)
+    ),
+    "dr_tf_hts_tape": InputVariable("superconducting_tfcoil", float, range=(0.0, 0.1)),
     "tauee_in": InputVariable("physics", float, range=(0.0, 100.0)),
     "t_plasma_energy_confinement_max": InputVariable(
         "physics", float, range=(0.1, 100.0)

--- a/process/data_structure/rebco_variables.py
+++ b/process/data_structure/rebco_variables.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 @dataclass(slots=True)
 class RebcoData:
-    dx_tf_hts_tape_rebco: float = 1.0e-6
+    dx_hts_tape_rebco: float = 1.0e-6
     """thickness of REBCO layer in tape (m) (`iteration variable 138`)"""
 
     dx_hts_tape_copper: float = 100.0e-6


### PR DESCRIPTION
## Description

Some variables in `input.py` have the wrong variable file assigned to them and so input files using these won't run.

These have been corrected as "rebco" -> "superconducting_tfcoil" where appropriate.

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
