### PR TITLE
Add specific `dr_cs_bore` variable

### DIFF
--- a/documentation/source/eng-models/central-solenoid.md
+++ b/documentation/source/eng-models/central-solenoid.md
@@ -433,7 +433,7 @@ solenoid usually consists of several coils, which can have opposite currents.  T
 forces that tend to separate the coils.  To prevent this, ITER has "tie-plates" which hold the coil 
 segments together.  PROCESS has a corresponding structure, known as the pre-compression structure, 
 made up of two cylinders, one on the inside and one on the outside, of the same thickness. The 
-radii of the two cylinders are `dr_bore` and `dr_bore` + `dr_cs`.  The thickness is derived using the 
+radii of the two cylinders are `dr_cs_bore` and `dr_cs_bore` + `dr_cs`.  The thickness is derived using the 
 separation force and the combined cross-sectional area:
 
 $$

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -7948,7 +7948,7 @@ def plot_pf_coils(
     coils_dz = []
     coil_text = []
 
-    dr_bore = mfile.get("dr_bore", scan=scan)
+    dr_cs_bore = mfile.get("dr_cs_bore", scan=scan)
     dr_cs = mfile.get("dr_cs", scan=scan)
     dz_cs_full = mfile.get("dz_cs_full", scan=scan)
 
@@ -7977,7 +7977,7 @@ def plot_pf_coils(
         coils_z=coils_z,
         coils_dr=coils_dr,
         coils_dz=coils_dz,
-        dr_bore=dr_bore,
+        dr_cs_bore=dr_cs_bore,
         dr_cs=dr_cs,
         ohdz=dz_cs_full,
     )
@@ -9946,7 +9946,7 @@ def plot_cs_coil_structure(
     dr_cs_full = mfile.get("dr_cs_full", scan=scan)
     dz_cs_full = mfile.get("dz_cs_full", scan=scan)
     dz_cs = mfile.get("dz_cs_full", scan=scan)
-    dr_bore = mfile.get("dr_bore", scan=scan)
+    dr_cs_bore = mfile.get("dr_cs_bore", scan=scan)
     r_cs_current_filaments_array = [
         mfile.get(f"r_pf_cs_current_filaments{i}", scan=scan) for i in range(NFIXMX)
     ]
@@ -9956,7 +9956,7 @@ def plot_cs_coil_structure(
 
     # Plot the right side of the CS
     right_cs = patches.Rectangle(
-        (dr_bore, -dz_cs / 2),
+        (dr_cs_bore, -dz_cs / 2),
         dr_cs,
         dz_cs,
         edgecolor="black",
@@ -9967,8 +9967,8 @@ def plot_cs_coil_structure(
 
     # Plot the bore of the machine
     bore_rect = patches.Rectangle(
-        (-dr_bore, -dz_cs / 2),
-        dr_bore * 2,
+        (-dr_cs_bore, -dz_cs / 2),
+        dr_cs_bore * 2,
         dz_cs,
         edgecolor="black",
         facecolor="lightgrey",
@@ -9977,7 +9977,7 @@ def plot_cs_coil_structure(
     axis.add_patch(bore_rect)
 
     left_cs = patches.Rectangle(
-        (-dr_bore - dr_cs, -dz_cs / 2),
+        (-dr_cs_bore - dr_cs, -dz_cs / 2),
         dr_cs,
         dz_cs,
         edgecolor="black",
@@ -9995,9 +9995,9 @@ def plot_cs_coil_structure(
     if dr_cs_turn > 0:
         n_lines = int(dr_cs / dr_cs_turn)
         for i in range(1, n_lines):
-            x = dr_bore + i * dr_cs_turn
+            x = dr_cs_bore + i * dr_cs_turn
             axis.plot([x, x], [-dz_cs / 2, dz_cs / 2], **t_kwargs)
-            x_left = -dr_bore - dr_cs + i * dr_cs_turn
+            x_left = -dr_cs_bore - dr_cs + i * dr_cs_turn
             axis.plot([x_left, x_left], [-dz_cs / 2, dz_cs / 2], **t_kwargs)
     # Plot horizontal lines (along Z) for each turn
     if dz_cs_turn > 0:
@@ -10005,9 +10005,9 @@ def plot_cs_coil_structure(
         for j in range(1, n_hlines):
             y = -dz_cs / 2 + j * dz_cs_turn
             # Right CS
-            axis.plot([dr_bore, dr_bore + dr_cs], [y, y], **t_kwargs)
+            axis.plot([dr_cs_bore, dr_cs_bore + dr_cs], [y, y], **t_kwargs)
             # Left CS
-            axis.plot([-dr_bore - dr_cs, -dr_bore], [y, y], **t_kwargs)
+            axis.plot([-dr_cs_bore - dr_cs, -dr_cs_bore], [y, y], **t_kwargs)
 
         l_kwargs = {"color": "black", "linestyle": "--", "linewidth": 0.6, "alpha": 0.5}
 
@@ -10015,14 +10015,14 @@ def plot_cs_coil_structure(
         axis.axhline(y=0.0, **l_kwargs)
         # Plot a vertical line at x = 0.0
         axis.axvline(x=0.0, **l_kwargs)
-        # Plot a vertical line at x = dr_bore
-        axis.axvline(x=dr_bore, **l_kwargs)
-        # Plot a vertical line at x = -dr_bore
-        axis.axvline(x=-dr_bore, **l_kwargs)
-        # Plot a vertical line at x = dr_bore + dr_cs
-        axis.axvline(x=(dr_bore + dr_cs), **l_kwargs)
-        # Plot a vertical line at x = -dr_bore - dr_cs
-        axis.axvline(x=-(dr_bore + dr_cs), **l_kwargs)
+        # Plot a vertical line at x = dr_cs_bore
+        axis.axvline(x=dr_cs_bore, **l_kwargs)
+        # Plot a vertical line at x = -dr_cs_bore
+        axis.axvline(x=-dr_cs_bore, **l_kwargs)
+        # Plot a vertical line at x = dr_cs_bore + dr_cs
+        axis.axvline(x=(dr_cs_bore + dr_cs), **l_kwargs)
+        # Plot a vertical line at x = -dr_cs_bore - dr_cs
+        axis.axvline(x=-(dr_cs_bore + dr_cs), **l_kwargs)
         # Plot a vertical line at y= dz_cs / 2
         axis.axhline(y=(dz_cs / 2), **l_kwargs)
         # Plot a vertical line at y= -dz_cs / 2

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -2664,12 +2664,12 @@ def plot_main_plasma_information(
         f"Extra heat power: {mfile.get('p_hcd_secondary_extra_heat_mw', scan=scan):.4f} MW\n"
         f"$\\eta_{{\\text{{CD,sec}}}}$: {mfile.get('eta_cd_hcd_secondary', scan=scan):.4f} A/W  |   $\\langle\\zeta_{{\\text{{CD,sec}}}}\\rangle$: {mfile.get('eta_cd_dimensionless_hcd_secondary', scan=scan):.4f}  \n"
         f"$\\gamma_{{\\text{{CD,sec}}}}$: {mfile.get('eta_cd_norm_hcd_secondary', scan=scan):.4f} $\\times 10^{{20}}  \\mathrm{{A}} / \\mathrm{{Wm}}^2$\n"
-        f"Current driven by secondary: {mfile.get('c_hcd_secondary_driven', scan=scan) / 1e6:.3f} MA\n"
+        f"Current driven by secondary: {mfile.get('c_hcd_secondary_driven', scan=scan) / 1e6:.3f} MA"
     )
 
     axis.text(
-        0.66,
-        0.6,
+        0.73,
+        0.675,
         textstr_hcd,
         fontsize=9,
         verticalalignment="top",

--- a/process/data_structure/build_variables.py
+++ b/process/data_structure/build_variables.py
@@ -106,7 +106,10 @@ class BuildData:
     """upper first wall thickness (m)"""
 
     dr_bore: float = 1.42
-    """central solenoid inboard radius (m) (`iteration variable 29`)"""
+    """Machine centre bore gap inboard radius (m) (`iteration variable 29`)"""
+
+    dr_cs_bore: float = 1.42
+    """Central solenoid bore radius [m]"""
 
     f_z_cryostat: float = 4.268
     """cryostat lid height scaling factor (tokamaks)"""

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -1672,39 +1672,14 @@ class Build(Model):
                 self.data.build.dz_fw_plasma_gap,
             )
 
-        # Calculate pre-compression structure thickness
-        if (
-            CSPrecompressionConfiguration(self.data.build.i_cs_precomp)
-            == CSPrecompressionConfiguration.CS_PRECOMPRESSION_STRUCTURE_PRESENT
-            and self.data.build.i_tf_inside_cs == TFCSRadialConfiguration.TF_OUTSIDE_CS
-        ):
+        # Calculate pre-compression structure thickness is self.data.build.i_cs_precomp=1
+        if CSPrecompressionConfiguration(self.data.build.i_cs_precomp)== CSPrecompressionConfiguration.CS_PRECOMPRESSION_STRUCTURE_PRESENT:
             self.data.build.dr_cs_precomp = self.data.build.fseppc / (
                 2.0e0
                 * np.pi
                 * self.data.build.fcspc
                 * self.data.build.sigallpc
-                * (
-                    self.data.build.dr_bore
-                    + self.data.build.dr_bore
-                    + self.data.build.dr_cs
-                )
-            )
-        elif (
-            CSPrecompressionConfiguration(self.data.build.i_cs_precomp)
-            == CSPrecompressionConfiguration.CS_PRECOMPRESSION_STRUCTURE_PRESENT
-            and self.data.build.i_tf_inside_cs == TFCSRadialConfiguration.TF_INSIDE_CS
-        ):
-            self.data.build.dr_cs_precomp = self.data.build.fseppc / (
-                2.0e0
-                * np.pi
-                * self.data.build.fcspc
-                * self.data.build.sigallpc
-                * (
-                    2.0 * self.data.build.dr_bore
-                    + 2.0 * self.data.build.dr_tf_inboard
-                    + 2.0 * self.data.build.dr_cs_tf_gap
-                    + self.data.build.dr_cs
-                )
+                * (2.0 * self.data.build.dr_cs_bore + self.data.build.dr_cs)
             )
         else:
             self.data.build.dr_cs_precomp = 0.0e0

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -1672,18 +1672,6 @@ class Build(Model):
                 self.data.build.dz_fw_plasma_gap,
             )
 
-        # Calculate pre-compression structure thickness is self.data.build.i_cs_precomp=1
-        if CSPrecompressionConfiguration(self.data.build.i_cs_precomp)== CSPrecompressionConfiguration.CS_PRECOMPRESSION_STRUCTURE_PRESENT:
-            self.data.build.dr_cs_precomp = self.data.build.fseppc / (
-                2.0e0
-                * np.pi
-                * self.data.build.fcspc
-                * self.data.build.sigallpc
-                * (2.0 * self.data.build.dr_cs_bore + self.data.build.dr_cs)
-            )
-        else:
-            self.data.build.dr_cs_precomp = 0.0e0
-
         # Issue #514 Radial dimensions of inboard leg
         # Calculate self.data.build.dr_tf_inboard if
         # self.data.tfcoil.dr_tf_wp_with_insulation is an iteration variable (140)
@@ -1711,6 +1699,21 @@ class Build(Model):
                 + self.data.build.dr_cs_tf_gap
             )
             self.data.build.dr_cs_bore = self.data.build.dr_bore
+
+        # Calculate pre-compression structure thickness
+        if (
+            CSPrecompressionConfiguration(self.data.build.i_cs_precomp)
+            == CSPrecompressionConfiguration.CS_PRECOMPRESSION_STRUCTURE_PRESENT
+        ):
+            self.data.build.dr_cs_precomp = self.data.build.fseppc / (
+                2.0e0
+                * np.pi
+                * self.data.build.fcspc
+                * self.data.build.sigallpc
+                * (2.0 * self.data.build.dr_cs_bore + self.data.build.dr_cs)
+            )
+        else:
+            self.data.build.dr_cs_precomp = 0.0e0
 
         # Radial build to tfcoil middle [m]
         self.data.build.r_tf_inboard_mid = (

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -1720,11 +1720,12 @@ class Build(Model):
             )
 
         if self.data.build.i_tf_inside_cs == TFCSRadialConfiguration.TF_INSIDE_CS:
-            self.data.build.r_tf_inboard_in = (
+            self.data.build.r_tf_inboard_in = self.data.build.dr_bore
+            # CS bore radius [m]
+            self.data.build.dr_cs_bore = (
                 self.data.build.dr_bore
-                # NOTE: dr_bore is just the hollow space, the
-                # true dr_bore size used for flux calculations
-                # is dr_bore + dr_tf_inboard + dr_cs_tf_gap
+                + self.data.build.dr_tf_inboard
+                + self.data.build.dr_cs_tf_gap
             )
         else:
             # Inboard side inner radius [m]
@@ -1734,6 +1735,7 @@ class Build(Model):
                 + self.data.build.dr_cs_precomp
                 + self.data.build.dr_cs_tf_gap
             )
+            self.data.build.dr_cs_bore = self.data.build.dr_bore
 
         # Radial build to tfcoil middle [m]
         self.data.build.r_tf_inboard_mid = (
@@ -1916,7 +1918,7 @@ class Build(Model):
             + 0.5e0 * self.data.build.dr_tf_outboard
         )
 
-        # TF coil horizontal self.data.build.dr_bore [m]
+        # TF coil horizontal bore at mid-plane [m]
         self.data.build.dr_tf_inner_bore = (
             self.data.build.r_tf_outboard_mid - 0.5e0 * self.data.build.dr_tf_outboard
         ) - (self.data.build.r_tf_inboard_mid - 0.5e0 * self.data.build.dr_tf_inboard)
@@ -2050,21 +2052,6 @@ class Build(Model):
                 "OP ",
             )
 
-            if self.data.build.i_tf_inside_cs == TFCSRadialConfiguration.TF_INSIDE_CS:
-                po.ocmmnt(
-                    self.outfile,
-                    (
-                        "\n "
-                        "(The stated machine dr_bore size is just for the hollow space, "
-                    ),
-                )
-                po.ocmmnt(
-                    self.outfile,
-                    (
-                        "the true dr_bore size used for calculations is "
-                        "dr_bore + dr_tf_inboard + dr_cs_tf_gap)\n"
-                    ),
-                )
             if (
                 self.data.build.i_tf_inside_cs == TFCSRadialConfiguration.TF_INSIDE_CS
                 and self.data.tfcoil.i_tf_bucking >= 2

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -1691,13 +1691,6 @@ class Build(Model):
                 + self.data.build.dr_cs_tf_gap
             )
         else:
-            # Inboard side inner radius [m]
-            self.data.build.r_tf_inboard_in = (
-                self.data.build.dr_bore
-                + self.data.build.dr_cs
-                + self.data.build.dr_cs_precomp
-                + self.data.build.dr_cs_tf_gap
-            )
             self.data.build.dr_cs_bore = self.data.build.dr_bore
 
         # Calculate pre-compression structure thickness
@@ -1714,6 +1707,16 @@ class Build(Model):
             )
         else:
             self.data.build.dr_cs_precomp = 0.0e0
+
+        if self.data.build.i_tf_inside_cs != TFCSRadialConfiguration.TF_INSIDE_CS:
+            # Inboard side inner radius [m]
+            # This is not calculated above because it requires the dr_cs_precomp
+            self.data.build.r_tf_inboard_in = (
+                self.data.build.dr_bore
+                + self.data.build.dr_cs
+                + self.data.build.dr_cs_precomp
+                + self.data.build.dr_cs_tf_gap
+            )
 
         # Radial build to tfcoil middle [m]
         self.data.build.r_tf_inboard_mid = (

--- a/process/models/geometry/pfcoil.py
+++ b/process/models/geometry/pfcoil.py
@@ -13,7 +13,7 @@ def pfcoil_geometry(
     coils_z: list[float],
     coils_dr: list[float],
     coils_dz: list[float],
-    dr_bore: float,
+    dr_cs_bore: float,
     dr_cs: float,
     ohdz: float,
 ) -> tuple[np.ndarray, np.ndarray, RectangleGeometry]:
@@ -30,7 +30,7 @@ def pfcoil_geometry(
         list of pf coil radial thicknesses
     coils_dz:
         list of pf coil vertical thicknesses
-    dr_bore:
+    dr_cs_bore:
         central solenoid inboard radius
     dr_cs:
         central solenoid thickness
@@ -55,7 +55,7 @@ def pfcoil_geometry(
         z_points.append([z_1, z_2, z_2, z_1, z_1])
 
     central_coil = RectangleGeometry(
-        anchor_x=dr_bore, anchor_z=(-ohdz / 2), width=dr_cs, height=ohdz
+        anchor_x=dr_cs_bore, anchor_z=(-ohdz / 2), width=dr_cs, height=ohdz
     )
 
     return r_points, z_points, central_coil

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -182,7 +182,7 @@ class PFCoil(Model):
             z_tf_inside_half=self.data.build.z_tf_inside_half,
             f_z_cs_tf_internal=self.data.pf_coil.f_z_cs_tf_internal,
             dr_cs=self.data.build.dr_cs,
-            dr_bore=self.data.build.dr_bore,
+            dr_cs_bore=self.data.build.dr_cs_bore,
         )
 
         self.data.pf_coil.z_cs_upper = self.data.pf_coil.z_pf_coil_upper[
@@ -649,9 +649,9 @@ class PFCoil(Model):
                 * np.pi
                 * np.pi
                 * (
-                    (self.data.build.dr_bore * self.data.build.dr_bore)
+                    (self.data.build.dr_cs_bore * self.data.build.dr_cs_bore)
                     + (self.data.build.dr_cs * self.data.build.dr_cs) / 6.0e0
-                    + (self.data.build.dr_cs * self.data.build.dr_bore) / 2.0e0
+                    + (self.data.build.dr_cs * self.data.build.dr_cs_bore) / 2.0e0
                 )
                 / (self.data.pf_coil.dz_cs_full)
             )
@@ -1050,7 +1050,7 @@ class PFCoil(Model):
                 c += 1
 
         self.data.pf_coil.itr_sum += (
-            (self.data.build.dr_bore + 0.5 * self.data.build.dr_cs)
+            (self.data.build.dr_cs_bore + 0.5 * self.data.build.dr_cs)
             * self.data.pf_coil.n_pf_coil_turns[self.data.pf_coil.n_cs_pf_coils - 1]
             * self.data.pf_coil.c_pf_coil_turn_peak_input[
                 self.data.pf_coil.n_cs_pf_coils - 1
@@ -1543,14 +1543,14 @@ class PFCoil(Model):
                         if self.data.pf_coil.r_pf_coil_middle_group_array[
                             ii, ij
                         ] <= (  # Inboard TF coil collision
-                            self.data.build.dr_bore
+                            self.data.build.dr_cs_bore
                             + self.data.build.dr_cs
                             + self.data.build.dr_cs_precomp
                             + self.data.build.dr_cs_tf_gap
                             + self.data.build.dr_tf_inboard
                             + self.data.pf_coil.r_pf_coil_middle[i]
                         ) and self.data.pf_coil.r_pf_coil_middle_group_array[ii, ij] >= (
-                            self.data.build.dr_bore
+                            self.data.build.dr_cs_bore
                             + self.data.build.dr_cs
                             + self.data.build.dr_cs_precomp
                             + self.data.build.dr_cs_tf_gap
@@ -3009,7 +3009,7 @@ class CSCoil(Model):
         z_tf_inside_half: float,
         f_z_cs_tf_internal: float,
         dr_cs: float,
-        dr_bore: float,
+        dr_cs_bore: float,
     ) -> CSGeometry:
         """Calculate the geometry of the Central Solenoid (CS) coil.
 
@@ -3021,8 +3021,8 @@ class CSCoil(Model):
             Fractional height of CS relative to TF bore
         dr_cs : float
             Thickness of the CS coil (m)
-        dr_bore : float
-            Radius of the TF bore (m)
+        dr_cs_bore : float
+            Radius of the CS bore (m)
 
         Returns
         -------
@@ -3030,7 +3030,7 @@ class CSCoil(Model):
             Data class containing the geometry parameters of the CS coil
         """
         # Central Solenoid mean radius
-        r_cs_middle = dr_bore + (0.5e0 * dr_cs)
+        r_cs_middle = dr_cs_bore + (0.5e0 * dr_cs)
 
         # Scale the CS height relative to TF bore height
         z_cs_half = z_tf_inside_half * f_z_cs_tf_internal
@@ -3234,7 +3234,7 @@ class CSCoil(Model):
             z_tf_inside_half=self.data.build.z_tf_inside_half,
             f_z_cs_tf_internal=self.data.pf_coil.f_z_cs_tf_internal,
             dr_cs=self.data.build.dr_cs,
-            dr_bore=self.data.build.dr_bore,
+            dr_cs_bore=self.data.build.dr_cs_bore,
         )
 
         self.data.pf_coil.z_cs_upper = self.data.pf_coil.z_pf_coil_upper[
@@ -3870,8 +3870,8 @@ class CSCoil(Model):
         op.ovarre(
             self.outfile,
             "Radial thickness of the CS bore [m]",
-            "(dr_bore)",
-            self.data.build.dr_bore,
+            "(dr_cs_bore)",
+            self.data.build.dr_cs_bore,
             "OP ",
         )
         op.oblnkl(self.outfile)

--- a/tests/unit/models/test_pfcoil.py
+++ b/tests/unit/models/test_pfcoil.py
@@ -2048,7 +2048,7 @@ def test_brookscoil(pfcoil):
 
 
 @pytest.mark.parametrize(
-    ("z_tf_inside_half", "f_z_cs_tf_internal", "dr_cs", "dr_bore", "expected"),
+    ("z_tf_inside_half", "f_z_cs_tf_internal", "dr_cs", "dr_cs_bore", "expected"),
     [
         # Typical values
         (
@@ -2101,13 +2101,13 @@ def test_brookscoil(pfcoil):
     ],
 )
 def test_calculate_cs_geometry(
-    cs_coil, z_tf_inside_half, f_z_cs_tf_internal, dr_cs, dr_bore, expected
+    cs_coil, z_tf_inside_half, f_z_cs_tf_internal, dr_cs, dr_cs_bore, expected
 ):
     result = cs_coil.calculate_cs_geometry(
         z_tf_inside_half=z_tf_inside_half,
         f_z_cs_tf_internal=f_z_cs_tf_internal,
         dr_cs=dr_cs,
-        dr_bore=dr_bore,
+        dr_cs_bore=dr_cs_bore,
     )
     for field in fields(result):
         assert pytest.approx(getattr(result, field.name)) == getattr(
@@ -2436,7 +2436,7 @@ def test_pfcoil(monkeypatch, pfcoil):
     monkeypatch.setattr(pfcoil.data.build, "dr_tf_outboard", 1.4)
     monkeypatch.setattr(pfcoil.data.build, "dr_tf_inboard", 1.4)
     monkeypatch.setattr(pfcoil.data.build, "r_tf_outboard_mid", 1.66e1)
-    monkeypatch.setattr(pfcoil.data.build, "dr_bore", 2.15)
+    monkeypatch.setattr(pfcoil.data.build, "dr_cs_bore", 2.15)
     monkeypatch.setattr(pfcoil.data.fwbs, "den_steel", 7.8e3)
     monkeypatch.setattr(pfcoil.data.pf_coil, "dr_pf_cs_middle_offset", 0.0)
     monkeypatch.setattr(pfcoil.data.pf_coil, "m_pf_coil_structure_total", 0.0)
@@ -2584,7 +2584,7 @@ def test_ohcalc(monkeypatch, reinitialise_error_module, cs_coil):
     monkeypatch.setattr(cs_coil.data.build, "z_tf_inside_half", 8.864)
     monkeypatch.setattr(cs_coil.data.build, "dr_cs", 6.510e-1)
     monkeypatch.setattr(cs_coil.data.fwbs, "den_steel", 7.8e3)
-    monkeypatch.setattr(cs_coil.data.build, "dr_bore", 2.6745)
+    monkeypatch.setattr(cs_coil.data.build, "dr_cs_bore", 2.6745)
     monkeypatch.setattr(cs_coil.data.pf_coil, "n_cs_pf_coils", 5)
     monkeypatch.setattr(cs_coil.data.pf_coil, "b_cs_peak_flat_top_end", 1.4e1)
     monkeypatch.setattr(cs_coil.data.pf_coil, "j_cs_flat_top_end", 1.693e7)


### PR DESCRIPTION
This pull request refactors the codebase to consistently use a new variable, `dr_cs_bore`, to represent the central solenoid (CS) bore radius, replacing the previous use of `dr_bore` for this purpose. The changes improve clarity and accuracy in the modeling of the CS geometry, update all related calculations, plotting routines, and tests, and provide more precise documentation for these variables.

**Variable refactoring and improved clarity:**

* Introduced `dr_cs_bore` in `BuildData` to explicitly represent the CS bore radius, updated its documentation, and ensured it is set appropriately in the radial build calculations (`process/data_structure/build_variables.py`, `process/models/build.py`). 
* Refactored all geometry, plotting, and collision detection code to use `dr_cs_bore` instead of `dr_bore` when referring to the CS bore, including function signatures, calculations, and docstrings (`process/models/geometry/pfcoil.py`, `process/models/pfcoil.py`, `process/core/io/plot/summary.py`). 
* Updated all output and documentation strings to reference `dr_cs_bore` where appropriate (`process/models/pfcoil.py`). 

**Testing updates:**

* Modified all relevant tests to use `dr_cs_bore` instead of `dr_bore` for the CS bore radius, ensuring test consistency with the new variable naming and logic (`tests/unit/models/test_pfcoil.py`). 

**Plotting improvements:**

* Adjusted text placement and axis values in plotting routines for improved visualization and to reflect the variable name changes (`process/core/io/plot/summary.py`).

These changes make the codebase more maintainable and reduce ambiguity around the meaning of the bore radius variables, ensuring that the CS bore and other bore-related quantities are clearly distinguished.## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
