### PR TITLE
Correct hstar being stored on data structure

### DIFF
--- a/process/models/physics/confinement_time.py
+++ b/process/models/physics/confinement_time.py
@@ -37,6 +37,8 @@ class ConfinementTimeData:
     """Plasma energy confinement time in seconds."""
     p_plasma_loss_mw: float
     """Total plasma loss power in MW."""
+    hstar: float
+    """Non-radiation corrected H factor on energy confinement times"""
 
 
 class PlasmaConfinementTime(Model):
@@ -936,8 +938,11 @@ class PlasmaConfinementTime(Model):
 
         # Calculate H* non-radiation corrected H factor
         # Note: we will assume the IPB-98y2 scaling.
-        if self.data.physics.i_rad_loss == ConfinementRadiationLossModel.CORE_ONLY:
-            self.data.physics.hstar = (
+        if (
+            ConfinementRadiationLossModel(self.data.physics.i_rad_loss)
+            == ConfinementRadiationLossModel.CORE_ONLY
+        ):
+            hstar = (
                 hfact
                 * (
                     p_plasma_loss_mw
@@ -952,7 +957,7 @@ class PlasmaConfinementTime(Model):
         elif (
             self.data.physics.i_rad_loss == ConfinementRadiationLossModel.FULL_RADIATION
         ):
-            self.data.physics.hstar = (
+            hstar = (
                 hfact
                 * (
                     p_plasma_loss_mw
@@ -964,7 +969,7 @@ class PlasmaConfinementTime(Model):
                 ** 0.31
             )
         elif self.data.physics.i_rad_loss == ConfinementRadiationLossModel.NO_RADIATION:
-            self.data.physics.hstar = hfact
+            hstar = hfact
 
         # Calculation of the transport power loss terms
         # Transport losses in Watts/m3 are 3/2 * n.e.T / tau , with T in eV
@@ -1002,6 +1007,7 @@ class PlasmaConfinementTime(Model):
             t_ion_energy_confinement=t_ion_energy_confinement,
             t_plasma_energy_confinement=t_energy_confinement,
             p_plasma_loss_mw=p_plasma_loss_mw,
+            hstar=hstar,
         )
 
     @staticmethod

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -886,6 +886,7 @@ class Physics(Model):
             confinement_time_data.t_ion_energy_confinement
         )
         self.data.physics.p_plasma_loss_mw = confinement_time_data.p_plasma_loss_mw
+        self.data.physics.hstar = confinement_time_data.hstar
 
         # Total transport power from scaling law (MW)
         self.data.physics.p_electron_transport_loss_mw = (

--- a/process/models/stellarator/stellarator.py
+++ b/process/models/stellarator/stellarator.py
@@ -2295,6 +2295,7 @@ class Stellarator(Model):
             confinement_time_data.t_ion_energy_confinement
         )
         self.data.physics.p_plasma_loss_mw = confinement_time_data.p_plasma_loss_mw
+        self.data.physics.hstar = confinement_time_data.hstar
 
         self.data.physics.ntau, self.data.physics.nTtau = (
             self.physics.confinement.calculate_double_and_triple_product(


### PR DESCRIPTION
I think `hstar` is being incorrectly set on the data structure in `calculate_confinement_time`. `calculate_confinement_time` is also called when creating the H-factor table for the OUT.DAT. I believe that the `hstar` from this is what was being written to the MFILE, not the `hstar` from the selected confinement scaling. 