### PR TITLE
Remove OSQP dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "numpy>=1.23",
     "scipy>=1.10",
     "cvxpy~=1.7.3",
-    "osqp>=1.0",
     "pandas>=2.0",
     "numba>=0.57",
     "PyVMCON>=2.4.0,<2.5.0",


### PR DESCRIPTION
We no longer use `osqp` as the solver for CVXPY in PyVMCON, instead we use `clarabel`. There is no reason to have this as a dependency anymore.