### PR TITLE
Add vaccum pump dataclass

### DIFF
--- a/process/models/vacuum.py
+++ b/process/models/vacuum.py
@@ -2,7 +2,7 @@
 
 import logging
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 
 import numpy as np
 
@@ -45,6 +45,22 @@ class VacuumPump:
     """Multiplier to convert conductance from gas species i to nitrogen"""
     description: str = ""
     """Description of the vacuum pump"""
+
+    def species(self):
+        """Yield species name, pump speed, and conductance multiplier.
+
+        Yields
+        ------
+        tuple[str, float, float]
+            Species name, volumetric flow rate, and conductance multiplier.
+        """
+        for species_field in fields(self.volflow_pump):
+            species_name = species_field.name
+            yield (
+                species_name,
+                getattr(self.volflow_pump, species_name),
+                getattr(self.xmult, species_name),
+            )
 
 
 @dataclass
@@ -361,18 +377,15 @@ class Vacuum(Model):
         #  thickness
         thcsh = thshldi / 3.0e0
 
-        #  Multiplier to convert conductance from gas species i to nitrogen
-        xmult = [1.0e0, 0.423e0, 0.378e0, 0.423e0]
-        # nitrogen, D-T, helium, D-T again
         nduct = ntf * ndiv
 
         #  Speed of high-vacuum pumps (m^3/s)
         # nitrogen, DT, helium, DT again
-        sp = (
-            [1.95, 1.8, 1.8, 1.8]
+        pump = (
+            TurbomolecularPump()
             if VacuumPumpType(self.data.vacuum.i_vacuum_pump_type)
             == VacuumPumpType.TURBOMOLECULAR
-            else [9.0, 25.0, 5.0, 25.0]
+            else CryoPump()
         )
 
         #  Calculate required pumping speeds
@@ -450,17 +463,22 @@ class Vacuum(Model):
         ceff = np.full(4, 1e-6)
         d = np.full(4, 1e-6)
 
-        for i in range(4):
-            sss = nduct / (1.0e0 / sp[i] / pumpn + 1.0e0 / cmax * xmult[i] / xmult[imax])
+        pump_species = tuple(pump.species())
+
+        for i, (_, volflow_pump_species, x_multiplier) in enumerate(pump_species):
+            sss = nduct / (
+                1.0e0 / volflow_pump_species / pumpn
+                + 1.0e0 / cmax * x_multiplier / pump_species[imax][2]
+            )
             if sss > s[i]:
                 continue
             imax = i
 
             ccc = 2.0e0 * s[i] / nduct
-            pumpn1 = 1.0e0 / (sp[i] * (nduct / s[i] - 1.0e0 / ccc))
-            pumpn2 = 1.01e0 * s[i] / (sp[i] * nduct)
+            pumpn1 = 1.0e0 / (volflow_pump_species * (nduct / s[i] - 1.0e0 / ccc))
+            pumpn2 = 1.01e0 * s[i] / (volflow_pump_species * nduct)
             pumpn = max(pumpn, pumpn1, pumpn2)
-            ceff[i] = 1.0e0 / (nduct / s[i] - 1.0e0 / (sp[i] * pumpn))
+            ceff[i] = 1.0e0 / (nduct / s[i] - 1.0e0 / (volflow_pump_species * pumpn))
 
             ceff, nflag, d1max = self._newton_method_duct_diameter(
                 d, i, s, xmult, l1, l2, l3, ntf, r0, aw, ritf, thcsh, ceff

--- a/process/models/vacuum.py
+++ b/process/models/vacuum.py
@@ -16,7 +16,7 @@ from process.models.engineering.ivc_functions import dshellvol, eshellvol
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class VacuumSpecies:
     """Dataclass for different particle species in the vacuum system"""
 
@@ -26,7 +26,7 @@ class VacuumSpecies:
     deuterium_tritium_again: float
 
 
-@dataclass
+@dataclass(frozen=True)
 class VacuumPump:
     """Base dataclass for vacuum pump specifications"""
 
@@ -63,7 +63,7 @@ class VacuumPump:
             )
 
 
-@dataclass
+@dataclass(frozen=True)
 class TurbomolecularPump(VacuumPump):
     """Turbomolecular pump with magnetic bearing specifications
 
@@ -84,7 +84,7 @@ class TurbomolecularPump(VacuumPump):
     )
 
 
-@dataclass
+@dataclass(frozen=True)
 class CryoPump(VacuumPump):
     """Compound cryopump specifications
 

--- a/process/models/vacuum.py
+++ b/process/models/vacuum.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+from dataclasses import dataclass, field
 
 import numpy as np
 
@@ -13,6 +14,68 @@ from process.models.build import FwBlktVVShape
 from process.models.engineering.ivc_functions import dshellvol, eshellvol
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VacuumFlowRates:
+    """Dataclass for vacuum pump flow rates for different gases in m³/s"""
+
+    nitrogen: float
+    deuterium_tritium: float
+    helium: float
+    deuterium_tritium_again: float
+
+
+@dataclass
+class VacuumPump:
+    """Base dataclass for vacuum pump specifications"""
+
+    name: str
+    """Name of the vacuum pump type"""
+    volflow_pump: VacuumFlowRates
+    """Volumetric flow rates of the vacuum pump for different gases in m³/s"""
+    description: str = ""
+    """Description of the vacuum pump"""
+
+
+@dataclass
+class TurbomolecularPump(VacuumPump):
+    """Turbomolecular pump with magnetic bearing specifications
+
+    Nominal speed of 2.0 m^3/s
+    """
+
+    name: str = "Turbomolecular"
+    volflow_pump: VacuumFlowRates = field(
+        default_factory=lambda: VacuumFlowRates(
+            nitrogen=1.95,
+            deuterium_tritium=1.8,
+            helium=1.8,
+            deuterium_tritium_again=1.8,
+        )
+    )
+    description: str = (
+        "Turbomolecular pump (magnetic bearing) with nominal speed 2.0 m³/s"
+    )
+
+
+@dataclass
+class CryoPump(VacuumPump):
+    """Compound cryopump specifications
+
+    Nominal speed of 10 m³/s
+    """
+
+    name: str = "Cryopump"
+    volflow_pump: VacuumFlowRates = field(
+        default_factory=lambda: VacuumFlowRates(
+            nitrogen=9.0,
+            deuterium_tritium=25.0,
+            helium=5.0,
+            deuterium_tritium_again=25.0,
+        )
+    )
+    description: str = "Compound cryopump with nominal speed 10 m³/s"
 
 
 class Vacuum(Model):

--- a/process/models/vacuum.py
+++ b/process/models/vacuum.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class VacuumFlowRates:
-    """Dataclass for vacuum pump flow rates for different gases in m³/s"""
+class VacuumSpecies:
+    """Dataclass for different particle species in the vacuum system"""
 
     nitrogen: float
     deuterium_tritium: float
@@ -32,8 +32,17 @@ class VacuumPump:
 
     name: str
     """Name of the vacuum pump type"""
-    volflow_pump: VacuumFlowRates
+    volflow_pump: VacuumSpecies
     """Volumetric flow rates of the vacuum pump for different gases in m³/s"""
+    xmult: VacuumSpecies = field(
+        default_factory=lambda: VacuumSpecies(
+            nitrogen=1.0e0,
+            deuterium_tritium=0.423e0,
+            helium=0.378e0,
+            deuterium_tritium_again=0.423e0,
+        )
+    )
+    """Multiplier to convert conductance from gas species i to nitrogen"""
     description: str = ""
     """Description of the vacuum pump"""
 
@@ -46,8 +55,8 @@ class TurbomolecularPump(VacuumPump):
     """
 
     name: str = "Turbomolecular"
-    volflow_pump: VacuumFlowRates = field(
-        default_factory=lambda: VacuumFlowRates(
+    volflow_pump: VacuumSpecies = field(
+        default_factory=lambda: VacuumSpecies(
             nitrogen=1.95,
             deuterium_tritium=1.8,
             helium=1.8,
@@ -67,8 +76,8 @@ class CryoPump(VacuumPump):
     """
 
     name: str = "Cryopump"
-    volflow_pump: VacuumFlowRates = field(
-        default_factory=lambda: VacuumFlowRates(
+    volflow_pump: VacuumSpecies = field(
+        default_factory=lambda: VacuumSpecies(
             nitrogen=9.0,
             deuterium_tritium=25.0,
             helium=5.0,


### PR DESCRIPTION
This pull request refactors the vacuum pump modeling in `process/models/vacuum.py` to use structured dataclasses for pump and gas species properties, replacing the previous use of raw lists and constants. This makes the code more maintainable, readable, and less error-prone. The main computational logic is updated to use these new dataclasses, improving clarity and extensibility.

**Vacuum pump and species modeling:**
* Introduced new frozen dataclasses: `VacuumSpecies` (to represent gas species parameters) and `VacuumPump` (as a base for pump specifications), along with concrete subclasses `TurbomolecularPump` and `CryoPump` for specific pump types. These replace hardcoded lists and constants for pump and species properties.
* The selection and use of pump specifications in the `vacuum` function now instantiate and use these dataclasses instead of raw lists.

**Computational logic updates:**
* Updated all calculations in the `vacuum` function to access pump speeds and conductance multipliers via the new dataclass structure, improving code clarity and reducing indexing errors. [[1]](diffhunk://#diff-35c2f5fd3bd05bc9eada48497db2b793c716dc32bcd84ba6082a3c5536dd2c24L406-R505) [[2]](diffhunk://#diff-35c2f5fd3bd05bc9eada48497db2b793c716dc32bcd84ba6082a3c5536dd2c24L443-R538) [[3]](diffhunk://#diff-35c2f5fd3bd05bc9eada48497db2b793c716dc32bcd84ba6082a3c5536dd2c24L507-R603)

**General improvements:**
* Added the necessary imports for `dataclasses` and related utilities to support the new structure.## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
