### PR TITLE
Add SOL physics class

### DIFF
--- a/documentation/source/physics-models/plasma_scrape_off_layer.md
+++ b/documentation/source/physics-models/plasma_scrape_off_layer.md
@@ -1,0 +1,60 @@
+# Scrape off Layer | `ScrapeOffLayer`
+
+## Power Decay Lengths
+
+In tokamak scrape-off layer (SOL) physics, $\lambda_q$ is the radial heat flux e-folding length, representing the narrow width over which exhaust power drops exponentially. It measures how tightly thermal energy exiting the core plasma is compressed onto open magnetic field lines.
+
+-----------
+
+### Eich 2013 Model | `calculate_eich2013_sol_power_decay_length()`
+
+The power decay length in metres is given by[^eich_2013]:
+
+$$
+\lambda_q = 1.35 \times 10^{-3} P_{\text{sep}}^{-0.02}R_0^{0.04}B_{\text{p}}(a)^{-0.92}\epsilon^{0.42}
+$$
+
+Here $P_{\text{sep}}$ is the plasma separatrix power in $\text{MW}$, $R_0$ is the plasma major radius in $\text{m}$, $B_{\text{p}}(a)$ is the plasma poloidal field at the outboard mid-plane measured in $\text{T}$ and $\epsilon$ is the plasma inverse aspect ratio.
+
+This can be found in Table 3 from Eich et.al [^eich_2013]
+
+The $R^2$ value for this fit is 0.88
+
+----------
+
+### MAST 2014 I | `calculate_mast2014_sol_power_decay_length_1()`
+
+The power decay length in metres is given by[^mast_2014]:
+
+$$
+\lambda_q = 1.84(\pm0.48) \times 10^{-3} P_{\text{sep}}^{0.18(\pm0.07)}B_{\text{p}}(a)^{-0.68(\pm0.14)}
+$$
+
+Here $P_{\text{sep}}$ is the plasma separatrix power in $\text{MW}$, and $B_{\text{p}}(a)$ is the plasma poloidal field at the outboard mid-plane measured in $\text{T}$.
+
+This can be found in Table 2 and Equation 3 from Thornton et.al [^mast_2014]
+
+The $R^2$ value for this fit is 0.56
+
+----------
+
+### MAST 2014 II | `calculate_mast2014_sol_power_decay_length_2()`
+
+The power decay length in metres is given by[^mast_2014]:
+
+$$
+\lambda_q = 4.57(\pm0.54) \times 10^{-3} P_{\text{sep}}^{0.22(\pm0.08)}I_{\text{p}}^{-0.64(\pm0.15)}
+$$
+
+Here $P_{\text{sep}}$ is the plasma separatrix power in $\text{MW}$, and $I_{\text{p}}$ is the total plasma current measured in $\text{MA}$.
+
+This can be found in Table 2 and Equation 4 from Thornton et.al [^mast_2014]
+
+The $R^2$ value for this fit is 0.55
+
+--------
+
+[^eich_2013]: T. Eich et al., “Scaling of the tokamak near the scrape-off layer H-mode power width and implications for ITER,” Nuclear Fusion, vol. 53, no. 9 p. 093031, Aug. 2013, doi: 10.1088/0029-5515/53/9/093031.
+
+[^mast_2014]: A. J. Thornton and A. Kirk, “Scaling of the scrape-off layer width during inter-ELM H modes on MAST as measured by infrared thermography,”
+Plasma Physics and Controlled Fusion, vol. 56, no. 5, p. 055008, Apr. 2014, doi: 10.1088/0741-3335/56/5/055008.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
               - Confinement time: physics-models/plasma_confinement.md
               - L-H transition: physics-models/plasma_h_mode.md
               - Plasma Core Power Balance: physics-models/plasma_power_balance.md
+              - Plasma Scrape-off Layer: physics-models/plasma_scrape_off_layer.md
               - Detailed Plasma Physics: physics-models/detailed_physics.md
           - Pulsed Plant Operation: physics-models/pulsed-plant.md
       - Engineering Models:

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -8914,6 +8914,85 @@ def plot_bootstrap_comparison(axis: plt.Axes, mfile: MFile, scan: int):
     axis.set_facecolor("#f0f0f0")
 
 
+def plot_sol_power_decay_length_comparison(axis: plt.Axes, mfile: MFile, scan: int):
+    """Function to plot a scatter box plot of SOL power decay lengths (λ_q).
+
+    Parameters
+    ----------
+    axis :
+        axis object to plot to
+    mfile :
+        MFILE data object
+    scan :
+        scan number to use
+    """
+    len_plasma_sol_eich13_power_decay_mm = (
+        mfile.get("len_plasma_sol_eich13_power_decay", scan=scan) * 1e3
+    )
+    len_plasma_sol_mast14_power_decay_1_mm = (
+        mfile.get("len_plasma_sol_mast14_power_decay_1", scan=scan) * 1e3
+    )
+    len_plasma_sol_mast14_power_decay_2_mm = (
+        mfile.get("len_plasma_sol_mast14_power_decay_2", scan=scan) * 1e3
+    )
+
+    # Data for the box plot
+    data = {
+        "Eich 2013": len_plasma_sol_eich13_power_decay_mm,
+        "MAST 2014 (1)": len_plasma_sol_mast14_power_decay_1_mm,
+        "MAST 2014 (2)": len_plasma_sol_mast14_power_decay_2_mm,
+    }
+    # Create the violin plot
+    axis.violinplot(data.values(), showextrema=False)
+
+    # Create the box plot
+    axis.boxplot(
+        data.values(), showfliers=True, showmeans=True, meanline=True, widths=0.3
+    )
+
+    # Scatter plot for each data point
+    colors = plt.cm.plasma(np.linspace(0, 1, len(data.values())))
+    for index, (key, value) in enumerate(data.items()):
+        axis.scatter(1, value, color=colors[index], label=key, alpha=1.0)
+    axis.legend(loc="upper left", bbox_to_anchor=(1, 1))
+
+    # Calculate average, standard deviation, and median
+    data_values = list(data.values())
+    avg_decay_length = np.mean(data_values)
+    std_decay_length = np.std(data_values)
+    median_decay_length = np.median(data_values)
+
+    # Plot average, standard deviation, and median as text
+    axis.text(
+        1.02,
+        0.2,
+        f"Average: {avg_decay_length:.4f}",
+        transform=axis.transAxes,
+        fontsize=9,
+    )
+    axis.text(
+        1.02,
+        0.15,
+        f"Standard Dev: {std_decay_length:.4f}",
+        transform=axis.transAxes,
+        fontsize=9,
+    )
+    axis.text(
+        1.02,
+        0.1,
+        f"Median: {median_decay_length:.4f}",
+        transform=axis.transAxes,
+        fontsize=9,
+    )
+
+    axis.set_title("SOL Power Decay Length ($\\lambda_q$) Comparison")
+    axis.set_ylabel("Power Decay Length [mm]")
+    axis.set_xlim([0.5, 1.5])
+    axis.set_xticks([])
+    axis.set_xticklabels([])
+    axis.set_facecolor("#f0f0f0")
+
+
 def plot_h_threshold_comparison(axis: plt.Axes, mfile: MFile, scan: int, u_seed=None):
     """Function to plot a scatter box plot of L-H threshold power comparisons.
 
@@ -16088,6 +16167,10 @@ def main_plot(
     )
     plot_confinement_time_comparison(
         pages["plasma_compare_2"].add_subplot(224), m_file, scan
+    )
+
+    plot_sol_power_decay_length_comparison(
+        _add_page("plasma_compare_3").add_subplot(221), m_file, scan
     )
 
     plot_debye_length_profile(

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -1651,6 +1651,15 @@ class PhysicsData:
     res_plasma_fuel_spitzer_vol_avg: float = 0.0
     """Volume averaged plasma Spitzer resistivity due to fuel ions (ohm m)"""
 
+    len_plasma_sol_eich13_power_decay: float = 0.0
+    """Eich 2013 power decay length in the scrape-off layer scaling (λ_q) [m]"""
+
+    len_plasma_sol_mast14_power_decay_1: float = 0.0
+    """MAST 2014 power decay length in the scrape-off layer scaling 1 (λ_q) [m]"""
+
+    len_plasma_sol_mast14_power_decay_2: float = 0.0
+    """MAST 2014 power decay length in the scrape-off layer scaling 2 (λ_q) [m]"""
+
     dt_power_density_plasma: float = 0.0
     sigmav_dt_average: float = 0.0
     dhe3_power_density: float = 0.0

--- a/process/main.py
+++ b/process/main.py
@@ -103,6 +103,7 @@ from process.models.physics.plasma_fields import PlasmaFields
 from process.models.physics.plasma_geometry import PlasmaGeom
 from process.models.physics.plasma_profiles import PlasmaProfile
 from process.models.physics.profiles import NeProfile, TeProfile
+from process.models.physics.scrape_off_layer import ScrapeOffLayer
 from process.models.power import Power
 from process.models.pulse import Pulse
 from process.models.shield import Shield
@@ -679,6 +680,7 @@ class Models:
         self.plasma_current = PlasmaCurrent()
         self.plasma_fields = PlasmaFields()
         self.plasma_dia_current = PlasmaDiamagneticCurrent()
+        self.scrape_off_layer = ScrapeOffLayer()
         self.physics = Physics(
             plasma_profile=self.plasma_profile,
             current_drive=self.current_drive,
@@ -693,6 +695,7 @@ class Models:
             plasma_fields=self.plasma_fields,
             plasma_dia_current=self.plasma_dia_current,
             plasma_geometry=self.plasma_geom,
+            scrape_off_layer=self.scrape_off_layer,
         )
         self.physics_detailed = DetailedPhysics(
             plasma_profile=self.plasma_profile,

--- a/process/main.py
+++ b/process/main.py
@@ -785,6 +785,7 @@ class Models:
             self.plasma_bootstrap_current,
             self.plasma_exhaust,
             self.plasma_current,
+            self.scrape_off_layer,
             self.neoclassics,
             self.plasma_inductance,
             self.ne_profile,

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -816,6 +816,13 @@ class Physics(Model):
             )
         )
 
+        # ===============================
+
+        # Calculate scrape-off layer physics
+
+        self.scrape_off_layer.run()
+
+        # ===============================
         self.data.physics.pflux_plasma_surface_neutron_avg_mw = (
             self.data.physics.p_neutron_total_mw / self.data.physics.a_plasma_surface
         )
@@ -2336,6 +2343,8 @@ class Physics(Model):
             po.ocmmnt(self.outfile, "  (Injected power only used for start-up phase)")
 
         self.exhaust.output()
+
+        self.scrape_off_layer.output()
 
         if self.data.stellarator.istell == 0:
             self.plasma_transition.output()

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from process.models.physics.plasma_fields import PlasmaFields
     from process.models.physics.plasma_geometry import PlasmaGeom
     from process.models.physics.plasma_profiles import PlasmaProfile
+    from process.models.physics.scrape_off_layer import ScrapeOffLayer
 
 logger = logging.getLogger(__name__)
 
@@ -195,6 +196,7 @@ class Physics(Model):
         plasma_fields: PlasmaFields,
         plasma_dia_current: PlasmaDiamagneticCurrent,
         plasma_geometry: PlasmaGeom,
+        scrape_off_layer: ScrapeOffLayer,
     ):
         self.outfile = constants.NOUT
         self.mfile = constants.MFILE
@@ -211,6 +213,7 @@ class Physics(Model):
         self.fields = plasma_fields
         self.dia_current = plasma_dia_current
         self.geometry = plasma_geometry
+        self.scrape_off_layer = scrape_off_layer
 
     def output(self) -> None:
         """Output plasma physics information."""

--- a/process/models/physics/scrape_off_layer.py
+++ b/process/models/physics/scrape_off_layer.py
@@ -1,0 +1,22 @@
+"""Module for calculating plasma scrape off layers physics"""
+
+import logging
+
+from process.core import constants
+from process.core.model import Model
+
+logger = logging.getLogger(__name__)
+
+
+class ScrapeOffLayer(Model):
+    """Model for calculating plasma scrape off layers physics."""
+
+    def __init__(self):
+        self.outfile = constants.NOUT
+        self.mfile = constants.MFILE
+
+    def run(self):
+        """Run the model. This model cannot yet be 'run'."""
+
+    def output(self) -> None:
+        """Output plasma scrape off layer physics information."""

--- a/process/models/physics/scrape_off_layer.py
+++ b/process/models/physics/scrape_off_layer.py
@@ -20,3 +20,47 @@ class ScrapeOffLayer(Model):
 
     def output(self) -> None:
         """Output plasma scrape off layer physics information."""
+
+    @staticmethod
+    def calculate_eich2013_sol_power_decay_length(
+        p_plasma_separatrix_mw: float,
+        rmajor: float,
+        b_plasma_surface_poloidal_average: float,
+        aspect: float,
+    ) -> float:
+        """Calculate the Eich 2013 SOL power decay length (λ_q).
+
+        Parameters
+        ----------
+        p_plasma_separatrix_mw : float
+            Power crossing the separatrix (Pₛₑₚ) (MW)
+        rmajor : float
+            Major radius of the plasma (R₀) [m]
+        b_plasma_surface_poloidal_average : float
+            Poloidal magnetic field at the plasma surface (⟨Bₚₒₗ(a)⟩)  [T]
+        aspect : float
+            Aspect ratio of the plasma  (A)
+
+        Returns
+        -------
+        float
+            Eich 2013 SOL power decay length (λ_q) [m]
+
+        Notes
+        -----
+        - The paper states that the poloidal field terms is for the outer midplane
+        Bₚₒₗ(a), we are using the outer surface average
+
+        References
+        ----------
+        [1] T. Eich et al., “Scaling of the tokamak near the scrape-off layer H-mode
+        power width and implications for ITER,” Nuclear Fusion, vol. 53, no. 9,
+        p. 093031, Aug. 2013, doi: 10.1088/0029-5515/53/9/093031.
+
+        """
+        return (
+            1.35e-3 * p_plasma_separatrix_mw**-0.02
+            + rmajor**0.04
+            + b_plasma_surface_poloidal_average**-0.92
+            + aspect**-0.42
+        )

--- a/process/models/physics/scrape_off_layer.py
+++ b/process/models/physics/scrape_off_layer.py
@@ -64,3 +64,70 @@ class ScrapeOffLayer(Model):
             + b_plasma_surface_poloidal_average**-0.92
             + aspect**-0.42
         )
+
+    @staticmethod
+    def calculate_mast2014_sol_power_decay_length_1(
+        p_plasma_separatrix_mw: float,
+        b_plasma_surface_poloidal_average: float,
+    ) -> float:
+        """Calculate the MAST 2014 SOL power decay length (λ_q).
+
+        Parameters
+        ----------
+        p_plasma_separatrix_mw : float
+            Power crossing the separatrix (Pₛₑₚ) (MW)
+        b_plasma_surface_poloidal_average : float
+            Poloidal magnetic field at the plasma surface (⟨Bₚₒₗ(a)⟩)  [T]
+
+        Returns
+        -------
+        float
+            MAST 2014 SOL power decay length (λ_q) [m]
+
+        Notes
+        -----
+        - The paper states that the poloidal field terms is for the outer midplane
+        Bₚₒₗ(a), we are using the outer surface average
+
+        References
+        ----------
+        [1] A. J. Thornton and A. Kirk, “Scaling of the scrape-off layer width during
+        inter-ELM H modes on MAST as measured by infrared thermography,”
+        Plasma Physics and Controlled Fusion, vol. 56, no. 5, p. 055008, Apr. 2014,
+        doi: 10.1088/0741-3335/56/5/055008.
+
+        """
+        return (
+            1.84e-3 * p_plasma_separatrix_mw**0.18
+            + b_plasma_surface_poloidal_average**-0.68
+        )
+
+    @staticmethod
+    def calculate_mast2014_sol_power_decay_length_2(
+        p_plasma_separatrix_mw: float,
+        cur_plasma_ma: float,
+    ) -> float:
+        """Calculate the MAST 2014 SOL power decay length (λ_q).
+
+        Parameters
+        ----------
+        p_plasma_separatrix_mw : float
+            Power crossing the separatrix (Pₛₑₚ) (MW)
+        cur_plasma_ma : float
+            Plasma current (Iₚ) [MA]
+
+        Returns
+        -------
+        float
+            MAST 2014 SOL power decay length (λ_q) [m]
+
+
+        References
+        ----------
+        [1] A. J. Thornton and A. Kirk, “Scaling of the scrape-off layer width during
+        inter-ELM H modes on MAST as measured by infrared thermography,”
+        Plasma Physics and Controlled Fusion, vol. 56, no. 5, p. 055008, Apr. 2014,
+        doi: 10.1088/0741-3335/56/5/055008.
+
+        """
+        return 4.57e-3 * p_plasma_separatrix_mw**0.22 + cur_plasma_ma**-0.64

--- a/process/models/physics/scrape_off_layer.py
+++ b/process/models/physics/scrape_off_layer.py
@@ -1,4 +1,4 @@
-"""Module for calculating plasma scrape off layers physics"""
+"""Module for calculating plasma scrape off layer physics"""
 
 import logging
 

--- a/process/models/physics/scrape_off_layer.py
+++ b/process/models/physics/scrape_off_layer.py
@@ -18,14 +18,14 @@ class ScrapeOffLayer(Model):
 
     def run(self):
         """Calculate the scrape off layer physics and update the physics variables."""
-        self.data.physics.len_plasma_sol_eich13_power_decay = self.calculate_eich2013_sol_power_decay_length(
+        self.data.physics.len_plasma_sol_eich13_power_decay = self.calculate_eich2013_sol_power_decay_length(  # noqa: E501
             p_plasma_separatrix_mw=self.data.physics.p_plasma_separatrix_mw,
             rmajor=self.data.physics.rmajor,
             b_plasma_surface_poloidal_average=self.data.physics.b_plasma_surface_poloidal_average,
             aspect=self.data.physics.aspect,
         )
 
-        self.data.physics.len_plasma_sol_mast14_power_decay_1 = self.calculate_mast2014_sol_power_decay_length_1(
+        self.data.physics.len_plasma_sol_mast14_power_decay_1 = self.calculate_mast2014_sol_power_decay_length_1(  # noqa: E501
             p_plasma_separatrix_mw=self.data.physics.p_plasma_separatrix_mw,
             b_plasma_surface_poloidal_average=self.data.physics.b_plasma_surface_poloidal_average,
         )

--- a/process/models/physics/scrape_off_layer.py
+++ b/process/models/physics/scrape_off_layer.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class ScrapeOffLayer(Model):
-    """Model for calculating plasma scrape off layers physics."""
+    """Model for calculating plasma scrape off layer physics."""
 
     def __init__(self):
         self.outfile = constants.NOUT
@@ -30,10 +30,11 @@ class ScrapeOffLayer(Model):
             b_plasma_surface_poloidal_average=self.data.physics.b_plasma_surface_poloidal_average,
         )
 
+        # NOTE: converting plasma_current from A to MA
         self.data.physics.len_plasma_sol_mast14_power_decay_2 = (
             self.calculate_mast2014_sol_power_decay_length_2(
                 p_plasma_separatrix_mw=self.data.physics.p_plasma_separatrix_mw,
-                cur_plasma_ma=self.data.physics.plasma_current / 1e6,  # Convert A to MA
+                cur_plasma_ma=self.data.physics.plasma_current / 1e6,
             )
         )
 
@@ -74,13 +75,13 @@ class ScrapeOffLayer(Model):
         Parameters
         ----------
         p_plasma_separatrix_mw : float
-            Power crossing the separatrix (Pₛₑₚ) (MW)
+            Power crossing the separatrix (Pₛₑₚ) [MW]
         rmajor : float
             Major radius of the plasma (R₀) [m]
         b_plasma_surface_poloidal_average : float
-            Poloidal magnetic field at the plasma surface (⟨Bₚₒₗ(a)⟩)  [T]
+            Poloidal magnetic field at the plasma surface (⟨Bₚₒₗ(a)⟩) [T]
         aspect : float
-            Aspect ratio of the plasma  (A)
+            Aspect ratio of the plasma (A)
 
         Returns
         -------
@@ -117,9 +118,9 @@ class ScrapeOffLayer(Model):
         Parameters
         ----------
         p_plasma_separatrix_mw : float
-            Power crossing the separatrix (Pₛₑₚ) (MW)
+            Power crossing the separatrix (Pₛₑₚ) [MW]
         b_plasma_surface_poloidal_average : float
-            Poloidal magnetic field at the plasma surface (⟨Bₚₒₗ(a)⟩)  [T]
+            Poloidal magnetic field at the plasma surface (⟨Bₚₒₗ(a)⟩) [T]
 
         Returns
         -------
@@ -155,7 +156,7 @@ class ScrapeOffLayer(Model):
         Parameters
         ----------
         p_plasma_separatrix_mw : float
-            Power crossing the separatrix (Pₛₑₚ) (MW)
+            Power crossing the separatrix (Pₛₑₚ) [MW]
         cur_plasma_ma : float
             Plasma current (Iₚ) [MA]
 

--- a/process/models/physics/scrape_off_layer.py
+++ b/process/models/physics/scrape_off_layer.py
@@ -3,6 +3,7 @@
 import logging
 
 from process.core import constants
+from process.core import process_output as po
 from process.core.model import Model
 
 logger = logging.getLogger(__name__)
@@ -16,10 +17,50 @@ class ScrapeOffLayer(Model):
         self.mfile = constants.MFILE
 
     def run(self):
-        """Run the model. This model cannot yet be 'run'."""
+        """Calculate the scrape off layer physics and update the physics variables."""
+        self.data.physics.len_plasma_sol_eich13_power_decay = self.calculate_eich2013_sol_power_decay_length(
+            p_plasma_separatrix_mw=self.data.physics.p_plasma_separatrix_mw,
+            rmajor=self.data.physics.rmajor,
+            b_plasma_surface_poloidal_average=self.data.physics.b_plasma_surface_poloidal_average,
+            aspect=self.data.physics.aspect,
+        )
+
+        self.data.physics.len_plasma_sol_mast14_power_decay_1 = self.calculate_mast2014_sol_power_decay_length_1(
+            p_plasma_separatrix_mw=self.data.physics.p_plasma_separatrix_mw,
+            b_plasma_surface_poloidal_average=self.data.physics.b_plasma_surface_poloidal_average,
+        )
+
+        self.data.physics.len_plasma_sol_mast14_power_decay_2 = (
+            self.calculate_mast2014_sol_power_decay_length_2(
+                p_plasma_separatrix_mw=self.data.physics.p_plasma_separatrix_mw,
+                cur_plasma_ma=self.data.physics.plasma_current / 1e6,  # Convert A to MA
+            )
+        )
 
     def output(self) -> None:
         """Output plasma scrape off layer physics information."""
+        po.oheadr(self.outfile, "Plasma Scrape Off Layer")
+
+        po.osubhd(self.outfile, "Power Decay Lengths (λ_q)")
+
+        po.ovarre(
+            self.outfile,
+            "Eich 2013 SOL power decay length (λ_q) [m]",
+            "(len_plasma_sol_eich13_power_decay)",
+            self.data.physics.len_plasma_sol_eich13_power_decay,
+        )
+        po.ovarre(
+            self.outfile,
+            "MAST 2014 SOL power decay length 1 (λ_q) [m]",
+            "(len_plasma_sol_mast14_power_decay_1)",
+            self.data.physics.len_plasma_sol_mast14_power_decay_1,
+        )
+        po.ovarre(
+            self.outfile,
+            "MAST 2014 SOL power decay length 2 (λ_q) [m]",
+            "(len_plasma_sol_mast14_power_decay_2)",
+            self.data.physics.len_plasma_sol_mast14_power_decay_2,
+        )
 
     @staticmethod
     def calculate_eich2013_sol_power_decay_length(
@@ -59,10 +100,11 @@ class ScrapeOffLayer(Model):
 
         """
         return (
-            1.35e-3 * p_plasma_separatrix_mw**-0.02
-            + rmajor**0.04
-            + b_plasma_surface_poloidal_average**-0.92
-            + aspect**-0.42
+            1.35e-3
+            * p_plasma_separatrix_mw**-0.02
+            * rmajor**0.04
+            * b_plasma_surface_poloidal_average**-0.92
+            * aspect**-0.42
         )
 
     @staticmethod
@@ -98,8 +140,9 @@ class ScrapeOffLayer(Model):
 
         """
         return (
-            1.84e-3 * p_plasma_separatrix_mw**0.18
-            + b_plasma_surface_poloidal_average**-0.68
+            1.84e-3
+            * p_plasma_separatrix_mw**0.18
+            * b_plasma_surface_poloidal_average**-0.68
         )
 
     @staticmethod
@@ -130,4 +173,4 @@ class ScrapeOffLayer(Model):
         doi: 10.1088/0741-3335/56/5/055008.
 
         """
-        return 4.57e-3 * p_plasma_separatrix_mw**0.22 + cur_plasma_ma**-0.64
+        return 4.57e-3 * p_plasma_separatrix_mw**0.22 * cur_plasma_ma**-0.64

--- a/tests/unit/models/physics/test_scrape_off_layer.py
+++ b/tests/unit/models/physics/test_scrape_off_layer.py
@@ -63,3 +63,83 @@ class TestScrapeOffLayer:
         )
         assert isinstance(result, float)
         assert result > 0
+
+    @staticmethod
+    def test_calculate_mast2014_sol_power_decay_length_1_nominal():
+        """Test MAST 2014 SOL power decay length 1 with nominal values."""
+        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
+            p_plasma_separatrix_mw=100.0,
+            b_plasma_surface_poloidal_average=0.5,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_mast2014_sol_power_decay_length_1_low_power():
+        """Test MAST 2014 SOL power decay length 1 with low power."""
+        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
+            p_plasma_separatrix_mw=10.0,
+            b_plasma_surface_poloidal_average=0.5,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_mast2014_sol_power_decay_length_1_high_power():
+        """Test MAST 2014 SOL power decay length 1 with high power."""
+        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
+            p_plasma_separatrix_mw=500.0,
+            b_plasma_surface_poloidal_average=0.5,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_mast2014_sol_power_decay_length_1_high_bpol():
+        """Test MAST 2014 SOL power decay length 1 with high poloidal field."""
+        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
+            p_plasma_separatrix_mw=100.0,
+            b_plasma_surface_poloidal_average=2.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_mast2014_sol_power_decay_length_2_nominal():
+        """Test MAST 2014 SOL power decay length 2 with nominal values."""
+        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
+            p_plasma_separatrix_mw=100.0,
+            cur_plasma_ma=1.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_mast2014_sol_power_decay_length_2_low_power():
+        """Test MAST 2014 SOL power decay length 2 with low power."""
+        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
+            p_plasma_separatrix_mw=10.0,
+            cur_plasma_ma=1.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_mast2014_sol_power_decay_length_2_high_power():
+        """Test MAST 2014 SOL power decay length 2 with high power."""
+        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
+            p_plasma_separatrix_mw=500.0,
+            cur_plasma_ma=1.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_mast2014_sol_power_decay_length_2_high_current():
+        """Test MAST 2014 SOL power decay length 2 with high plasma current."""
+        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
+            p_plasma_separatrix_mw=100.0,
+            cur_plasma_ma=3.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0

--- a/tests/unit/models/physics/test_scrape_off_layer.py
+++ b/tests/unit/models/physics/test_scrape_off_layer.py
@@ -1,145 +1,101 @@
+import pytest
+
 from process.models.physics.scrape_off_layer import ScrapeOffLayer
 
 
-class TestScrapeOffLayer:
-    """Test suite for ScrapeOffLayer class."""
+@pytest.mark.parametrize(
+    ("p_plasma_separatrix_mw", "rmajor", "b_plasma_surface_poloidal_average", "aspect"),
+    [
+        (100.0, 3.0, 0.5, 3.0),
+        (10.0, 3.0, 0.5, 3.0),
+        (500.0, 3.0, 0.5, 3.0),
+        (100.0, 10.0, 0.5, 3.0),
+        (100.0, 1.0, 0.5, 3.0),
+    ],
+)
+def test_calculate_eich2013_sol_power_decay_length(
+    p_plasma_separatrix_mw, rmajor, b_plasma_surface_poloidal_average, aspect
+):
+    """Test Eich 2013 SOL power decay length with various parameters."""
+    result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
+        p_plasma_separatrix_mw=p_plasma_separatrix_mw,
+        rmajor=rmajor,
+        b_plasma_surface_poloidal_average=b_plasma_surface_poloidal_average,
+        aspect=aspect,
+    )
+    assert isinstance(result, float)
+    assert result > 0
 
-    @staticmethod
-    def test_calculate_eich2013_sol_power_decay_length_nominal():
-        """Test Eich 2013 SOL power decay length with nominal values."""
-        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
-            p_plasma_separatrix_mw=100.0,
-            rmajor=3.0,
-            b_plasma_surface_poloidal_average=0.5,
-            aspect=3.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
 
-    @staticmethod
-    def test_calculate_eich2013_sol_power_decay_length_low_power():
-        """Test with low plasma separatrix power."""
-        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
-            p_plasma_separatrix_mw=10.0,
-            rmajor=3.0,
-            b_plasma_surface_poloidal_average=0.5,
-            aspect=3.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
+def test_calculate_eich2013_sol_power_decay_length_exact():
+    """Test Eich 2013 SOL power decay length with exact value check."""
+    result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
+        p_plasma_separatrix_mw=100.0,
+        rmajor=3.0,
+        b_plasma_surface_poloidal_average=0.5,
+        aspect=3.0,
+    )
+    assert isinstance(result, float)
+    assert pytest.approx(result) == 0.0015345296622855315
 
-    @staticmethod
-    def test_calculate_eich2013_sol_power_decay_length_high_power():
-        """Test with high plasma separatrix power."""
-        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
-            p_plasma_separatrix_mw=500.0,
-            rmajor=3.0,
-            b_plasma_surface_poloidal_average=0.5,
-            aspect=3.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
 
-    @staticmethod
-    def test_calculate_eich2013_sol_power_decay_length_large_rmajor():
-        """Test with large major radius."""
-        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
-            p_plasma_separatrix_mw=100.0,
-            rmajor=10.0,
-            b_plasma_surface_poloidal_average=0.5,
-            aspect=3.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
+@pytest.mark.parametrize(
+    ("p_plasma_separatrix_mw", "b_plasma_surface_poloidal_average"),
+    [
+        (100.0, 0.5),
+        (10.0, 0.5),
+        (500.0, 0.5),
+        (100.0, 2.0),
+    ],
+)
+def test_calculate_mast2014_sol_power_decay_length_1(
+    p_plasma_separatrix_mw, b_plasma_surface_poloidal_average
+):
+    """Test MAST 2014 SOL power decay length 1 with various parameters."""
+    result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
+        p_plasma_separatrix_mw=p_plasma_separatrix_mw,
+        b_plasma_surface_poloidal_average=b_plasma_surface_poloidal_average,
+    )
+    assert isinstance(result, float)
+    assert result > 0
 
-    @staticmethod
-    def test_calculate_eich2013_sol_power_decay_length_small_rmajor():
-        """Test with small major radius."""
-        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
-            p_plasma_separatrix_mw=100.0,
-            rmajor=1.0,
-            b_plasma_surface_poloidal_average=0.5,
-            aspect=3.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
 
-    @staticmethod
-    def test_calculate_mast2014_sol_power_decay_length_1_nominal():
-        """Test MAST 2014 SOL power decay length 1 with nominal values."""
-        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
-            p_plasma_separatrix_mw=100.0,
-            b_plasma_surface_poloidal_average=0.5,
-        )
-        assert isinstance(result, float)
-        assert result > 0
+def test_calculate_mast2014_sol_power_decay_length_1_exact():
+    """Test MAST 2014 SOL power decay length 1 with exact value check."""
+    result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
+        p_plasma_separatrix_mw=100.0,
+        b_plasma_surface_poloidal_average=0.5,
+    )
+    assert isinstance(result, float)
+    assert pytest.approx(result) == 0.006753333858250275
 
-    @staticmethod
-    def test_calculate_mast2014_sol_power_decay_length_1_low_power():
-        """Test MAST 2014 SOL power decay length 1 with low power."""
-        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
-            p_plasma_separatrix_mw=10.0,
-            b_plasma_surface_poloidal_average=0.5,
-        )
-        assert isinstance(result, float)
-        assert result > 0
 
-    @staticmethod
-    def test_calculate_mast2014_sol_power_decay_length_1_high_power():
-        """Test MAST 2014 SOL power decay length 1 with high power."""
-        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
-            p_plasma_separatrix_mw=500.0,
-            b_plasma_surface_poloidal_average=0.5,
-        )
-        assert isinstance(result, float)
-        assert result > 0
+@pytest.mark.parametrize(
+    ("p_plasma_separatrix_mw", "cur_plasma_ma"),
+    [
+        (100.0, 1.0),
+        (10.0, 1.0),
+        (500.0, 1.0),
+        (100.0, 3.0),
+    ],
+)
+def test_calculate_mast2014_sol_power_decay_length_2(
+    p_plasma_separatrix_mw, cur_plasma_ma
+):
+    """Test MAST 2014 SOL power decay length 2 with various parameters."""
+    result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
+        p_plasma_separatrix_mw=p_plasma_separatrix_mw,
+        cur_plasma_ma=cur_plasma_ma,
+    )
+    assert isinstance(result, float)
+    assert result > 0
 
-    @staticmethod
-    def test_calculate_mast2014_sol_power_decay_length_1_high_bpol():
-        """Test MAST 2014 SOL power decay length 1 with high poloidal field."""
-        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_1(
-            p_plasma_separatrix_mw=100.0,
-            b_plasma_surface_poloidal_average=2.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
 
-    @staticmethod
-    def test_calculate_mast2014_sol_power_decay_length_2_nominal():
-        """Test MAST 2014 SOL power decay length 2 with nominal values."""
-        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
-            p_plasma_separatrix_mw=100.0,
-            cur_plasma_ma=1.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
-
-    @staticmethod
-    def test_calculate_mast2014_sol_power_decay_length_2_low_power():
-        """Test MAST 2014 SOL power decay length 2 with low power."""
-        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
-            p_plasma_separatrix_mw=10.0,
-            cur_plasma_ma=1.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
-
-    @staticmethod
-    def test_calculate_mast2014_sol_power_decay_length_2_high_power():
-        """Test MAST 2014 SOL power decay length 2 with high power."""
-        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
-            p_plasma_separatrix_mw=500.0,
-            cur_plasma_ma=1.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
-
-    @staticmethod
-    def test_calculate_mast2014_sol_power_decay_length_2_high_current():
-        """Test MAST 2014 SOL power decay length 2 with high plasma current."""
-        result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
-            p_plasma_separatrix_mw=100.0,
-            cur_plasma_ma=3.0,
-        )
-        assert isinstance(result, float)
-        assert result > 0
+def test_calculate_mast2014_sol_power_decay_length_2_exact():
+    """Test MAST 2014 SOL power decay length 2 with exact value check."""
+    result = ScrapeOffLayer.calculate_mast2014_sol_power_decay_length_2(
+        p_plasma_separatrix_mw=100.0,
+        cur_plasma_ma=1.0,
+    )
+    assert isinstance(result, float)
+    assert pytest.approx(result) == 0.01258682517425542

--- a/tests/unit/models/physics/test_scrape_off_layer.py
+++ b/tests/unit/models/physics/test_scrape_off_layer.py
@@ -1,0 +1,65 @@
+from process.models.physics.scrape_off_layer import ScrapeOffLayer
+
+
+class TestScrapeOffLayer:
+    """Test suite for ScrapeOffLayer class."""
+
+    @staticmethod
+    def test_calculate_eich2013_sol_power_decay_length_nominal():
+        """Test Eich 2013 SOL power decay length with nominal values."""
+        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
+            p_plasma_separatrix_mw=100.0,
+            rmajor=3.0,
+            b_plasma_surface_poloidal_average=0.5,
+            aspect=3.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_eich2013_sol_power_decay_length_low_power():
+        """Test with low plasma separatrix power."""
+        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
+            p_plasma_separatrix_mw=10.0,
+            rmajor=3.0,
+            b_plasma_surface_poloidal_average=0.5,
+            aspect=3.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_eich2013_sol_power_decay_length_high_power():
+        """Test with high plasma separatrix power."""
+        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
+            p_plasma_separatrix_mw=500.0,
+            rmajor=3.0,
+            b_plasma_surface_poloidal_average=0.5,
+            aspect=3.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_eich2013_sol_power_decay_length_large_rmajor():
+        """Test with large major radius."""
+        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
+            p_plasma_separatrix_mw=100.0,
+            rmajor=10.0,
+            b_plasma_surface_poloidal_average=0.5,
+            aspect=3.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0
+
+    @staticmethod
+    def test_calculate_eich2013_sol_power_decay_length_small_rmajor():
+        """Test with small major radius."""
+        result = ScrapeOffLayer.calculate_eich2013_sol_power_decay_length(
+            p_plasma_separatrix_mw=100.0,
+            rmajor=1.0,
+            b_plasma_surface_poloidal_average=0.5,
+            aspect=3.0,
+        )
+        assert isinstance(result, float)
+        assert result > 0


### PR DESCRIPTION
This pull request introduces a new dedicated model for scrape-off layer (SOL) physics in the codebase, providing consistent calculation, storage, and output of SOL power decay lengths using established scalings. It also adds documentation and new plotting functionality to visualize and compare these quantities. The most important changes are grouped below.

---

### Scrape-off Layer Model Integration

* Added a new `ScrapeOffLayer` model (`process/models/physics/scrape_off_layer.py`) that implements calculation methods for three SOL power decay length scalings (Eich 2013, MAST 2014 I, MAST 2014 II), updates the data structure, and provides output routines.
* Integrated the `ScrapeOffLayer` model into the main workflow, including initialization in `main.py`, inclusion in the `Physics` model, and invocation in the main model sequence.

### Data Structure and Output

* Added new physics variables to store SOL power decay lengths in `PhysicsData` (`len_plasma_sol_eich13_power_decay`, `len_plasma_sol_mast14_power_decay_1`, `len_plasma_sol_mast14_power_decay_2`).
* Updated the divertor model to use the new SOL power decay length calculation and to instantiate the `ScrapeOffLayer` model. 

### Documentation

* Added a new documentation page describing the SOL power decay length scalings, equations, and references.
* Linked the new SOL documentation in the navigation menu.

### Visualization

* Added a new plotting function to visualize and compare the three SOL power decay length scalings, and included this plot in the summary page. 

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
