### PR TITLE
Fix varyrun not respecting bounds and not iterating array variables

### DIFF
--- a/process/core/io/in_dat/base.py
+++ b/process/core/io/in_dat/base.py
@@ -414,10 +414,11 @@ def get_parameters(data, use_string_values=True):
                 if item == "f_nd_impurity_electrons":
                     for k in range(len(data["f_nd_impurity_electrons"].get_value)):
                         name = f"f_nd_impurity_electrons({str(k + 1).zfill(1)})"
-                        # if the variable appears elsewhere in data - it is being
+                        # if the variable appears elsewhere in data, it is being
                         # used as an iteration variable. need to add to
                         # parameters separately otherwise its value in a
-                        # varyrun remains the same
+                        # varyrun remains the same as it is taken from the
+                        # default values
                         if name in data:
                             value = data[name].value
                             parameters[module][name] = value

--- a/process/core/io/in_dat/base.py
+++ b/process/core/io/in_dat/base.py
@@ -414,8 +414,16 @@ def get_parameters(data, use_string_values=True):
                 if item == "f_nd_impurity_electrons":
                     for k in range(len(data["f_nd_impurity_electrons"].get_value)):
                         name = f"f_nd_impurity_electrons({str(k + 1).zfill(1)})"
-                        value = data["f_nd_impurity_electrons"].get_value[k]
-                        parameters[module][name] = value
+                        # if the variable appears elsewhere in data - it is being
+                        # used as an iteration variable. need to add to
+                        # parameters separately otherwise its value in a
+                        # varyrun remains the same
+                        if name in data:
+                            value = data[name].value
+                            parameters[module][name] = value
+                        else:
+                            value = data["f_nd_impurity_electrons"].get_value[k]
+                            parameters[module][name] = value
 
                 elif item == "ioptimz":
                     name = item

--- a/process/core/io/vary_run/config.py
+++ b/process/core/io/vary_run/config.py
@@ -145,9 +145,10 @@ iteration variables should get varied"""
         return self
 
     def __next__(self):
-        _neqns, itervars = get_neqns_itervars(in_dat=self.infile, wdir=self.wdir)
+        _neqns, itervars = get_neqns_itervars(in_dat=self.initial_infile, wdir=self.wdir)
+
         lbs, ubs = get_variable_range(
-            itervars, self.factor, self.infile, self.data, self.wdir
+            itervars, self.factor, self.initial_infile, self.data, self.wdir
         )
         self.run_process(self.wdir / self.infile, self.solver)
         check_input_error(mfile=self.outfile, wdir=self.wdir)

--- a/process/core/io/vary_run/tools.py
+++ b/process/core/io/vary_run/tools.py
@@ -59,8 +59,6 @@ def get_variable_range(itervars, factor, indat, data: DataStructure, wdir="."):
     """Returns the lower and upper bounds of the variable range
     for each iteration variable.
 
-    For f-values the allowed range is equal to their process bounds.
-
     Parameters
     ----------
     itervars :
@@ -320,7 +318,7 @@ def get_from_indat_or_default(in_dat, varname):
     if "(" in varname:
         name, index = re.match(r"([a-zA-Z0-9_]+)\(([0-9]+)\)", varname.strip()).groups()
 
-        if varname in in_dat.data:
+        if name in in_dat.data:
             return in_dat.data[name].get_value[int(index) - 1]
 
         return dicts["DICT_DEFAULT"][name][int(index) - 1]


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
Closes #4058 
Also fixes varyrun to vary iteration variable values within factor * initial value, instead of updating each iteration
Also small fix to get value of f_nd_impurity_electrons(13) from the in_dat.data instead of from its default value 

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
