### PR TITLE
Always reset pytest working directory to invocation dir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ Defines fixtures that will be shared across all test modules.
 """
 
 import os
-import pathlib
 import traceback
 import warnings
 
@@ -172,14 +171,13 @@ def reinitialise_error_module():
 
 
 @pytest.fixture(autouse=True)
-def return_to_root():
+def return_to_root(request):
     """Various parts of PROCESS change directories and do not always change back.
     This fixture ensures that, at the end of each test, the cwd is reset to what it
     was at the beginning of the test.
     """
-    cwd = pathlib.Path.cwd()
     yield
-    os.chdir(cwd)
+    os.chdir(request.config.invocation_dir)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -9,7 +9,7 @@ import pytest
 from testbook import testbook
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def examples_temp_data(tmp_path_factory):
     """Copy examples dir contents into temp dir for testing.
 


### PR DESCRIPTION
Getting the `cwd` within the `return_to_root` fixture was prone to error when another fixture ran first and changed the working directory. I have set the fixture now to return the working directory to the invocation directory (where the user called pytest from).

This issue manifests as an error 128 from the `git` subprocess when running just `pytest`