### PR TITLE
🐛 Prevent lower inequality constraint value from going outside the plot

### DIFF
--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14237,7 +14237,7 @@ def plot_inequality_constraint_equations(axis: plt.Axes, m_file: MFile, scan: in
             # For a lower limit, the normalised value is the residual itself
             normalised_value = con_residual_norm
             bar_left = 0
-            # Set the bar width to be 10 times the normalised value,
+            # Set the bar width to be 1/10 times the normalised value,
             # but cap it at 1.0 to avoid overly long bars
             bar_width = min(normalised_value * 0.1, 1.0)
 

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -14234,9 +14234,12 @@ def plot_inequality_constraint_equations(axis: plt.Axes, m_file: MFile, scan: in
             bar_left = normalised_value
             bar_width = 1 - normalised_value
         else:
+            # For a lower limit, the normalised value is the residual itself
             normalised_value = con_residual_norm
             bar_left = 0
-            bar_width = normalised_value
+            # Set the bar width to be 10 times the normalised value,
+            # but cap it at 1.0 to avoid overly long bars
+            bar_width = min(normalised_value * 0.1, 1.0)
 
         # If the constraint value is very close to the bound then plot a square marker at the bound
         if np.isclose(normalised_value, 1.0, atol=1e-3):


### PR DESCRIPTION


## Description

* For lower limit constraints, the bar width is now set to 10 times the normalized value, but capped at a maximum of 1.0, preventing bars from extending excessively when the residual is large.


<img width="940" height="627" alt="image" src="https://github.com/user-attachments/assets/46eb8843-e1ad-49cb-aa49-4b890b361ff3" />


## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
