### PR TITLE
Moved error message outside for loop

### DIFF
--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -1541,10 +1541,10 @@ class PFCoil(Model):
                         ):
                             pf_tf_collision += 1
 
-                        if pf_tf_collision >= 1:
-                            logger.error(
-                                "One or more collision between TF and PF coils. Check PF placement."
-                            )
+            if pf_tf_collision >= 1:
+                logger.error(
+                    "One or more collision between TF and PF coils. Check PF placement."
+                )
 
     @staticmethod
     def solv(n_pf_groups_max, n_pf_coil_groups, nrws, gmat, bvec):


### PR DESCRIPTION
## Description

Moves PF coil collision error/warning message outside of `for` loop to prevent unnecessary repetition at the end of a PROCESS run.

## Checklist

I confirm that I have completed the following checks:

- [x] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [x] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [x] I have added new tests where appropriate for the changes I have made.
- [x] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [x] If I have made documentation changes, I have checked they render correctly.
- [x] I have added documentation for my change, if appropriate.
