### PR TITLE
Increase stellarator-helias epsfcn

### DIFF
--- a/tests/regression/input_files/stellarator_helias.IN.DAT
+++ b/tests/regression/input_files/stellarator_helias.IN.DAT
@@ -227,7 +227,7 @@ f_nd_impurity_electrons(14) = 1.0E-5       *Tungsten
 ioptimz  = 1            *Code operation switch (1: Optimisation, VMCON only)
 maxcal   = 100          *Maximum number of VMCON iterations
 minmax   = 6            *Switch for figure-of-merit (7: Min Capital Cost)
-epsfcn   = 0.01
+epsfcn   = 0.01         *Default for this parameter is 1e-3 however this specific IN.DAT and starting point benefit from a larger step length
 runtitle = SQuID
 
 *-----------------Tfcoil Variables-----------------*

--- a/tests/regression/input_files/stellarator_helias.IN.DAT
+++ b/tests/regression/input_files/stellarator_helias.IN.DAT
@@ -227,7 +227,7 @@ f_nd_impurity_electrons(14) = 1.0E-5       *Tungsten
 ioptimz  = 1            *Code operation switch (1: Optimisation, VMCON only)
 maxcal   = 100          *Maximum number of VMCON iterations
 minmax   = 6            *Switch for figure-of-merit (7: Min Capital Cost)
-epsfcn   = 0.001
+epsfcn   = 0.01
 runtitle = SQuID
 
 *-----------------Tfcoil Variables-----------------*


### PR DESCRIPTION
At the moment `stellarator-helias` does not converge within its first 100 iterations. PROCESS then automatically revises the epsfcn (step length for calculating derivatives) from `1e-3` to `1e-2`. Instead of waiting for this to happen automatically, I propose the input file is updated to reflect this. 

@jjwalkowiak what do you think?