### PR TITLE
Fix Stellarator regression failures 

### DIFF
--- a/process/core/solver/constraints.py
+++ b/process/core/solver/constraints.py
@@ -592,8 +592,17 @@ def constraint_equation_17(constraint_registration, data):
     f_p_plasma_separatrix_rad_max: maximum allowed plasma radiation fraction at the
     separatrix
     """
+    if data.stellarator.istell != 0:
+        # Remove the contribution of psolradmw from f_p_plasma_separatrix_rad
+        # TODO: this is replicating behaviour before #4299
+        # is this really what should happen?
+        f_rad_sol = data.physics.psolradmw / data.physics.p_plasma_heating_total_mw
+        f_p_plasma_separatrix_rad = data.physics.f_p_plasma_separatrix_rad - f_rad_sol
+    else:
+        f_p_plasma_separatrix_rad = data.physics.f_p_plasma_separatrix_rad
+
     return leq(
-        data.physics.f_p_plasma_separatrix_rad,
+        f_p_plasma_separatrix_rad,
         data.constraints.f_p_plasma_separatrix_rad_max,
         constraint_registration,
     )

--- a/process/models/stellarator/stellarator.py
+++ b/process/models/stellarator/stellarator.py
@@ -2224,6 +2224,34 @@ class Stellarator(Model):
         #  N.B. self.data.stellarator.iotabar replaces tokamak self.data.physics.q95 in argument list
 
         (
+            self.data.physics.eden_plasma_electrons_thermal_vol_avg,
+            self.data.physics.e_plasma_electrons_thermal,
+        ) = self.physics.calaculate_stored_thermal_energy(
+            vol_plasma=self.data.physics.vol_plasma,
+            nd_plasma_vol_avg=self.data.physics.nd_plasma_electrons_vol_avg,
+            temp_plasma_density_weighted_vol_avg_kev=self.data.physics.temp_plasma_electron_density_weighted_kev,
+        )
+
+        (
+            self.data.physics.eden_plasma_ions_thermal_vol_avg,
+            self.data.physics.e_plasma_ions_thermal,
+        ) = self.physics.calaculate_stored_thermal_energy(
+            vol_plasma=self.data.physics.vol_plasma,
+            nd_plasma_vol_avg=self.data.physics.nd_plasma_ions_total_vol_avg,
+            temp_plasma_density_weighted_vol_avg_kev=self.data.physics.temp_plasma_ion_density_weighted_kev,
+        )
+
+        self.data.physics.eden_plasma_thermal_vol_avg = (
+            self.data.physics.eden_plasma_electrons_thermal_vol_avg
+            + self.data.physics.eden_plasma_ions_thermal_vol_avg
+        )
+
+        self.data.physics.e_plasma_thermal_total = (
+            self.data.physics.e_plasma_electrons_thermal
+            + self.data.physics.e_plasma_ions_thermal
+        )
+
+        (
             self.data.physics.pden_electron_transport_loss_mw,
             self.data.physics.pden_ion_transport_loss_mw,
             self.data.physics.t_electron_energy_confinement,


### PR DESCRIPTION
Reverts constraint 17 to pre-#4299. 

The issue is that constraint 17 used to be formatted as https://github.com/ukaea/PROCESS/blob/a68bb7f9af7774ad4b0cd5663bc9fa576c429ee5/process/core/solver/constraints.py#L594-L605

Importantly, it used `pden_plasma_rad_mw`. Now, the constraint uses `f_p_plasma_separatrix_rad` which is calculated as
https://github.com/ukaea/PROCESS/blob/024a2f2e5a9ac750132f6ed010cbe03a34351916/process/models/physics/physics.py#L1037-L1042

However this uses `p_plasma_rad_mw` which also includes the SOL radiation

https://github.com/ukaea/PROCESS/blob/a68bb7f9af7774ad4b0cd5663bc9fa576c429ee5/process/models/stellarator/stellarator.py#L2170

which is never accounted for in pden_plasma_rad_mw. This changed the constraint, making the problem harder to solve, and led to constant failures when running the `stellarator-helias` test.

The diffs in the `stellarator-helias` test should revert it back to [this file](https://github.com/timothy-nunn/process-tracking-data/blob/master/stellarator_helias_MFILE_a68bb7f9af7774ad4b0cd5663bc9fa576c429ee5.DAT).

Thanks @clmould for identifying constraint 17 was the problem!