### PR TITLE
change back to cwd to avoid being stuck in examples temp dir

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -18,6 +18,12 @@ def examples_temp_data(tmp_path_factory):
     :type tmp_path: Path
     :return: temporary path containing examples files
     :rtype: Path
+
+    Yields:
+    -------
+      the temp dir
+
+    Changes back to the cwd afterwards
     """
     data_path = Path(__file__).parent.parent.parent / "examples"
     tmp_path = tmp_path_factory.mktemp("examples")
@@ -27,12 +33,15 @@ def examples_temp_data(tmp_path_factory):
         ignore=ignore_patterns("*.md", "*log", "__pycache__", "*.ipynb*"),
     )
 
+    cwd = Path.cwd()
     # This change of directory is undone by the return_to_root fixture, hence we do not
     # need to change back directories here
     os.chdir(tmp_path / "examples")
 
-    # Return tmp_path/examples, now containing files copied from examples dir
-    return tmp_path / "examples"
+    # yield tmp_path/examples, now containing files copied from examples dir
+    yield tmp_path / "examples"
+
+    os.chdir(cwd)
 
 
 def _get_location(loc, name):


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

When running `pytest` the regression tests were failing:
<img width="1029" height="294" alt="image" src="https://github.com/user-attachments/assets/6179be58-6ca4-4d09-963b-a726270fa8a2" />

This happened because it was stuck in the examples temp dir

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
