### PR TITLE
Remove unnecessary copy statements in superconducting.py

### DIFF
--- a/process/models/tfcoil/superconducting.py
+++ b/process/models/tfcoil/superconducting.py
@@ -1,6 +1,5 @@
 """Module for superconducting TF coil models and related classes."""
 
-import copy
 import logging
 from dataclasses import dataclass
 from enum import IntEnum
@@ -2265,7 +2264,6 @@ class CICCSuperconductingTFCoil(SuperconductingTFCoil):
                 a_tf_wp_no_insulation=self.data.superconducting_tfcoil.a_tf_wp_no_insulation,
                 dia_tf_turn_coolant_channel=self.data.tfcoil.dia_tf_turn_coolant_channel,
                 f_a_tf_turn_cable_space_extra_void=self.data.tfcoil.f_a_tf_turn_cable_space_extra_void,
-                data=self.data,
             )
 
             self.data.tfcoil.a_tf_turn_cable_space_no_void = (
@@ -3261,7 +3259,6 @@ class CICCSuperconductingTFCoil(SuperconductingTFCoil):
         a_tf_wp_no_insulation: float,
         dia_tf_turn_coolant_channel: float,
         f_a_tf_turn_cable_space_extra_void: float,
-        data: DataStructure,
     ) -> CICCAveragedTurnGeometry:
         """Subroutine straight from Python, see comments in
         tf_averaged_turn_geom_wrapper. Setting the TF WP turn geometry for SC magnets
@@ -3378,15 +3375,6 @@ class CICCSuperconductingTFCoil(SuperconductingTFCoil):
 
         # Area of inter-turn insulation: single turn [m2]
         a_tf_turn_insulation = a_tf_turn - t_conductor**2
-
-        # NOTE: Fortran has a_tf_turn_cable_space_no_void as an intent(out) variable
-        # that was outputting into data.tfcoil.a_tf_turn_cable_space_no_void.
-        # The local variable, however, appears to initially hold the value of
-        # data.tfcoil.a_tf_turn_cable_space_no_void despite not being intent(in).
-        # I have replicated this behaviour in Python for now.
-        a_tf_turn_cable_space_no_void = copy.copy(
-            data.tfcoil.a_tf_turn_cable_space_no_void
-        )
 
         # Radius of rounded corners of cable space inside conduit [m]
         radius_tf_turn_cable_space_corners = dx_tf_turn_steel * 0.75e0
@@ -4470,18 +4458,14 @@ class CROCOSuperconductingTFCoil(SuperconductingTFCoil):
         # Area of inter-turn insulation: single turn [m²]
         a_tf_turn_insulation = a_tf_turn - t_conductor**2
 
-        a_tf_turn_cable_space_no_void = copy.copy(
-            self.data.tfcoil.a_tf_turn_cable_space_no_void
-        )
-
         # Diameter of circular cable space inside conduit [m]
         dx_tf_turn_cable_space_average = t_conductor - 2.0e0 * dx_tf_turn_steel
 
         # Cross-sectional area of conduit jacket per turn [m²]
-        a_tf_turn_steel = t_conductor**2 - a_tf_turn_cable_space_no_void
+        a_tf_turn_steel = t_conductor**2 - self.data.tfcoil.a_tf_turn_cable_space_no_void
 
         return CROCOAveragedTurnGeometry(
-            a_tf_turn_cable_space_no_void=a_tf_turn_cable_space_no_void,
+            a_tf_turn_cable_space_no_void=self.data.tfcoil.a_tf_turn_cable_space_no_void,
             a_tf_turn_steel=a_tf_turn_steel,
             a_tf_turn_insulation=a_tf_turn_insulation,
             n_tf_coil_turns=n_tf_coil_turns,

--- a/tests/unit/models/tfcoil/test_sctfcoil.py
+++ b/tests/unit/models/tfcoil/test_sctfcoil.py
@@ -1388,7 +1388,6 @@ def test_tf_cable_in_conduit_averaged_turn_geometry(
         a_tf_wp_no_insulation=tfaveragedturngeomparam.a_tf_wp_no_insulation,
         dia_tf_turn_coolant_channel=0.004,
         f_a_tf_turn_cable_space_extra_void=0.3,
-        data=cicc_sctfcoil.data,
     )
 
     # Existing checks


### PR DESCRIPTION
Remove vestiges of Fortran.