### PR TITLE
Ensure i_fw_coolant_type is output as a string

### DIFF
--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -5473,7 +5473,7 @@ def plot_first_wall_poloidal_cross_section(axis: plt.Axes, mfile: MFile, scan: i
     )
 
     textstr_fw = "\n".join((
-        rf"Coolant type: {i_fw_coolant_type.strip()}",
+        rf"Coolant type: {i_fw_coolant_type}",
         rf"$T_{{FW,peak}}$: {temp_fw_peak:,.3f} K",
         rf"$P_{{FW}}$: {pres_fw_coolant / 1e3:,.3f} kPa",
         rf"$P_{{FW}}$: {pres_fw_coolant / 1e5:,.3f} bar",

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -5386,7 +5386,7 @@ def plot_first_wall_poloidal_cross_section(axis: plt.Axes, mfile: MFile, scan: i
     len_fw_channel = mfile.get("len_fw_channel", scan=scan)
     temp_fw_coolant_in = mfile.get("temp_fw_coolant_in", scan=scan)
     temp_fw_coolant_out = mfile.get("temp_fw_coolant_out", scan=scan)
-    i_fw_coolant_type = mfile.get("i_fw_coolant_type", scan=scan)
+    i_fw_coolant_type = mfile.get("i_fw_coolant_type", scan=scan).strip("'\"")
     temp_fw_peak = mfile.get("temp_fw_peak", scan=scan)
     pres_fw_coolant = mfile.get("pres_fw_coolant", scan=scan)
     n_fw_outboard_channels = mfile.get("n_fw_outboard_channels", scan=scan)
@@ -5473,7 +5473,7 @@ def plot_first_wall_poloidal_cross_section(axis: plt.Axes, mfile: MFile, scan: i
     )
 
     textstr_fw = "\n".join((
-        rf"Coolant type: {i_fw_coolant_type}",
+        rf"Coolant type: {i_fw_coolant_type.strip()}",
         rf"$T_{{FW,peak}}$: {temp_fw_peak:,.3f} K",
         rf"$P_{{FW}}$: {pres_fw_coolant / 1e3:,.3f} kPa",
         rf"$P_{{FW}}$: {pres_fw_coolant / 1e5:,.3f} bar",

--- a/process/models/blankets/blanket_library.py
+++ b/process/models/blankets/blanket_library.py
@@ -796,7 +796,7 @@ class BlanketLibrary(Model):
                 self.outfile,
                 "Coolant type",
                 "(i_fw_coolant_type)",
-                CoolantType(self.data.fwbs.i_fw_coolant_type).full_name,
+                f"'{CoolantType(self.data.fwbs.i_fw_coolant_type).full_name}'",
             )
             po.ovarre(
                 self.outfile,

--- a/process/models/fw.py
+++ b/process/models/fw.py
@@ -757,7 +757,7 @@ class FirstWall(Model):
             self.outfile,
             "First wall coolant type",
             "(i_fw_coolant_type)",
-            CoolantType(self.data.fwbs.i_fw_coolant_type).full_name,
+            f"'{CoolantType(self.data.fwbs.i_fw_coolant_type).full_name}'",
         )
         po.ovarre(
             self.outfile,

--- a/tests/unit/data/large_tokamak_MFILE.DAT
+++ b/tests/unit/data/large_tokamak_MFILE.DAT
@@ -7356,7 +7356,7 @@ Radial_thickness_off_outboard_first_wall_(m)_____________________________ (dr_fw
 Number_of_inboard_first_wall_cooling_channels____________________________ (n_fw_inboard_channels)________         7550 OP 
 Number_of_outboard_first_wall_cooling_channels___________________________ (n_fw_outboard_channels)_______        12505 OP 
 # First wall pumping #
-First_wall_coolant_type__________________________________________________ (i_fw_coolant_type)____________     'helium' 
+First_wall_coolant_type__________________________________________________ (i_fw_coolant_type)____________     'Helium' 
 Outlet_temperature_of_first_wall_coolant_[K]_____________________________ (temp_fw_coolant_out)__________ 8.23000000000000000e+02 OP 
 Inlet_temperature_of_first_wall_coolant_[K]______________________________ (temp_fw_coolant_in)___________ 5.73000000000000000e+02 OP 
 Pressure_of_first_wall_coolant_[Pa]______________________________________ (pres_fw_coolant)______________ 1.55000000000000000e+07 OP 


### PR DESCRIPTION
Because `i_fw_coolant_type` was being output as `Helium` rather than `'helium'` (notice the quotes) PROCESS was trying to treat it as a float, not a string.