### PR TITLE
WIP:  Organise TF coil variables and create resistive tf coil data class

### DIFF
--- a/process/core/input.py
+++ b/process/core/input.py
@@ -499,8 +499,8 @@ INPUT_VARIABLES = {
     "f_radius_beam_tangency_rmajor": InputVariable(
         "current_drive", float, range=(0.5, 2.0)
     ),
-    "frhocp": InputVariable("tfcoil", float, range=(0.01, 5.0)),
-    "frholeg": InputVariable("tfcoil", float, range=(0.01, 5.0)),
+    "frhocp": InputVariable("resistive_tfcoil", float, range=(0.01, 5.0)),
+    "frholeg": InputVariable("resistive_tfcoil", float, range=(0.01, 5.0)),
     "fseppc": InputVariable("build", float, range=(1000000.0, 1000000000.0)),
     "fvoldw": InputVariable("fwbs", float, range=(0.0, 10.0)),
     "fvolsi": InputVariable("fwbs", float, range=(0.0, 10.0)),
@@ -725,7 +725,7 @@ INPUT_VARIABLES = {
     ),
     "redun_vacp": InputVariable("costs", float, range=(0.0, 100.0)),
     "residual_sig_hoop": InputVariable("cs_fatigue", float, range=(0.0, 1000000000.0)),
-    "rho_tf_bus": InputVariable("tfcoil", float, range=(0.0, 1e-05)),
+    "rho_tf_bus": InputVariable("resistive_tfcoil", float, range=(0.0, 1e-05)),
     "rho_tf_joints": InputVariable("tfcoil", float, range=(0.0, 0.01)),
     "radius_plasma_pedestal_density_norm": InputVariable(
         "physics", float, range=(0.01, 1.0)

--- a/process/core/model.py
+++ b/process/core/model.py
@@ -30,6 +30,7 @@ from process.data_structure.primary_pumping_variables import PrimaryPumpingData
 from process.data_structure.pulse_variables import PulseData
 from process.data_structure.rebco_variables import RebcoData
 from process.data_structure.reinke_variables import ReinkeData
+from process.data_structure.resistive_tf_coil_variables import ResistiveTFData
 from process.data_structure.scan_variables import ScanData
 from process.data_structure.stellarator_configuration import StellaratorConfigData
 from process.data_structure.stellarator_variables import StellaratorData
@@ -82,6 +83,7 @@ class DataStructure:
     rebco: RebcoData = initialise_later
     tfcoil: TFData = initialise_later
     superconducting_tfcoil: SuperconductingTFData = initialise_later
+    resistive_tfcoil: ResistiveTFData = initialise_later
     globals: GlobalData = initialise_later
     scan: ScanData = initialise_later
     numerics: NumericsData = initialise_later

--- a/process/core/solver/constraints.py
+++ b/process/core/solver/constraints.py
@@ -695,7 +695,10 @@ def constraint_equation_19(constraint_registration, data):
     p_tf_leg_resistive_mw: TF coil outboard leg resistive power (total) (MW)
     mvalim: MVA limit for resistive TF coil set (total) (MW)
     """
-    totmva = data.tfcoil.p_cp_resistive_mw + data.tfcoil.p_tf_leg_resistive_mw
+    totmva = (
+        data.resistive_tfcoil.p_cp_resistive_mw
+        + data.resistive_tfcoil.p_tf_leg_resistive_mw
+    )
 
     return leq(totmva, data.constraints.mvalim, constraint_registration)
 

--- a/process/data_structure/resistive_tf_coil_variables.py
+++ b/process/data_structure/resistive_tf_coil_variables.py
@@ -1,0 +1,51 @@
+"""Module containing variables for the resistive TF coil models"""
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ResistiveTFData:
+    """Dataclass holding resistive TF coil variables"""
+
+    a_res_tf_coil_conductor: float = 0.0
+    """Area of resistive conductor in resistive TF coil [m2]"""
+
+    cdtfleg: float = 0.0  # questioning this
+    """TF outboard leg current density (A/m2)"""
+
+    res_tf_leg: float = 0.0
+    """TF coil leg resistance (ohm)"""
+
+    p_cp_resistive_mw: float = 0.0
+    """Peak resistive TF coil inboard leg power (MW)"""
+
+    p_tf_joints_resistive_mw: float = 0.0
+    """TF joints resistive power losses (MW)"""
+
+    p_tf_leg_resistive_mw: float = 0.0
+    """TF coil outboard leg resistive power (MW)"""
+
+    rho_cp: float = 0.0
+    """TF coil inboard leg resistivity [Ohm-m]. If `itart=0`, this variable is the
+    average resistivity over the whole magnet
+    """
+
+    rho_tf_leg: float = 0.0
+    """Resistivity of a TF coil leg (Ohm-m)"""
+
+    rho_tf_bus: float = 1.86e-8
+    """Resistivity of a TF coil bus (Ohm-m). Default values is for that of GLIDCOP AL-15 (C15715) at 293K"""
+
+    frhocp: float = 1.0
+    """Centrepost resistivity enhancement factor. For `itart=0`, this factor
+    is used for the whole magnet
+    """
+
+    frholeg: float = 1.0
+    """Outboard legs resistivity enhancement factor. Only used for `itart=1`."""
+
+    p_tf_joints_resistive: float = 0.0
+    """Calculated TF joints resistive power losses [W]"""
+
+    vtfkv: float = 0.0
+    """TF coil voltage for resistive coil including bus (kV)"""

--- a/process/data_structure/superconducting_tf_coil_variables.py
+++ b/process/data_structure/superconducting_tf_coil_variables.py
@@ -48,6 +48,9 @@ class SuperconductingTFData:
     a_tf_coil_inboard_insulation: float = 0.0
     """Inboard coil insulation cross-section per coil [m²]"""
 
+    a_tf_turn_insulation: float = 0.0
+    """single turn insulation area (m2)"""
+
     f_a_tf_coil_inboard_steel: float = 0.0
     """Inboard coil steel fraction [-]"""
 

--- a/process/data_structure/tfcoil_variables.py
+++ b/process/data_structure/tfcoil_variables.py
@@ -28,16 +28,10 @@ class TFData:
     Does not include the area of voids and central helium channel
     """
 
-    a_res_tf_coil_conductor: float = 0.0
-    """Area of resistive conductor in resistive TF coil [m2]"""
-
     a_tf_turn_cable_space_no_void: float = 0.0
     """Cable space area (per turn)  [m2]
     Includes the area of voids and central helium channel
     """
-
-    a_tf_turn_insulation: float = 0.0
-    """single turn insulation area (m2)"""
 
     a_tf_coil_wp_turn_insulation: float = 0.0
     """winding pack turn insulation area per coil (m2)"""
@@ -60,7 +54,7 @@ class TFData:
     a_tf_wp_coolant_channels: float = 0.0
     """winding pack He coil area (m2)"""
 
-    bcritsc: float = 24.0
+    bcritsc: float = 24.0  # superconducting
     """upper critical field (T) for Nb3Sn superconductor at zero temperature and
     strain (`i_tf_sc_mat=4, =bc20m`)
     """
@@ -95,17 +89,17 @@ class TFData:
     tfc_sidewall_is_fraction: bool = False
     """logical switch to make dx_tf_side_case_min a fraction of TF coil thickness (`casths_fraction`)"""
 
-    t_conductor: float = 0.0
+    t_conductor: float = 0.0  # superconducting
     """Conductor (cable + steel conduit) area averaged dimension [m]"""
 
-    dx_tf_turn_general: float = 0.0
+    dx_tf_turn_general: float = 0.0  # superconducting
     """TF coil turn edge length including turn insulation [m]
     If the turn is not a square (i_tf_turns_integer = 1) a squared turn of
     equivalent size is use to calculated this quantity
     If the dx_tf_turn_general is non zero, c_tf_turn is calculated
     """
 
-    i_dx_tf_turn_general_input: bool = False
+    i_dx_tf_turn_general_input: bool = False  # superconducting
     """Boolean switch to activated when the user set the TF coil turn dimensions
     Not an input
     """
@@ -117,23 +111,20 @@ class TFData:
     constraint equation icc = 86
     """
 
-    dx_tf_turn_cable_space_general: float = 0.0
+    dx_tf_turn_cable_space_general: float = 0.0  # superconducting
     """TF coil superconducting cable squared/rounded dimensions [m]
     If the turn is not a square (i_tf_turns_integer = 1) a squared cable of
     equivalent size is use to calculated this quantity
     If the dx_tf_turn_cable_space_general is non zero, c_tf_turn is calculated
     """
 
-    i_dx_tf_turn_cable_space_general_input: bool = False
+    i_dx_tf_turn_cable_space_general_input: bool = False  # superconducting
     """Boolean switch to activated when the user set the TF coil cable dimensions
     Not an input
     """
 
-    acs: float = 0.0
+    acs: float = 0.0  # superconducting
     """Area of space inside conductor (m2)"""
-
-    cdtfleg: float = 0.0
-    """TF outboard leg current density (A/m2) (resistive coils only)"""
 
     cforce: float = 0.0
     """centering force on inboard leg (per coil) (N/m)"""
@@ -184,10 +175,10 @@ class TFData:
     e_tf_coil_magnetic_stored: float = 0.0
     """Stored magnetic energy in a single TF coil (J)"""
 
-    b_crit_upper_nbti: float = 14.86
+    b_crit_upper_nbti: float = 14.86  # superconducting
     """upper critical field of GL_nbti"""
 
-    t_crit_nbti: float = 9.04
+    t_crit_nbti: float = 9.04  # superconducting
     """critical temperature of GL_nbti"""
 
     max_force_density: float = 0.0
@@ -198,7 +189,7 @@ class TFData:
     (iteration variable 59)
     """
 
-    fhts: float = 0.5
+    fhts: float = 0.5  # superconductor
     """technology adjustment factor for critical current density fit for isumat..=2
     Bi-2212 superconductor, to describe the level of technology assumed (i.e. to
     account for stress, fatigue, radiation, AC losses, joints or manufacturing
@@ -243,7 +234,7 @@ class TFData:
     1 : integer turns
     """
 
-    i_tf_sc_mat: int = 1
+    i_tf_sc_mat: int = 1  # superconductor
     """Switch for superconductor material in TF coils:
     - =1 ITER Nb3Sn critical surface model with standard
     ITER parameters
@@ -272,7 +263,7 @@ class TFData:
     - =2  Picture frame coils
     """
 
-    i_tf_cond_eyoung_axial: int = 0
+    i_tf_cond_eyoung_axial: int = 0  # superconductor
     """Switch for the behavior of the TF coil conductor elastic axial properties
     - =0  Young's modulus is set to zero, and the conductor is not considered
     in the stress calculation. This corresponds to the case that the
@@ -284,7 +275,7 @@ class TFData:
     account the superconducting material `i_tf_sc_mat`
     """
 
-    i_tf_cond_eyoung_trans: int = 1
+    i_tf_cond_eyoung_trans: int = 1  # superconductor
     """Switch for the behavior of the elastic properties of the TF coil
     conductor in the transverse direction. Only active if
     `i_tf_cond_eyoung_axial == 2`
@@ -294,10 +285,10 @@ class TFData:
     which is set to a sensible material-dependent default.
     """
 
-    n_tf_wp_pancakes: int = 10
+    n_tf_wp_pancakes: int = 10  # superconductor
     """Number of pancakes in TF coil. Only used if `i_tf_turns_integer=1`"""
 
-    n_tf_wp_layers: int = 20
+    n_tf_wp_layers: int = 20  # superconductor
     """Number of layers in TF coil. Only used if `i_tf_turns_integer=1`"""
 
     n_rad_per_layer: int = 100
@@ -305,7 +296,7 @@ class TFData:
     quantities (stresses, strain displacement etc..)
     """
 
-    i_tf_bucking: int = -1
+    i_tf_bucking: int = 1
     """Switch for TF inboard support structure design:
     Default setting for backward compatibility
     - if copper resistive TF (i_tf_sup = 0) : Free standing TF without bucking structure
@@ -345,7 +336,7 @@ class TFData:
     j_tf_bus: float = 1.25e6
     """bussing current density (A/m2)"""
 
-    j_crit_str_tf: float = 0.0
+    j_crit_str_tf: float = 0.0  # superconductor
     """j_crit_str : superconductor strand critical current density under operating
     conditions (A/m2). Necessary for the cost calculation in $/kAm
     """
@@ -367,10 +358,10 @@ class TFData:
     Necessary for the cost calculation in $/kAm
     """
 
-    j_tf_wp_critical: float = 0.0
+    j_tf_wp_critical: float = 0.0  # superconducting
     """critical current density for winding pack (A/m2)"""
 
-    j_tf_wp_quench_heat_max: float = 0.0
+    j_tf_wp_quench_heat_max: float = 0.0  # supercondcuting
     """allowable TF coil winding pack current density, for dump temperature rise protection (A/m2)"""
 
     j_tf_wp: float = 0.0
@@ -436,9 +427,6 @@ class TFData:
     r_b_tf_inboard_peak: float = 0.0
     """Radius of maximum TF B-field (m)"""
 
-    res_tf_leg: float = 0.0
-    """TF coil leg resistance (ohm)"""
-
     toroidalgap: float = 1.0
     """Minimal distance between two toroidal coils. (m)"""
 
@@ -479,13 +467,13 @@ class TFData:
 
     sig_tf_wp: float = 0.0
 
-    str_cs_con_res: float = -0.005
+    str_cs_con_res: float = -0.005  # superconductor?
     """Residual manufacturing strain in CS superconductor material"""
 
-    str_pf_con_res: float = -0.005
+    str_pf_con_res: float = -0.005  # superconuctor?
     """Residual manufacturing strain in PF superconductor material"""
 
-    str_tf_con_res: float = -0.005
+    str_tf_con_res: float = -0.005  # supercondcutor?
     """Residual manufacturing strain in TF superconductor material
     If `i_str_wp == 0`, used to compute the critical surface.
     Otherwise, the self-consistent winding pack `str_wp` is used.
@@ -512,7 +500,7 @@ class TFData:
     - =1  str_wp is used
     """
 
-    quench_model: str = "exponential"
+    quench_model: str = "exponential"  # superconductor?
     """switch for TF coil quench model (Only applies to REBCO magnet at present, issue #522):
     - ='exponential' exponential quench with constant discharge resistor
     - ='linear' quench with constant voltage
@@ -521,10 +509,10 @@ class TFData:
     time1: float = 0
     """Time at which TF quench is detected (s)"""
 
-    tcritsc: float = 16.0
+    tcritsc: float = 16.0  # superconductor
     """critical temperature (K) for superconductor at zero field and strain (`i_tf_sc_mat=4, =tc0m`)"""
 
-    t_tf_superconductor_quench: float = 10.0
+    t_tf_superconductor_quench: float = 10.0  # superductor
     """fast discharge time for TF coil in event of quench (s) (`iteration variable 56`)
     For REBCO model, meaning depends on quench_model:
     - exponential quench : e-folding time (s)`
@@ -546,12 +534,6 @@ class TFData:
     tfcmw: float = 0.0
     """Peak power per TF power supply (MW)"""
 
-    p_cp_resistive_mw: float = 0.0
-    """Peak resistive TF coil inboard leg power (MW)"""
-
-    p_tf_joints_resistive_mw: float = 0.0
-    """TF joints resistive power losses (MW)"""
-
     tfcryoarea: float = 0.0
     """surface area of toroidal shells covering TF coils (m2)"""
 
@@ -563,28 +545,6 @@ class TFData:
 
     dx_tf_wp_insertion_gap: float = 0.01
     """TF coil WP insertion gap (m)"""
-
-    p_tf_leg_resistive_mw: float = 0.0
-    """TF coil outboard leg resistive power (MW)"""
-
-    rho_cp: float = 0.0
-    """TF coil inboard leg resistivity [Ohm-m]. If `itart=0`, this variable is the
-    average resistivity over the whole magnet
-    """
-
-    rho_tf_leg: float = 0.0
-    """Resistivity of a TF coil leg (Ohm-m)"""
-
-    rho_tf_bus: float = 1.86e-8
-    """Resistivity of a TF coil bus (Ohm-m). Default values is for that of GLIDCOP AL-15 (C15715) at 293K"""
-
-    frhocp: float = 1.0
-    """Centrepost resistivity enhancement factor. For `itart=0`, this factor
-    is used for the whole magnet
-    """
-
-    frholeg: float = 1.0
-    """Outboard legs resistivity enhancement factor. Only used for `itart=1`."""
 
     i_cp_joints: int = -1
     """Switch for CP demountable joints type
@@ -608,9 +568,6 @@ class TFData:
 
     th_joint_contact: float = 0.03
     """TF sliding joints contact pad width [m]"""
-
-    p_tf_joints_resistive: float = 0.0
-    """Calculated TF joints resistive power losses [W]"""
 
     len_tf_coil: float = 0.0
     """TF coil circumference (m)"""
@@ -643,7 +600,7 @@ class TFData:
     dx_tf_turn_insulation: float = 8e-4
     """conduit insulation thickness (m)"""
 
-    layer_ins: float = 0.0
+    layer_ins: float = 0.0  # superconducting
     """Additional insulation thickness between layers (m)"""
 
     dr_tf_nose_case: float = 0.3
@@ -670,28 +627,28 @@ class TFData:
     Rem : Thickness calculated for stellarators.
     """
 
-    temp_tf_superconductor_margin_min: float = 0.0
+    temp_tf_superconductor_margin_min: float = 0.0  # superconducting
     """minimum allowable temperature margin : TF coils (K)"""
 
-    temp_cs_superconductor_margin_min: float = 0.0
+    temp_cs_superconductor_margin_min: float = 0.0  # superconducting
     """minimum allowable temperature margin : CS (K)"""
 
-    tmargmin: float = 0.0
+    tmargmin: float = 0.0  # superconducting
     """minimum allowable temperature margin : TFC AND CS (K)"""
 
-    temp_margin: float = 0.0
+    temp_margin: float = 0.0  # superconducting
     """temperature margin (K)"""
 
-    temp_tf_superconductor_margin: float = 0.0
+    temp_tf_superconductor_margin: float = 0.0  # superconducting
     """TF coil superconductor temperature margin (K)"""
 
-    temp_tf_conductor_quench_max: float = 150.0
+    temp_tf_conductor_quench_max: float = 150.0  # superconductor
     """maximum temp during a quench for protection (K)"""
 
-    temp_croco_quench_max: float = 200.0
+    temp_croco_quench_max: float = 200.0  # superconductor
     """CroCo strand: maximum permitted temp during a quench (K)"""
 
-    temp_croco_quench: float = 0.0
+    temp_croco_quench: float = 0.0  # superconductor
     """CroCo strand: Actual temp reached during a quench (K)"""
 
     temp_tf_cryo: float = 4.5
@@ -700,7 +657,7 @@ class TFData:
     n_tf_coil_turns: float = 0.0
     """number of turns per TF coil"""
 
-    v_tf_coil_dump_quench_max_kv: float = 20.0
+    v_tf_coil_dump_quench_max_kv: float = 20.0  # superconducting
     """max voltage across TF coil during quench (kV) (`iteration variable 52`)"""
 
     vforce: float = 0.0
@@ -714,22 +671,19 @@ class TFData:
     vforce_outboard: float = 0.0
     """Vertical tension on outboard leg/coil (N)"""
 
-    f_a_tf_turn_cable_space_extra_void: float = 0.4
+    f_a_tf_turn_cable_space_extra_void: float = 0.4  # superconductor
     """coolant fraction of TFC 'cable' (`i_tf_sup=1`), or of TFC leg (`i_tf_sup=0`)"""
 
     voltfleg: float = 0.0
     """volume of each TF coil outboard leg (m3)"""
 
-    vtfkv: float = 0.0
-    """TF coil voltage for resistive coil including bus (kV)"""
-
-    v_tf_coil_dump_quench_kv: float = 0.0
+    v_tf_coil_dump_quench_kv: float = 0.0  # superconductor
     """voltage across a TF coil during quench (kV)"""
 
     m_tf_coil_case: float = 0.0
     """mass per coil of external case (kg)"""
 
-    m_tf_coil_conductor: float = 0.0
+    m_tf_coil_conductor: float = 0.0  # superconductor?
     """TF coil conductor mass per coil (kg/coil).
     For `itart=1`, coil is return limb plus centrepost/n_tf_coils
     """

--- a/process/models/power.py
+++ b/process/models/power.py
@@ -1067,7 +1067,7 @@ class Power(Model):
             self.data.heat_transport.helpow_cryal = (
                 self.data.tfcoil.p_cp_resistive
                 + self.data.tfcoil.p_tf_leg_resistive
-                + self.data.tfcoil.p_tf_joints_resistive
+                + self.data.resistive_tfcoil.p_tf_joints_resistive
                 + self.data.fwbs.pnuc_cp_tf * 1.0e6
             )
 
@@ -2109,11 +2109,13 @@ class Power(Model):
             a_tf_bus = self.data.tfcoil.c_tf_turn / self.data.tfcoil.j_tf_bus
 
             # Bus resistance [ohm]
-            # Bus resistivity (self.data.tfcoil.rho_tf_bus)
+            # Bus resistivity (self.data.resistive_tfcoil.rho_tf_bus)
             # Issue #1253: there was a fudge here to set the bus bar resistivity equal
             # to the TF conductor resistivity. I have removed this.
             tfbusres = (
-                self.data.tfcoil.rho_tf_bus * self.data.tfcoil.len_tf_bus / a_tf_bus
+                self.data.resistive_tfcoil.rho_tf_bus
+                * self.data.tfcoil.len_tf_bus
+                / a_tf_bus
             )
 
             #  Bus mass (kg)
@@ -2123,7 +2125,7 @@ class Power(Model):
 
             #  Total maximum impedance MDK actually just fixed resistance
             res_tf_system_total = (
-                self.data.tfcoil.n_tf_coils * self.data.tfcoil.res_tf_leg
+                self.data.tfcoil.n_tf_coils * self.data.resistive_tfcoil.res_tf_leg
                 + (self.data.tfcoil.p_cp_resistive / self.data.tfcoil.c_tf_total**2)
                 + tfbusres
             )
@@ -2131,7 +2133,7 @@ class Power(Model):
             #  No reactive portion of the voltage is included here - assume long
             #  ramp times
             #  MDK This is steady state voltage, not "peak" voltage
-            self.data.tfcoil.vtfkv = (
+            self.data.resistive_tfcoil.vtfkv = (
                 1.0e-3
                 * res_tf_system_total
                 * self.data.tfcoil.c_tf_turn
@@ -2139,14 +2141,14 @@ class Power(Model):
             )
 
             # Resistive powers (MW):
-            self.data.tfcoil.p_cp_resistive_mw = (
+            self.data.resistive_tfcoil.p_cp_resistive_mw = (
                 1.0e-6 * self.data.tfcoil.p_cp_resistive
             )  # inboard legs (called centrepost, CP for tart design)
-            self.data.tfcoil.p_tf_leg_resistive_mw = (
+            self.data.resistive_tfcoil.p_tf_leg_resistive_mw = (
                 1.0e-6 * self.data.tfcoil.p_tf_leg_resistive
             )  # outboard legs
-            self.data.tfcoil.p_tf_joints_resistive_mw = (
-                1.0e-6 * self.data.tfcoil.p_tf_joints_resistive
+            self.data.resistive_tfcoil.p_tf_joints_resistive_mw = (
+                1.0e-6 * self.data.resistive_tfcoil.p_tf_joints_resistive
             )  # Joints
             tfbusmw = (
                 1.0e-6 * self.data.tfcoil.c_tf_turn**2 * tfbusres
@@ -2164,11 +2166,11 @@ class Power(Model):
 
             # Total power consumption (MW)
             self.data.tfcoil.tfcmw = (
-                self.data.tfcoil.p_cp_resistive_mw
-                + self.data.tfcoil.p_tf_leg_resistive_mw
+                self.data.resistive_tfcoil.p_cp_resistive_mw
+                + self.data.resistive_tfcoil.p_tf_leg_resistive_mw
                 + tfbusmw
                 + tfreacmw
-                + self.data.tfcoil.p_tf_joints_resistive_mw
+                + self.data.resistive_tfcoil.p_tf_joints_resistive_mw
             )
 
             # Total steady state AC power demand (MW)
@@ -2218,7 +2220,7 @@ class Power(Model):
             self.outfile,
             "Steady-state voltage per coil (kV)",
             "(vtfkv)",
-            self.data.tfcoil.vtfkv,
+            self.data.resistive_tfcoil.vtfkv,
             "OP ",
         )
         # po.ovarre(outfile,'Peak power (MW)','(tfcmw..)',tfcmw)
@@ -2233,14 +2235,14 @@ class Power(Model):
             self.outfile,
             "Power dissipation in TF coil set: inboard legs (MW)",
             "(p_cp_resistive_mw)",
-            self.data.tfcoil.p_cp_resistive_mw,
+            self.data.resistive_tfcoil.p_cp_resistive_mw,
             "OP ",
         )
         po.ovarre(
             self.outfile,
             "Power dissipation in TF coil set: outboard legs (MW)",
             "(p_tf_leg_resistive_mw)",
-            self.data.tfcoil.p_tf_leg_resistive_mw,
+            self.data.resistive_tfcoil.p_tf_leg_resistive_mw,
             "OP ",
         )
         po.ovarre(
@@ -2255,7 +2257,7 @@ class Power(Model):
                 self.outfile,
                 "Power dissipation in TF coil set: joints",
                 "(p_tf_joints_resistive_mw)",
-                self.data.tfcoil.p_tf_joints_resistive_mw,
+                self.data.resistive_tfcoil.p_tf_joints_resistive_mw,
                 "OP ",
             )
 
@@ -2300,7 +2302,7 @@ class Power(Model):
             self.data.tfcoil.n_tf_coils,
             self.data.tfcoil.v_tf_coil_dump_quench_kv,
             ettfmj,
-            self.data.tfcoil.res_tf_leg,
+            self.data.resistive_tfcoil.res_tf_leg,
         )
 
     def tfcpwr(
@@ -2373,7 +2375,7 @@ class Power(Model):
 
         #  Total resistance of TF bus, ohms
         # rtfbus = 2.62e-4 * len_tf_bus / albusa
-        rtfbus = self.data.tfcoil.rho_tf_bus * len_tf_bus / (albusa / 10000)
+        rtfbus = self.data.resistive_tfcoil.rho_tf_bus * len_tf_bus / (albusa / 10000)
 
         #  Total voltage drop across TF bus, volts
         vtfbus = 1000.0e0 * itfka * rtfbus

--- a/process/models/tfcoil/base.py
+++ b/process/models/tfcoil/base.py
@@ -1554,7 +1554,7 @@ class TFCoil(Model):
                 self.outfile,
                 "Average conductor resistivity (ohm.m)",
                 "(rho_cp)",
-                self.data.tfcoil.rho_cp,
+                self.data.resistive_tfcoil.rho_cp,
             )
             po.ovarre(
                 self.outfile,

--- a/process/models/tfcoil/resistive.py
+++ b/process/models/tfcoil/resistive.py
@@ -361,7 +361,7 @@ class ResistiveTFCoil(TFCoil):
         )
 
         # Exact mid-plane cross-section area of the conductor per TF coil [m2]
-        self.data.tfcoil.a_res_tf_coil_conductor = np.pi * (
+        self.data.resistive_tfcoil.a_res_tf_coil_conductor = np.pi * (
             (
                 self.data.superconducting_tfcoil.r_tf_wp_inboard_outer
                 - self.data.tfcoil.dx_tf_wp_insulation
@@ -385,12 +385,14 @@ class ResistiveTFCoil(TFCoil):
             self.data.tfcoil.dx_tf_wp_insulation
             + self.data.tfcoil.dx_tf_turn_insulation * self.data.tfcoil.n_tf_coil_turns
         )
-        self.data.tfcoil.a_res_tf_coil_conductor *= 1.0e0 - self.data.tfcoil.fcoolcp
+        self.data.resistive_tfcoil.a_res_tf_coil_conductor *= (
+            1.0e0 - self.data.tfcoil.fcoolcp
+        )
 
         # Inter turn insulation area per coil [m2]
         self.data.tfcoil.a_tf_coil_wp_turn_insulation = (
             self.data.superconducting_tfcoil.a_tf_wp_no_insulation
-            - self.data.tfcoil.a_res_tf_coil_conductor
+            - self.data.resistive_tfcoil.a_res_tf_coil_conductor
             / (1.0e0 - self.data.tfcoil.fcoolcp)
         )
 
@@ -478,17 +480,17 @@ class ResistiveTFCoil(TFCoil):
         """
         # Resistivity of the Glidcop copper centerpost
         if self.data.tfcoil.i_tf_sup == TFConductorModel.WATER_COOLED_COPPER:
-            self.data.tfcoil.rho_cp = (
+            self.data.resistive_tfcoil.rho_cp = (
                 # 1.86 is the resistivity at `20°C` for GLIDCOP AL-15
                 # 0.00393 is the coefficient of resistivity for copper
-                self.data.tfcoil.frhocp
+                self.data.resistive_tfcoil.frhocp
                 * (1.86e0 + 0.00393e0 * (self.data.tfcoil.temp_cp_average - 293.15e0))
                 * 1.0e-8
             )
 
         # Resistivity of the aluminium centerpost
         if self.data.tfcoil.i_tf_sup == TFConductorModel.HELIUM_COOLED_ALUMINIUM:
-            self.data.tfcoil.rho_cp = self.data.tfcoil.frhocp * (
+            self.data.resistive_tfcoil.rho_cp = self.data.resistive_tfcoil.frhocp * (
                 2.00016e-14 * self.data.tfcoil.temp_cp_average**3
                 - 6.75384e-13 * self.data.tfcoil.temp_cp_average**2
                 + 8.89159e-12 * self.data.tfcoil.temp_cp_average
@@ -506,8 +508,8 @@ class ResistiveTFCoil(TFCoil):
 
             # Leg resistivity (different leg temperature as separate cooling channels)
             if self.data.tfcoil.i_tf_sup == TFConductorModel.WATER_COOLED_COPPER:
-                self.data.tfcoil.rho_tf_leg = (
-                    self.data.tfcoil.frholeg
+                self.data.resistive_tfcoil.rho_tf_leg = (
+                    self.data.resistive_tfcoil.frholeg
                     * (
                         1.86e0
                         + 0.00393e0 * (self.data.tfcoil.temp_tf_legs_outboard - 293.15e0)
@@ -515,10 +517,13 @@ class ResistiveTFCoil(TFCoil):
                     * 1.0e-8
                 )
             elif self.data.tfcoil.i_tf_sup == TFConductorModel.HELIUM_COOLED_ALUMINIUM:
-                self.data.tfcoil.rho_tf_leg = self.data.tfcoil.frholeg * (
-                    2.00016e-14 * self.data.tfcoil.temp_tf_legs_outboard**3
-                    - 6.75384e-13 * self.data.tfcoil.temp_tf_legs_outboard**2
-                    + 8.89159e-12 * self.data.tfcoil.temp_tf_legs_outboard
+                self.data.resistive_tfcoil.rho_tf_leg = (
+                    self.data.resistive_tfcoil.frholeg
+                    * (
+                        2.00016e-14 * self.data.tfcoil.temp_tf_legs_outboard**3
+                        - 6.75384e-13 * self.data.tfcoil.temp_tf_legs_outboard**2
+                        + 8.89159e-12 * self.data.tfcoil.temp_tf_legs_outboard
+                    )
                 )
 
             # Tricky trick to make the leg / CP temperatures the same
@@ -546,7 +551,7 @@ class ResistiveTFCoil(TFCoil):
                 self.data.tfcoil.dx_tf_turn_insulation,
                 self.data.tfcoil.n_tf_coil_turns,
                 self.data.tfcoil.c_tf_total,
-                self.data.tfcoil.rho_cp,
+                self.data.resistive_tfcoil.rho_cp,
                 self.data.tfcoil.fcoolcp,
                 self.data.tfcoil.n_tf_coils,
             )
@@ -603,15 +608,15 @@ class ResistiveTFCoil(TFCoil):
             # Outer leg resistive power loss
             # ---
             # TF outboard leg's resistance calculation (per leg) [ohm]
-            self.data.tfcoil.res_tf_leg = (
-                self.data.tfcoil.rho_tf_leg
+            self.data.resistive_tfcoil.res_tf_leg = (
+                self.data.resistive_tfcoil.rho_tf_leg
                 * self.data.tfcoil.len_tf_coil
                 / self.data.superconducting_tfcoil.a_leg_cond
             )
 
             # TF outer leg resistive power (TOTAL) [W]
             self.data.tfcoil.p_tf_leg_resistive = (
-                self.data.tfcoil.res_tf_leg
+                self.data.resistive_tfcoil.res_tf_leg
                 * (self.data.tfcoil.c_tf_total / self.data.tfcoil.n_tf_coils) ** 2
             ) * self.data.tfcoil.n_tf_coils
             # ---
@@ -634,7 +639,7 @@ class ResistiveTFCoil(TFCoil):
                 )
 
                 # Total joints resistive power losses
-                self.data.tfcoil.p_tf_joints_resistive = (
+                self.data.resistive_tfcoil.p_tf_joints_resistive = (
                     self.data.tfcoil.n_tf_joints
                     * self.data.tfcoil.rho_tf_joints
                     * self.data.tfcoil.c_tf_total**2
@@ -642,7 +647,7 @@ class ResistiveTFCoil(TFCoil):
                 )
             else:
                 # Joints resistance to be evaluated for SC
-                self.data.tfcoil.p_tf_joints_resistive = 0.0e0
+                self.data.resistive_tfcoil.p_tf_joints_resistive = 0.0e0
 
             # ---
 
@@ -651,7 +656,7 @@ class ResistiveTFCoil(TFCoil):
         else:
             # TF resistive powers
             self.data.tfcoil.p_cp_resistive = (
-                self.data.tfcoil.rho_cp
+                self.data.resistive_tfcoil.rho_cp
                 * self.data.tfcoil.c_tf_total**2
                 * self.data.tfcoil.len_tf_coil
                 / (
@@ -665,7 +670,7 @@ class ResistiveTFCoil(TFCoil):
             self.data.tfcoil.p_tf_leg_resistive = 0.0e0
 
             # No joints if self.data.physics.itart = 0
-            self.data.tfcoil.p_tf_joints_resistive = 0.0e0
+            self.data.resistive_tfcoil.p_tf_joints_resistive = 0.0e0
 
     def resistive_tf_coil_areas_and_masses(self):
         """Calculate the areas and masses of the resistive TF coil"""
@@ -946,7 +951,7 @@ class ResistiveTFCoil(TFCoil):
             self.outfile,
             "Area of resistive conductor per coil",
             "(a_res_tf_coil_conductor)",
-            self.data.tfcoil.a_res_tf_coil_conductor,
+            self.data.resistive_tfcoil.a_res_tf_coil_conductor,
         )
         po.ovarre(
             self.outfile,
@@ -1079,13 +1084,13 @@ class ResistiveTFCoil(TFCoil):
                 self.outfile,
                 "CP resistivity (ohm.m)",
                 "(rho_cp)",
-                self.data.tfcoil.rho_cp,
+                self.data.resistive_tfcoil.rho_cp,
             )
             po.ovarre(
                 self.outfile,
                 "Leg resistivity (ohm.m)",
                 "(rho_tf_leg)",
-                self.data.tfcoil.rho_tf_leg,
+                self.data.resistive_tfcoil.rho_tf_leg,
             )
             po.ovarre(
                 self.outfile,
@@ -1103,13 +1108,13 @@ class ResistiveTFCoil(TFCoil):
                 self.outfile,
                 "joints resistive power loss (W)",
                 "(p_tf_joints_resistive)",
-                self.data.tfcoil.p_tf_joints_resistive,
+                self.data.resistive_tfcoil.p_tf_joints_resistive,
             )
             po.ovarre(
                 self.outfile,
                 "Outboard leg resistance per coil (ohm)",
                 "(res_tf_leg)",
-                self.data.tfcoil.res_tf_leg,
+                self.data.resistive_tfcoil.res_tf_leg,
             )
             po.ovarre(
                 self.outfile,
@@ -1129,7 +1134,7 @@ class ResistiveTFCoil(TFCoil):
                 self.outfile,
                 "TF resistivity (ohm.m)",
                 "(p_cp_resistive)",
-                self.data.tfcoil.rho_cp,
+                self.data.resistive_tfcoil.rho_cp,
             )
             po.ovarre(
                 self.outfile,

--- a/tests/unit/models/tfcoil/test_resistive_tf_coil.py
+++ b/tests/unit/models/tfcoil/test_resistive_tf_coil.py
@@ -461,7 +461,7 @@ def test_tf_res_heating(tfresheatingparam, monkeypatch, resistive_tf_coil):
     """
 
     monkeypatch.setattr(
-        resistive_tf_coil.data.tfcoil, "rho_cp", tfresheatingparam.rho_cp
+        resistive_tf_coil.data.resistive_tfcoil, "rho_cp", tfresheatingparam.rho_cp
     )
 
     monkeypatch.setattr(
@@ -483,7 +483,9 @@ def test_tf_res_heating(tfresheatingparam, monkeypatch, resistive_tf_coil):
     )
 
     monkeypatch.setattr(
-        resistive_tf_coil.data.tfcoil, "rho_tf_leg", tfresheatingparam.rho_tf_leg
+        resistive_tf_coil.data.resistive_tfcoil,
+        "rho_tf_leg",
+        tfresheatingparam.rho_tf_leg,
     )
 
     monkeypatch.setattr(
@@ -513,7 +515,9 @@ def test_tf_res_heating(tfresheatingparam, monkeypatch, resistive_tf_coil):
     )
 
     monkeypatch.setattr(
-        resistive_tf_coil.data.tfcoil, "res_tf_leg", tfresheatingparam.res_tf_leg
+        resistive_tf_coil.data.resistive_tfcoil,
+        "res_tf_leg",
+        tfresheatingparam.res_tf_leg,
     )
 
     monkeypatch.setattr(
@@ -549,7 +553,7 @@ def test_tf_res_heating(tfresheatingparam, monkeypatch, resistive_tf_coil):
     )
 
     monkeypatch.setattr(
-        resistive_tf_coil.data.tfcoil,
+        resistive_tf_coil.data.resistive_tfcoil,
         "p_tf_joints_resistive",
         tfresheatingparam.p_tf_joints_resistive,
     )
@@ -573,11 +577,11 @@ def test_tf_res_heating(tfresheatingparam, monkeypatch, resistive_tf_coil):
     )
 
     monkeypatch.setattr(
-        resistive_tf_coil.data.tfcoil, "frholeg", tfresheatingparam.frholeg
+        resistive_tf_coil.data.resistive_tfcoil, "frholeg", tfresheatingparam.frholeg
     )
 
     monkeypatch.setattr(
-        resistive_tf_coil.data.tfcoil, "frhocp", tfresheatingparam.frhocp
+        resistive_tf_coil.data.resistive_tfcoil, "frhocp", tfresheatingparam.frhocp
     )
 
     monkeypatch.setattr(
@@ -656,11 +660,11 @@ def test_tf_res_heating(tfresheatingparam, monkeypatch, resistive_tf_coil):
 
     resistive_tf_coil.tf_res_heating()
 
-    assert resistive_tf_coil.data.tfcoil.rho_cp == pytest.approx(
+    assert resistive_tf_coil.data.resistive_tfcoil.rho_cp == pytest.approx(
         tfresheatingparam.expected_rho_cp
     )
 
-    assert resistive_tf_coil.data.tfcoil.rho_tf_leg == pytest.approx(
+    assert resistive_tf_coil.data.resistive_tfcoil.rho_tf_leg == pytest.approx(
         tfresheatingparam.expected_rho_tf_leg
     )
 
@@ -668,7 +672,7 @@ def test_tf_res_heating(tfresheatingparam, monkeypatch, resistive_tf_coil):
         tfresheatingparam.expected_vol_cond_cp
     )
 
-    assert resistive_tf_coil.data.tfcoil.res_tf_leg == pytest.approx(
+    assert resistive_tf_coil.data.resistive_tfcoil.res_tf_leg == pytest.approx(
         tfresheatingparam.expected_res_tf_leg
     )
 
@@ -680,8 +684,9 @@ def test_tf_res_heating(tfresheatingparam, monkeypatch, resistive_tf_coil):
         tfresheatingparam.expected_p_cp_resistive
     )
 
-    assert resistive_tf_coil.data.tfcoil.p_tf_joints_resistive == pytest.approx(
-        tfresheatingparam.expected_pres_joints
+    assert (
+        resistive_tf_coil.data.resistive_tfcoil.p_tf_joints_resistive
+        == pytest.approx(tfresheatingparam.expected_pres_joints)
     )
 
     assert resistive_tf_coil.data.tfcoil.a_cp_cool == pytest.approx(


### PR DESCRIPTION
closes #3822

Organise `tfcoil_variables.py`. Move superconductiong TF coil variables into `superconducting_tf_coil_variables.py` and create a `resistive_tf_coil_variables.py` for resistive tfcoil model variables. Uses what is used in which tests as the guide to where they should go.


