### PR TITLE
`stress_radial_cs_inner` is very small when it should be `0`

### DIFF
--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -4378,12 +4378,20 @@ class CSCoil(Model):
         hp_term_1 = k * ((2.0e0 + f_poisson_cs_structure) / (3.0e0 * (alpha + 1.0e0)))
 
         hp_term_2 = (
-            alpha**2 + alpha + 1.0e0 - alpha**2 / epsilon**2 - epsilon * (alpha + 1.0e0)
+            alpha**2
+            + alpha
+            + 1.0e0
+            - (alpha**2 / epsilon**2)
+            - epsilon * (alpha + 1.0e0)
         )
+        if np.isclose(hp_term_2, 0.0):
+            hp_term_2 = 0.0
 
         hp_term_3 = m * ((3.0e0 + f_poisson_cs_structure) / (8.0e0))
 
         hp_term_4 = alpha**2 + 1.0e0 - alpha**2 / epsilon**2 - epsilon**2
+        if np.isclose(hp_term_4, 0.0):
+            hp_term_4 = 0.0
 
         return hp_term_1 * hp_term_2 - hp_term_3 * hp_term_4
 


### PR DESCRIPTION
Some of the failures we have seen on main are from `stress_radial_cs_inner` switching between being a very small negative number or a very small positive number, both of which have the same absolute value. Changing the order of calculation in `calculate_cs_radial_stress` has stopped this from occurring and `stress_radial_cs_inner` is now exactly `0`, which it should be. 

Edit: this has worked on Mac to make it exactly 0 but Linux machines still seem to find a very small value (+/- 9.486166219722724e-08). It is possible that this has at least stopped the negative-positive flip flop but that will require some testing.