### PR TITLE
Add page numbering and footer to summary plots

### DIFF
--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -15790,14 +15790,40 @@ def plot_summary(
     output_format: str = "pdf",
     show: bool = False,
 ):
+
+    def add_page_footer(
+        fig: plt.Figure, page_number: int, total_pages: int, run_label: str
+    ):
+        footer_text = f"{run_label}"
+        fig.text(
+            0.01,
+            0.01,
+            footer_text,
+            fontsize=7,
+            ha="left",
+            va="bottom",
+            color="dimgray",
+        )
+        fig.text(
+            0.99,
+            0.01,
+            f"Page {page_number}/{total_pages}",
+            fontsize=7,
+            ha="right",
+            va="bottom",
+            color="dimgray",
+        )
+
     # create main plot
     # Increase range when adding new page
     pages = [plt.figure(figsize=(12, 9), dpi=80) for i in range(37)]
 
     # run main_plot
+    mfile_obj = MFile(mfile) if mfile != "" else MFile("MFILE.DAT")
+    run_label = f"{mfile_obj.get('fileprefix', scan=-1)} | scan {scan or -1} | {mfile_obj.get('date', scan=-1)} {mfile_obj.get('time', scan=-1)} | {mfile_obj.get('tagno', scan=-1)} | Branch: {mfile_obj.get('branch_name', scan=-1)}  "
     main_plot(
         pages,
-        MFile(mfile) if mfile != "" else MFile("MFILE.DAT"),
+        mfile_obj,
         scan=scan or -1,
         demo_ranges=demo_ranges,
         colour_scheme=colour,
@@ -15805,12 +15831,14 @@ def plot_summary(
 
     if output_format == "pdf":
         with bpdf.PdfPages(mfile.with_name(mfile.name + "SUMMARY.pdf")) as pdf:
-            for p in pages:
+            for page_number, p in enumerate(pages, start=1):
+                add_page_footer(p, page_number, len(pages), run_label)
                 pdf.savefig(p)
     elif output_format == "png":
         folder = Path(mfile.with_name(mfile.stem + "_SUMMARY"))
         folder.mkdir(parents=True, exist_ok=True)
         for no, page in enumerate(pages):
+            add_page_footer(page, no + 1, len(pages), run_label)
             page.savefig(Path(folder, f"page{no}.png"), format="png")
 
     # show fig if option used


### PR DESCRIPTION
This pull request enhances the `plot_summary` function in `process/core/io/plot/summary.py` by adding a standardized footer to each generated plot page, improving document clarity and traceability. The footer includes run metadata and page numbering for both PDF and PNG outputs.

**Plot output improvements:**
* Added the `add_page_footer` function to append a footer on each plot page with the run label and page number/total pages, ensuring consistent annotation across all output pages.
* The run label in the footer now displays key metadata from the `MFile` (file prefix, scan number, date, time, tag number, and branch name), making each page self-descriptive.

**Code structure and maintainability:**
* Refactored the code to use a single `MFile` object (`mfile_obj`) for metadata extraction and to construct the run label, reducing redundant object creation.
* Updated both PDF and PNG export loops to call `add_page_footer` before saving, ensuring the footer is present in all output formats.

<img width="1401" height="112" alt="image" src="https://github.com/user-attachments/assets/f9a7a6a3-aa72-4756-ae6d-2863bc8edca5" />


<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
