### PR TITLE
make bzero warning message clearer

### DIFF
--- a/process/models/superconductors.py
+++ b/process/models/superconductors.py
@@ -1034,7 +1034,9 @@ def bottura_scaling(
     # If input field is over the strain adjusted critical field then report error
     if b_conductor / b_c20_eps >= 1.0:
         logger.error(
-            "Reduced field bzero artificially lowered %s %s", b_conductor, b_c20_eps
+            "Reduced field bzero artificially lowered b_conductor=%s b_c20_eps=%s",
+            b_conductor,
+            b_c20_eps,
         )
 
     # Reduced field at zero temperature, taking account of strain


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

This error message wasn't very clear, have returned it to match how it previously displayed

Previous state (screenshot taken from #3764):
<img width="735" height="112" alt="image" src="https://github.com/user-attachments/assets/489a8b9f-edf7-4af7-bd04-a04398c03469" />

Currently on main:
<img width="832" height="106" alt="image" src="https://github.com/user-attachments/assets/3b5edcc4-67dd-4d7c-b71e-d7d8d6ccb6a2" />


With this PR:
<img width="1057" height="96" alt="image" src="https://github.com/user-attachments/assets/bb5a79b4-71fa-4520-844a-00073fa43796" />


## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
