### PR TITLE
Move stellarator closer to solution point to reduce number of iterations

### DIFF
--- a/tests/regression/input_files/stellarator_helias.IN.DAT
+++ b/tests/regression/input_files/stellarator_helias.IN.DAT
@@ -110,7 +110,7 @@ boundu(59) = 0.9
 boundl(59) = 0.3
 
 ixc = 56 * itv_tdmptf Fast Discharge Time For TF Coil In Event Of Quench (S) (`Iteration Variable 56`)
-t_tf_superconductor_quench = 10.0
+t_tf_superconductor_quench = 35.0
 boundl(56) = 1
 boundu(56) = 50.
 


### PR DESCRIPTION
Both myself (Mac) and @clmould (Linux) get the same solution (number of iterations and convergence parameter) for the `stellarator_helias` regression test. This hopefully means that now, by moving the initial starting point of the regression test closer to the final solution point, the test is able to solver quicker and does so without an accumulation of floating point error which leads to differing solutions on different computer systems.