### PR TITLE
Updated PF numbering in outputs

### DIFF
--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -8066,10 +8066,10 @@ def plot_pf_coils(
     noc = number_of_coils - 1 if iohcl == 1 else number_of_coils
 
     for coil in range(noc):
-        coils_r.append(mfile.get(f"r_pf_coil_middle[{coil:01}]", scan=scan))
-        coils_z.append(mfile.get(f"z_pf_coil_middle[{coil:01}]", scan=scan))
-        coils_dr.append(mfile.get(f"pfdr({coil:01})", scan=scan))
-        coils_dz.append(mfile.get(f"pfdz({coil:01})", scan=scan))
+        coils_r.append(mfile.get(f"r_pf_coil_middle[{coil + 1:01}]", scan=scan))
+        coils_z.append(mfile.get(f"z_pf_coil_middle[{coil + 1:01}]", scan=scan))
+        coils_dr.append(mfile.get(f"pfdr({coil + 1:01})", scan=scan))
+        coils_dz.append(mfile.get(f"pfdz({coil + 1:01})", scan=scan))
         coil_text.append(str(coil + 1))
 
     r_points, z_points, central_coil = pfcoil_geometry(
@@ -16352,10 +16352,10 @@ def plot_pf_dimensions(
     radial_thicknesses = []
     vertical_thicknesses = []
     for coil in range(int(mfile.get("n_pf_cs_plasma_circuits", scan=scan) - 2)):
-        r_pf_coil_middle.append(mfile.get(f"r_pf_coil_middle[{coil}]", scan=scan))
-        z_pf_coil_middle.append(mfile.get(f"z_pf_coil_middle[{coil}]", scan=scan))
-        radial_thicknesses.append(mfile.get(f"pfdr({coil})", scan=scan))
-        vertical_thicknesses.append(mfile.get(f"pfdz({coil})", scan=scan))
+        r_pf_coil_middle.append(mfile.get(f"r_pf_coil_middle[{coil + 1}]", scan=scan))
+        z_pf_coil_middle.append(mfile.get(f"z_pf_coil_middle[{coil + 1}]", scan=scan))
+        radial_thicknesses.append(mfile.get(f"pfdr({coil + 1})", scan=scan))
+        vertical_thicknesses.append(mfile.get(f"pfdz({coil + 1})", scan=scan))
 
     plot_pf_coils(axis=axis, mfile=mfile, scan=scan, colour_scheme=colour_scheme)
 

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -8060,10 +8060,10 @@ def plot_pf_coils(
     noc = number_of_coils - 1 if iohcl == 1 else number_of_coils
 
     for coil in range(noc):
-        coils_r.append(mfile.get(f"r_pf_coil_middle[{coil:01}]", scan=scan))
-        coils_z.append(mfile.get(f"z_pf_coil_middle[{coil:01}]", scan=scan))
-        coils_dr.append(mfile.get(f"pfdr({coil:01})", scan=scan))
-        coils_dz.append(mfile.get(f"pfdz({coil:01})", scan=scan))
+        coils_r.append(mfile.get(f"r_pf_coil_middle[{coil + 1:01}]", scan=scan))
+        coils_z.append(mfile.get(f"z_pf_coil_middle[{coil + 1:01}]", scan=scan))
+        coils_dr.append(mfile.get(f"pfdr({coil + 1:01})", scan=scan))
+        coils_dz.append(mfile.get(f"pfdz({coil + 1:01})", scan=scan))
         coil_text.append(str(coil + 1))
 
     r_points, z_points, central_coil = pfcoil_geometry(
@@ -16059,10 +16059,10 @@ def plot_pf_dimensions(
     radial_thicknesses = []
     vertical_thicknesses = []
     for coil in range(int(mfile.get("n_pf_cs_plasma_circuits", scan=scan) - 2)):
-        r_pf_coil_middle.append(mfile.get(f"r_pf_coil_middle[{coil}]", scan=scan))
-        z_pf_coil_middle.append(mfile.get(f"z_pf_coil_middle[{coil}]", scan=scan))
-        radial_thicknesses.append(mfile.get(f"pfdr({coil})", scan=scan))
-        vertical_thicknesses.append(mfile.get(f"pfdz({coil})", scan=scan))
+        r_pf_coil_middle.append(mfile.get(f"r_pf_coil_middle[{coil + 1}]", scan=scan))
+        z_pf_coil_middle.append(mfile.get(f"z_pf_coil_middle[{coil + 1}]", scan=scan))
+        radial_thicknesses.append(mfile.get(f"pfdr({coil + 1})", scan=scan))
+        vertical_thicknesses.append(mfile.get(f"pfdz({coil + 1})", scan=scan))
 
     plot_pf_coils(axis=axis, mfile=mfile, scan=scan, colour_scheme=colour_scheme)
 

--- a/process/core/io/plot/summary.py
+++ b/process/core/io/plot/summary.py
@@ -15694,17 +15694,13 @@ def plot_pf_cs_plasma_mutual_inductance(
     axis.set_title("PF/CS Plasma Mutual Inductance")
     axis.set_xticks(range(n_pf_cs_plasma_circuits))
     axis.set_yticks(range(n_pf_cs_plasma_circuits))
-    x_labels = list(range(n_pf_cs_plasma_circuits))
+    labels = list(range(1, n_pf_cs_plasma_circuits + 1))
 
     if iohcl == 1:
-        x_labels[-2] = "CS"
-    x_labels[-1] = "Plasma"
-    y_labels = list(range(n_pf_cs_plasma_circuits))
-    if iohcl == 1:
-        y_labels[-2] = "CS"
-    y_labels[-1] = "Plasma"
-    axis.set_xticklabels(x_labels)
-    axis.set_yticklabels(y_labels)
+        labels[-2] = "CS"
+    labels[-1] = "Plasma"
+    axis.set_xticklabels(labels)
+    axis.set_yticklabels(labels)
 
     # Add boxes around each cell
     for i in range(n_pf_cs_plasma_circuits):
@@ -16351,7 +16347,9 @@ def plot_pf_dimensions(
     z_pf_coil_middle = []
     radial_thicknesses = []
     vertical_thicknesses = []
-    for coil in range(int(mfile.get("n_pf_cs_plasma_circuits", scan=scan) - 2)):
+    iohcl = mfile.get("iohcl", scan=scan) if "iohcl" in mfile.data else 1
+    x = 1 if iohcl == 0 else 2
+    for coil in range(int(mfile.get("n_pf_cs_plasma_circuits", scan=scan) - x)):
         r_pf_coil_middle.append(mfile.get(f"r_pf_coil_middle[{coil + 1}]", scan=scan))
         z_pf_coil_middle.append(mfile.get(f"z_pf_coil_middle[{coil + 1}]", scan=scan))
         radial_thicknesses.append(mfile.get(f"pfdr({coil + 1})", scan=scan))

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2750,7 +2750,8 @@ class PFCoil(Model):
         inv_st_pulse = 1.0e0 / pf_d.f_j_cs_start_pulse_end_flat_top
 
         for k in range(self.data.pf_coil.n_pf_cs_plasma_circuits - 1):
-            if k == self.data.pf_coil.n_pf_cs_plasma_circuits - 2:
+            if (self.data.build.iohcl != 0) and (k ==
+                        self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
                 line = "\tCS\t\t"
             else:
                 line = f"\t{k + 1}\t\t"
@@ -2768,7 +2769,8 @@ class PFCoil(Model):
         op.ocmmnt(self.outfile, "This consists of: CS coil field balancing:")
 
         for k in range(pf_d.n_pf_cs_plasma_circuits - 1):
-            if k == pf_d.n_pf_cs_plasma_circuits - 2:
+            if (self.data.build.iohcl != 0) and (k ==
+                                    self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
                 op.write(
                     self.outfile,
                     (
@@ -2796,7 +2798,8 @@ class PFCoil(Model):
         op.oblnkl(self.outfile)
         op.ocmmnt(self.outfile, "And: equilibrium field:")
         for k in range(pf_d.n_pf_cs_plasma_circuits - 1):
-            if k == pf_d.n_pf_cs_plasma_circuits - 2:
+            if (self.data.build.iohcl != 0) and (k ==
+                                    self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
                 op.write(
                     self.outfile,
                     (
@@ -2847,7 +2850,8 @@ class PFCoil(Model):
                 if k == self.data.pf_coil.n_pf_cs_plasma_circuits - 1:
                     circuit_name = f"Plasma Time point {jjj} (A)"
                     circuit_var_name = f"(plasmat{jjj})"
-                elif k == self.data.pf_coil.n_pf_cs_plasma_circuits - 2:
+                elif (self.data.build.iohcl != 0) and (k ==
+                                        self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
                     circuit_name = f"CS Circuit Time point {jjj} (A)"
                     circuit_var_name = f"(cs t{jjj})"
                 else:

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2436,12 +2436,12 @@ class PFCoil(Model):
             "1.0e0",
         ])
 
-        for line in tabulate(
+        op.write(self.outfile, tabulate(
             pf_coil_geometry_rows,
             headers=["Coil", "R(m)", "Z(m)", "dR(m)", "dZ(m)", "turns"],
             tablefmt="plain",
-        ).splitlines():
-            op.write(self.outfile, line)
+            disable_numparse=True,
+        ))
 
         for k in range(pf_d.nef):
             op.ovarre(
@@ -2629,13 +2629,12 @@ class PFCoil(Model):
         ])
 
         op.oblnkl(self.outfile)
-        for line in tabulate(
+        op.write(self.outfile, tabulate(
             rows,
             headers=headers,
             tablefmt="plain",
             disable_numparse=True,
-        ).splitlines():
-            op.write(self.outfile, line)
+        ))
 
         op.oblnkl(self.outfile)
         op.ocmmnt(self.outfile, "----------------------------")
@@ -2683,13 +2682,12 @@ class PFCoil(Model):
         ))
 
         op.oblnkl(self.outfile)
-        for line in tabulate(
+        op.write(self.outfile, tabulate(
             rows,
             headers=headers,
             tablefmt="plain",
             disable_numparse=True,
-        ).splitlines():
-            op.write(self.outfile, line)
+        ))
         op.oblnkl(self.outfile)
         op.ovarre(
             self.outfile,
@@ -2707,7 +2705,6 @@ class PFCoil(Model):
         )
 
         op.osubhd(self.outfile, "Summary of volt-second consumption by circuit (Wb):")
-        op.write(self.outfile, "Circuit\t\t\tBOP\t\t\tBOF\t\tEOF")
         op.oblnkl(self.outfile)
         headers = [
             "Circuit",
@@ -2732,13 +2729,12 @@ class PFCoil(Model):
             f"{pf.vsdum[n_cs, 2]:.3f}"
         ])
         op.oblnkl(self.outfile)
-        for line in tabulate(
+        op.write(self.outfile, tabulate(
             rows,
             headers=headers,
             tablefmt="plain",
             disable_numparse=True,
-        ).splitlines():
-            op.write(self.outfile, line)
+        ))
         op.oblnkl(self.outfile)
 
         op.oshead(self.outfile, "Waveforms")
@@ -2763,13 +2759,12 @@ class PFCoil(Model):
         for k in range(pulse_timings.n_pf_active_points_total):
             line += [f"{pulse_timings.pf_active_cumulative[k]:.2f}"]
         rows = [line]
-        for line in tabulate(
+        op.write(self.outfile, tabulate(
             rows,
             headers=headers[1:],
             tablefmt="plain",
             disable_numparse=True,
-        ).splitlines():
-            op.write(self.outfile, line)
+        ))
 
         op.oblnkl(self.outfile)
         op.write(self.outfile, "Currents (A)")
@@ -2803,13 +2798,12 @@ class PFCoil(Model):
 
         # op.write(self.outfile, line)
         op.oblnkl(self.outfile)
-        for line in tabulate(
+        op.write(self.outfile, tabulate(
             rows,
             headers=headers,
             tablefmt="plain",
             disable_numparse=True,
-        ).splitlines():
-            op.write(self.outfile, line)
+        ))
 
         op.oblnkl(self.outfile)
 
@@ -2839,13 +2833,12 @@ class PFCoil(Model):
                     ])
 
         op.oblnkl(self.outfile)
-        for line in tabulate(
+        op.write(self.outfile, tabulate(
             rows,
             headers=headers,
             tablefmt="plain",
             disable_numparse=True,
-        ).splitlines():
-            op.write(self.outfile, line)
+        ))
 
         op.oblnkl(self.outfile)
         op.ocmmnt(self.outfile, "And: equilibrium field:")
@@ -2874,13 +2867,12 @@ class PFCoil(Model):
                 ])
 
         op.oblnkl(self.outfile)
-        for line in tabulate(
+        op.write(self.outfile, tabulate(
             rows,
             headers=headers,
             tablefmt="plain",
             disable_numparse=True,
-        ).splitlines():
-            op.write(self.outfile, line)
+        ))
 
         op.oblnkl(self.outfile)
         op.ovarre(

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2660,26 +2660,36 @@ class PFCoil(Model):
         op.oheadr(self.outfile, "Volt Second Consumption")
 
         pf = self.data.pf_coil
-        op.write(self.outfile, "\t" * 6 + "volt-sec\t\t\tvolt-sec\t\tvolt-sec")
-        op.write(self.outfile, "\t" * 6 + "start-up\t\t\tburn\t\t\t\ttotal")
-        op.write(
-            self.outfile,
-            f"PF coils:\t\t{pf.vs_pf_coils_total_ramp:.2f}"
-            f"\t\t\t\t{pf.vs_pf_coils_total_burn:.2f}\t\t\t{pf.vs_pf_coils_total_pulse:.2f}",
-        )
-        op.write(
-            self.outfile,
-            f"CS coil:\t\t{pf.vs_cs_ramp:.2f}"
-            f"\t\t\t\t{pf.vs_cs_burn:.2f}\t\t\t{pf.vs_cs_total_pulse:.2f}",
-        )
-        op.write(
-            self.outfile, "\t" * 6 + "-" * 7 + "\t" * 4 + "-" * 7 + "\t" * 3 + "-" * 7
-        )
-        op.write(
-            self.outfile,
-            f"Total:\t\t\t{pf.vs_cs_pf_total_ramp:.2f}\t\t\t\t{pf.vs_cs_pf_total_burn:.2f}\t\t\t{pf.vs_cs_pf_total_pulse:.2f}",
-        )
+        headers = [
+            "",
+            "Start-up (Vs)",
+            "Burn (Vs)",
+            "Total (Vs)"
+        ]
+        rows = []
+        rows.extend((
+            ["PF coils",
+                f"{pf.vs_pf_coils_total_ramp:.2f}",
+            f"{pf.vs_pf_coils_total_burn:.2f}",
+            f"{pf.vs_pf_coils_total_pulse:.2f}"],
+            ["CS coil",
+                f"{pf.vs_cs_ramp:.2f}",
+            f"{pf.vs_cs_burn:.2f}",
+            f"{pf.vs_cs_total_pulse:.2f}"],
+            ["Total",
+            f"{pf.vs_cs_pf_total_ramp:.2f}",
+            f"{pf.vs_cs_pf_total_burn:.2f}",
+            f"{pf.vs_cs_pf_total_pulse:.2f}"]
+        ))
 
+        op.oblnkl(self.outfile)
+        for line in tabulate(
+            rows,
+            headers=headers,
+            tablefmt="plain",
+            disable_numparse=True,
+        ).splitlines():
+            op.write(self.outfile, line)
         op.oblnkl(self.outfile)
         op.ovarre(
             self.outfile,
@@ -2699,27 +2709,45 @@ class PFCoil(Model):
         op.osubhd(self.outfile, "Summary of volt-second consumption by circuit (Wb):")
         op.write(self.outfile, "Circuit\t\t\tBOP\t\t\tBOF\t\tEOF")
         op.oblnkl(self.outfile)
-
+        headers = [
+            "Circuit",
+            "BOP",
+            "BOF",
+            "EOF"
+        ]
+        rows = []
         for k in range(pf.nef):
-            op.write(
-                self.outfile,
-                f"\t{k + 1}\t\t\t{pf.vsdum[k, 0]:.3f}"
-                f"\t\t\t{pf.vsdum[k, 1]:.3f}\t\t{pf.vsdum[k, 2]:.3f}",
-            )
+            rows.append([
+                f"PF {k + 1}",
+                f"{pf.vsdum[k, 0]:.3f}",
+                f"{pf.vsdum[k, 1]:.3f}",
+                f"{pf.vsdum[k, 2]:.3f}"
+            ])
 
         n_cs = pf.n_cs_pf_coils - 1
-        op.write(
-            self.outfile,
-            f"\tCS\t\t\t{pf.vsdum[n_cs, 0]:.3f}"
-            f"\t\t\t{pf.vsdum[n_cs, 1]:.3f}\t\t{pf.vsdum[n_cs, 2]:.3f}",
-        )
+        rows.append([
+            "CS coil",
+            f"{pf.vsdum[n_cs, 0]:.3f}",
+            f"{pf.vsdum[n_cs, 1]:.3f}",
+            f"{pf.vsdum[n_cs, 2]:.3f}"
+        ])
+        op.oblnkl(self.outfile)
+        for line in tabulate(
+            rows,
+            headers=headers,
+            tablefmt="plain",
+            disable_numparse=True,
+        ).splitlines():
+            op.write(self.outfile, line)
+        op.oblnkl(self.outfile)
 
         op.oshead(self.outfile, "Waveforms")
         op.ocmmnt(self.outfile, "Currents (Amps/coil) as a function of time:")
         op.oblnkl(self.outfile)
 
-        op.write(self.outfile, "\t" * 8 + "time (sec)")
-        line = "\t\t"
+        op.write(self.outfile, "Times (s)")
+
+        headers = ["Coil"]
         pulse_timings = PulseTimings(
             t_plant_pulse_coil_precharge=self.data.times.t_plant_pulse_coil_precharge,
             t_plant_pulse_plasma_current_ramp_up=self.data.times.t_plant_pulse_plasma_current_ramp_up,
@@ -2729,16 +2757,25 @@ class PFCoil(Model):
             t_plant_pulse_dwell=self.data.times.t_plant_pulse_dwell,
         )
         for k in range(pulse_timings.n_pf_active_points_total):
-            line += f"\t\t{pulse_timings.pf_active_cumulative[k]:.2f}"
-        op.write(self.outfile, line)
-
-        line = "\t\t"
-        for k in range(pulse_timings.n_pf_active_points_total):
             label = pulse_timings.POINT_ABBREVIATIONS[k]
-            line += f"\t\t{label}"
-        op.write(self.outfile, line)
+            headers.append(label)
+        line = []
+        for k in range(pulse_timings.n_pf_active_points_total):
+            line += [f"{pulse_timings.pf_active_cumulative[k]:.2f}"]
+        rows = [line]
+        for line in tabulate(
+            rows,
+            headers=headers[1:],
+            tablefmt="plain",
+            disable_numparse=True,
+        ).splitlines():
+            op.write(self.outfile, line)
 
-        op.ocmmnt(self.outfile, "circuit")
+        op.oblnkl(self.outfile)
+        op.write(self.outfile, "Currents (A)")
+        op.ocmmnt(self.outfile, "Circuit:")
+
+        rows = []
 
         pf_d = self.data.pf_coil
         cpft = self.data.pf_coil.c_pf_coil_turn
@@ -2752,75 +2789,98 @@ class PFCoil(Model):
         for k in range(self.data.pf_coil.n_pf_cs_plasma_circuits - 1):
             if (self.data.build.iohcl != 0) and (k ==
                         self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
-                line = "\tCS\t\t"
+                line = ["CS"]
             else:
-                line = f"\t{k + 1}\t\t"
+                line = [f"PF {k + 1}"]
             for jj in range(6):
-                line += f"\t{cpft[k, jj] * self.data.pf_coil.n_pf_coil_turns[k]:.3e}"
+                line += [f"{cpft[k, jj] * self.data.pf_coil.n_pf_coil_turns[k]:.3e}"]
+            rows.append(line)
+
+        line = ["Plasma"]
+        for jj in range(6):
+            line += [f"{cpft[self.data.pf_coil.n_pf_cs_plasma_circuits - 1, jj]:.3e}"]
+        rows.append(line)
+
+        # op.write(self.outfile, line)
+        op.oblnkl(self.outfile)
+        for line in tabulate(
+            rows,
+            headers=headers,
+            tablefmt="plain",
+            disable_numparse=True,
+        ).splitlines():
             op.write(self.outfile, line)
 
-        line = "Plasma (A)\t\t"
-        for jj in range(6):
-            line += f"\t{cpft[self.data.pf_coil.n_pf_cs_plasma_circuits - 1, jj]:.3e}"
-
-        op.write(self.outfile, line)
-
         op.oblnkl(self.outfile)
-        op.ocmmnt(self.outfile, "This consists of: CS coil field balancing:")
 
+        op.ocmmnt(self.outfile, "This consists of: CS coil field balancing:")
+        rows = []
         for k in range(pf_d.n_pf_cs_plasma_circuits - 1):
             if (self.data.build.iohcl != 0) and (k ==
                                     self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
-                op.write(
-                    self.outfile,
-                    (
-                        f"CS\t\t\t{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}\t"
-                        f"{cpft[k, 1] * nturn[k]:.3e}\t"
-                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
-                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
-                        f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}\t"
+                rows.append([
+                        "CS",
+                        f"{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}",
+                        f"{cpft[k, 1] * nturn[k]:.3e}",
+                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
+                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
+                        f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}",
                         f"{cpft[k, 5] * nturn[k]:.3e}"
-                    ),
-                )
+                    ])
             else:
-                op.write(
-                    self.outfile,
-                    (
-                        f"{k + 1}\t\t\t{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}\t"
-                        f"{cpft[k, 1] * nturn[k]:.3e}\t"
-                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
-                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
-                        f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}\t"
+                rows.append([
+                        f"PF {k + 1}",
+                        f"{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}",
+                        f"{cpft[k, 1] * nturn[k]:.3e}",
+                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
+                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
+                        f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}",
                         f"{cpft[k, 5] * nturn[k]:.3e}"
-                    ),
-                )
+                    ])
+
+        op.oblnkl(self.outfile)
+        for line in tabulate(
+            rows,
+            headers=headers,
+            tablefmt="plain",
+            disable_numparse=True,
+        ).splitlines():
+            op.write(self.outfile, line)
 
         op.oblnkl(self.outfile)
         op.ocmmnt(self.outfile, "And: equilibrium field:")
+        rows = []
         for k in range(pf_d.n_pf_cs_plasma_circuits - 1):
             if (self.data.build.iohcl != 0) and (k ==
                                     self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
-                op.write(
-                    self.outfile,
-                    (
-                        f"CS\t\t\t{0.0:.3e}\t{0.0:.3e}\t"
-                        f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
-                        f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
-                        f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}\t"
+                rows.append([
+                        "CS",
+                        f"{0.0:.3e}",
+                        f"{0.0:.3e}",
+                        f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
+                        f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
+                        f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}",
                         "0.0e0"
-                    ),
-                )
+                    ])
             else:
-                op.write(
-                    self.outfile,
-                    (
-                        f"{k + 1}\t\t\t{0.0:.3e}\t{0.0:.3e}\t"
-                        f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
-                        f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
-                        f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}\t"
+                rows.append([
+                        f"PF {k + 1}",
+                        f"{0.0:.3e}",
+                        f"{0.0:.3e}",
+                        f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
+                        f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
+                        f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}",
                         "0.0e0"
-                    ),
-                )
+                ])
+
+        op.oblnkl(self.outfile)
+        for line in tabulate(
+            rows,
+            headers=headers,
+            tablefmt="plain",
+            disable_numparse=True,
+        ).splitlines():
+            op.write(self.outfile, line)
 
         op.oblnkl(self.outfile)
         op.ovarre(

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2898,34 +2898,6 @@ class PFCoil(Model):
             "OP ",
         )
 
-        op.oshead(self.outfile, "PF Circuit Waveform Data")
-        op.ovarre(
-            self.outfile,
-            "Number of PF circuits including CS and plasma",
-            "(n_pf_cs_plasma_circuits)",
-            self.data.pf_coil.n_pf_cs_plasma_circuits,
-        )
-        for k in range(self.data.pf_coil.n_pf_cs_plasma_circuits):
-            for jjj in range(6):
-                if k == self.data.pf_coil.n_pf_cs_plasma_circuits - 1:
-                    circuit_name = f"Plasma Time point {jjj} (A)"
-                    circuit_var_name = f"(plasmat{jjj})"
-                elif (self.data.build.iohcl != 0) and (k ==
-                                        self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
-                    circuit_name = f"CS Circuit Time point {jjj} (A)"
-                    circuit_var_name = f"(cs t{jjj})"
-                else:
-                    circuit_name = f"PF Circuit {k + 1} Time point {jjj} (A)"
-                    circuit_var_name = f"(pfc{k}t{jjj})"
-
-                op.ovarre(
-                    self.outfile,
-                    circuit_name,
-                    circuit_var_name,
-                    self.data.pf_coil.c_pf_coil_turn[k, jjj]
-                    * self.data.pf_coil.n_pf_coil_turns[k],
-                )
-
     @staticmethod
     def selfinductance(a, b, c, n):
         """Calculates the selfinductance using Bunet's formula.

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -1994,7 +1994,7 @@ class PFCoil(Model):
             for ig in range(pf_d.nef):
                 op.write(
                     self.outfile,
-                    f"{ig}\t{pf_d.ind_pf_cs_plasma_mutual[:n_pf_cs, ig]}",
+                    f"{ig + 1}\t{pf_d.ind_pf_cs_plasma_mutual[:n_pf_cs, ig]}",
                 )
 
             if self.data.build.iohcl != 0:
@@ -2403,7 +2403,7 @@ class PFCoil(Model):
         # PF coils
         pf_coil_geometry_rows = [
             [
-                f"PF {k}",
+                f"PF {k + 1}",
                 f"{pf_d.r_pf_coil_middle[k]:.2e}",
                 f"{pf_d.z_pf_coil_middle[k]:.2e}",
                 f"{pf_d.r_pf_coil_outer[k] - pf_d.r_pf_coil_inner[k]:.2e}",
@@ -2446,44 +2446,44 @@ class PFCoil(Model):
         for k in range(pf_d.nef):
             op.ovarre(
                 self.mfile,
-                f"PF coil {k} radius (m)",
-                f"(r_pf_coil_middle[{k}])",
+                f"PF coil {k + 1} radius (m)",
+                f"(r_pf_coil_middle[{k + 1}])",
                 pf_d.r_pf_coil_middle[k],
             )
             op.ovarre(
                 self.mfile,
-                f"PF coil {k} vertical position (m)",
-                f"(z_pf_coil_middle[{k}])",
+                f"PF coil {k + 1} vertical position (m)",
+                f"(z_pf_coil_middle[{k + 1}])",
                 pf_d.z_pf_coil_middle[k],
             )
             op.ovarre(
                 self.mfile,
-                f"PF coil {k} radial thickness (m)",
-                f"(pfdr({k}))",
+                f"PF coil {k + 1} radial thickness (m)",
+                f"(pfdr({k + 1}))",
                 pf_d.r_pf_coil_outer[k] - pf_d.r_pf_coil_inner[k],
             )
             op.ovarre(
                 self.mfile,
-                f"PF coil {k} vertical thickness (m)",
-                f"(pfdz({k}))",
+                f"PF coil {k + 1} vertical thickness (m)",
+                f"(pfdz({k + 1}))",
                 pf_d.z_pf_coil_upper[k] - pf_d.z_pf_coil_lower[k],
             )
             op.ovarre(
                 self.mfile,
-                f"PF coil {k} turns",
-                f"(n_pf_coil_turns[{k}])",
+                f"PF coil {k + 1} turns",
+                f"(n_pf_coil_turns[{k + 1}])",
                 pf_d.n_pf_coil_turns[k],
             )
             op.ovarre(
                 self.mfile,
-                f"PF coil {k} current (MA)",
-                f"(c_pf_cs_coils_peak_ma[{k}])",
+                f"PF coil {k + 1} current (MA)",
+                f"(c_pf_cs_coils_peak_ma[{k + 1}])",
                 pf_d.c_pf_cs_coils_peak_ma[k],
             )
             op.ovarre(
                 self.mfile,
-                f"PF coil {k} field (T)",
-                f"(b_pf_coil_peak[{k}])",
+                f"PF coil {k + 1} field (T)",
+                f"(b_pf_coil_peak[{k + 1}])",
                 pf_d.b_pf_coil_peak[k],
             )
         for time in range(6):
@@ -2565,7 +2565,7 @@ class PFCoil(Model):
         for k in range(pf_d.nef):
             if pf_d.i_pf_conductor == PFConductorModel.SUPERCONDUCTING:
                 rows.append([
-                    f"PF {k}",
+                    f"PF {k + 1}",
                     f"{pf_d.c_pf_cs_coils_peak_ma[k]:.3e}",
                     f"{pf_d.j_pf_wp_critical[k]:.3e}",
                     f"{pf_d.j_pf_coil_wp_peak[k]:.3e}",
@@ -2576,7 +2576,7 @@ class PFCoil(Model):
                 ])
             else:
                 rows.append([
-                    f"PF {k}",
+                    f"PF {k + 1}",
                     f"{pf_d.c_pf_cs_coils_peak_ma[k]:.3e}",
                     "-1.0e0",
                     f"{pf_d.j_pf_coil_wp_peak[k]:.3e}",
@@ -2703,14 +2703,14 @@ class PFCoil(Model):
         for k in range(pf.nef):
             op.write(
                 self.outfile,
-                f"\t{k}\t\t\t{pf.vsdum[k, 0]:.3f}"
+                f"\t{k + 1}\t\t\t{pf.vsdum[k, 0]:.3f}"
                 f"\t\t\t{pf.vsdum[k, 1]:.3f}\t\t{pf.vsdum[k, 2]:.3f}",
             )
 
         n_cs = pf.n_cs_pf_coils - 1
         op.write(
             self.outfile,
-            f"\tCS coil\t\t\t{pf.vsdum[n_cs, 0]:.3f}"
+            f"\tCS\t\t\t{pf.vsdum[n_cs, 0]:.3f}"
             f"\t\t\t{pf.vsdum[n_cs, 1]:.3f}\t\t{pf.vsdum[n_cs, 2]:.3f}",
         )
 
@@ -2750,7 +2750,10 @@ class PFCoil(Model):
         inv_st_pulse = 1.0e0 / pf_d.f_j_cs_start_pulse_end_flat_top
 
         for k in range(self.data.pf_coil.n_pf_cs_plasma_circuits - 1):
-            line = f"\t{k}\t\t"
+            if k == self.data.pf_coil.n_pf_cs_plasma_circuits - 2:
+                line = "\tCS\t\t"
+            else:
+                line = f"\t{k + 1}\t\t"
             for jj in range(6):
                 line += f"\t{cpft[k, jj] * self.data.pf_coil.n_pf_coil_turns[k]:.3e}"
             op.write(self.outfile, line)
@@ -2765,31 +2768,56 @@ class PFCoil(Model):
         op.ocmmnt(self.outfile, "This consists of: CS coil field balancing:")
 
         for k in range(pf_d.n_pf_cs_plasma_circuits - 1):
-            op.write(
-                self.outfile,
-                (
-                    f"{k}\t\t\t{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}\t"
-                    f"{cpft[k, 1] * nturn[k]:.3e}\t"
-                    f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
-                    f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
-                    f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}\t"
-                    f"{cpft[k, 5] * nturn[k]:.3e}"
-                ),
-            )
+            if k == pf_d.n_pf_cs_plasma_circuits - 2:
+                op.write(
+                    self.outfile,
+                    (
+                        f"CS\t\t\t{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}\t"
+                        f"{cpft[k, 1] * nturn[k]:.3e}\t"
+                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
+                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
+                        f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}\t"
+                        f"{cpft[k, 5] * nturn[k]:.3e}"
+                    ),
+                )
+            else:
+                op.write(
+                    self.outfile,
+                    (
+                        f"{k + 1}\t\t\t{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}\t"
+                        f"{cpft[k, 1] * nturn[k]:.3e}\t"
+                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
+                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}\t"
+                        f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}\t"
+                        f"{cpft[k, 5] * nturn[k]:.3e}"
+                    ),
+                )
 
         op.oblnkl(self.outfile)
         op.ocmmnt(self.outfile, "And: equilibrium field:")
         for k in range(pf_d.n_pf_cs_plasma_circuits - 1):
-            op.write(
-                self.outfile,
-                (
-                    f"{k}\t\t\t{0.0:.3e}\t{0.0:.3e}\t"
-                    f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
-                    f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
-                    f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}\t"
-                    "0.0e0"
-                ),
-            )
+            if k == pf_d.n_pf_cs_plasma_circuits - 2:
+                op.write(
+                    self.outfile,
+                    (
+                        f"CS\t\t\t{0.0:.3e}\t{0.0:.3e}\t"
+                        f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
+                        f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
+                        f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}\t"
+                        "0.0e0"
+                    ),
+                )
+            else:
+                op.write(
+                    self.outfile,
+                    (
+                        f"{k + 1}\t\t\t{0.0:.3e}\t{0.0:.3e}\t"
+                        f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
+                        f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}\t"
+                        f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}\t"
+                        "0.0e0"
+                    ),
+                )
 
         op.oblnkl(self.outfile)
         op.ovarre(
@@ -2823,7 +2851,7 @@ class PFCoil(Model):
                     circuit_name = f"CS Circuit Time point {jjj} (A)"
                     circuit_var_name = f"(cs t{jjj})"
                 else:
-                    circuit_name = f"PF Circuit {k} Time point {jjj} (A)"
+                    circuit_name = f"PF Circuit {k + 1} Time point {jjj} (A)"
                     circuit_var_name = f"(pfc{k}t{jjj})"
 
                 op.ovarre(

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2672,19 +2672,19 @@ class PFCoil(Model):
                 "PF coils",
                 f"{pf.vs_pf_coils_total_ramp:.2f}",
                 f"{pf.vs_pf_coils_total_burn:.2f}",
-                f"{pf.vs_pf_coils_total_pulse:.2f}"
+                f"{pf.vs_pf_coils_total_pulse:.2f}",
             ],
             [
                 "CS coil",
                 f"{pf.vs_cs_ramp:.2f}",
                 f"{pf.vs_cs_burn:.2f}",
-                f"{pf.vs_cs_total_pulse:.2f}"
+                f"{pf.vs_cs_total_pulse:.2f}",
             ],
             [
                 "Total",
                 f"{pf.vs_cs_pf_total_ramp:.2f}",
                 f"{pf.vs_cs_pf_total_burn:.2f}",
-                f"{pf.vs_cs_pf_total_pulse:.2f}"
+                f"{pf.vs_cs_pf_total_pulse:.2f}",
             ],
         ))
 
@@ -2835,7 +2835,7 @@ class PFCoil(Model):
                     f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
                     f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
                     f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}",
-                    f"{cpft[k, 5] * nturn[k]:.3e}"
+                    f"{cpft[k, 5] * nturn[k]:.3e}",
                 ])
             else:
                 rows.append([
@@ -2845,7 +2845,7 @@ class PFCoil(Model):
                     f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
                     f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
                     f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}",
-                    f"{cpft[k, 5] * nturn[k]:.3e}"
+                    f"{cpft[k, 5] * nturn[k]:.3e}",
                 ])
 
         op.oblnkl(self.outfile)
@@ -2873,7 +2873,7 @@ class PFCoil(Model):
                     f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
                     f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
                     f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}",
-                    "0.0e0"
+                    "0.0e0",
                 ])
             else:
                 rows.append([
@@ -2883,7 +2883,7 @@ class PFCoil(Model):
                     f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
                     f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
                     f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}",
-                    "0.0e0"
+                    "0.0e0",
                 ])
 
         op.oblnkl(self.outfile)

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2436,12 +2436,15 @@ class PFCoil(Model):
             "1.0e0",
         ])
 
-        op.write(self.outfile, tabulate(
-            pf_coil_geometry_rows,
-            headers=["Coil", "R(m)", "Z(m)", "dR(m)", "dZ(m)", "turns"],
-            tablefmt="plain",
-            disable_numparse=True,
-        ))
+        op.write(
+            self.outfile,
+            tabulate(
+                pf_coil_geometry_rows,
+                headers=["Coil", "R(m)", "Z(m)", "dR(m)", "dZ(m)", "turns"],
+                tablefmt="plain",
+                disable_numparse=True,
+            ),
+        )
 
         for k in range(pf_d.nef):
             op.ovarre(
@@ -2629,12 +2632,15 @@ class PFCoil(Model):
         ])
 
         op.oblnkl(self.outfile)
-        op.write(self.outfile, tabulate(
-            rows,
-            headers=headers,
-            tablefmt="plain",
-            disable_numparse=True,
-        ))
+        op.write(
+            self.outfile,
+            tabulate(
+                rows,
+                headers=headers,
+                tablefmt="plain",
+                disable_numparse=True,
+            ),
+        )
 
         op.oblnkl(self.outfile)
         op.ocmmnt(self.outfile, "----------------------------")
@@ -2659,35 +2665,39 @@ class PFCoil(Model):
         op.oheadr(self.outfile, "Volt Second Consumption")
 
         pf = self.data.pf_coil
-        headers = [
-            "",
-            "Start-up (Vs)",
-            "Burn (Vs)",
-            "Total (Vs)"
-        ]
+        headers = ["", "Start-up (Vs)", "Burn (Vs)", "Total (Vs)"]
         rows = []
         rows.extend((
-            ["PF coils",
+            [
+                "PF coils",
                 f"{pf.vs_pf_coils_total_ramp:.2f}",
-            f"{pf.vs_pf_coils_total_burn:.2f}",
-            f"{pf.vs_pf_coils_total_pulse:.2f}"],
-            ["CS coil",
+                f"{pf.vs_pf_coils_total_burn:.2f}",
+                f"{pf.vs_pf_coils_total_pulse:.2f}"
+            ],
+            [
+                "CS coil",
                 f"{pf.vs_cs_ramp:.2f}",
-            f"{pf.vs_cs_burn:.2f}",
-            f"{pf.vs_cs_total_pulse:.2f}"],
-            ["Total",
-            f"{pf.vs_cs_pf_total_ramp:.2f}",
-            f"{pf.vs_cs_pf_total_burn:.2f}",
-            f"{pf.vs_cs_pf_total_pulse:.2f}"]
+                f"{pf.vs_cs_burn:.2f}",
+                f"{pf.vs_cs_total_pulse:.2f}"
+            ],
+            [
+                "Total",
+                f"{pf.vs_cs_pf_total_ramp:.2f}",
+                f"{pf.vs_cs_pf_total_burn:.2f}",
+                f"{pf.vs_cs_pf_total_pulse:.2f}"
+            ],
         ))
 
         op.oblnkl(self.outfile)
-        op.write(self.outfile, tabulate(
-            rows,
-            headers=headers,
-            tablefmt="plain",
-            disable_numparse=True,
-        ))
+        op.write(
+            self.outfile,
+            tabulate(
+                rows,
+                headers=headers,
+                tablefmt="plain",
+                disable_numparse=True,
+            ),
+        )
         op.oblnkl(self.outfile)
         op.ovarre(
             self.outfile,
@@ -2706,19 +2716,14 @@ class PFCoil(Model):
 
         op.osubhd(self.outfile, "Summary of volt-second consumption by circuit (Wb):")
         op.oblnkl(self.outfile)
-        headers = [
-            "Circuit",
-            "BOP",
-            "BOF",
-            "EOF"
-        ]
+        headers = ["Circuit", "BOP", "BOF", "EOF"]
         rows = []
         for k in range(pf.nef):
             rows.append([
                 f"PF {k + 1}",
                 f"{pf.vsdum[k, 0]:.3f}",
                 f"{pf.vsdum[k, 1]:.3f}",
-                f"{pf.vsdum[k, 2]:.3f}"
+                f"{pf.vsdum[k, 2]:.3f}",
             ])
 
         n_cs = pf.n_cs_pf_coils - 1
@@ -2726,15 +2731,18 @@ class PFCoil(Model):
             "CS coil",
             f"{pf.vsdum[n_cs, 0]:.3f}",
             f"{pf.vsdum[n_cs, 1]:.3f}",
-            f"{pf.vsdum[n_cs, 2]:.3f}"
+            f"{pf.vsdum[n_cs, 2]:.3f}",
         ])
         op.oblnkl(self.outfile)
-        op.write(self.outfile, tabulate(
-            rows,
-            headers=headers,
-            tablefmt="plain",
-            disable_numparse=True,
-        ))
+        op.write(
+            self.outfile,
+            tabulate(
+                rows,
+                headers=headers,
+                tablefmt="plain",
+                disable_numparse=True,
+            ),
+        )
         op.oblnkl(self.outfile)
 
         op.oshead(self.outfile, "Waveforms")
@@ -2759,12 +2767,15 @@ class PFCoil(Model):
         for k in range(pulse_timings.n_pf_active_points_total):
             line += [f"{pulse_timings.pf_active_cumulative[k]:.2f}"]
         rows = [line]
-        op.write(self.outfile, tabulate(
-            rows,
-            headers=headers[1:],
-            tablefmt="plain",
-            disable_numparse=True,
-        ))
+        op.write(
+            self.outfile,
+            tabulate(
+                rows,
+                headers=headers[1:],
+                tablefmt="plain",
+                disable_numparse=True,
+            ),
+        )
 
         op.oblnkl(self.outfile)
         op.write(self.outfile, "Currents (A)")
@@ -2782,8 +2793,9 @@ class PFCoil(Model):
         inv_st_pulse = 1.0e0 / pf_d.f_j_cs_start_pulse_end_flat_top
 
         for k in range(self.data.pf_coil.n_pf_cs_plasma_circuits - 1):
-            if (self.data.build.iohcl != 0) and (k ==
-                        self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
+            if (self.data.build.iohcl != 0) and (
+                k == self.data.pf_coil.n_pf_cs_plasma_circuits - 2
+            ):
                 line = ["CS"]
             else:
                 line = [f"PF {k + 1}"]
@@ -2798,81 +2810,92 @@ class PFCoil(Model):
 
         # op.write(self.outfile, line)
         op.oblnkl(self.outfile)
-        op.write(self.outfile, tabulate(
-            rows,
-            headers=headers,
-            tablefmt="plain",
-            disable_numparse=True,
-        ))
+        op.write(
+            self.outfile,
+            tabulate(
+                rows,
+                headers=headers,
+                tablefmt="plain",
+                disable_numparse=True,
+            ),
+        )
 
         op.oblnkl(self.outfile)
 
         op.ocmmnt(self.outfile, "This consists of: CS coil field balancing:")
         rows = []
         for k in range(pf_d.n_pf_cs_plasma_circuits - 1):
-            if (self.data.build.iohcl != 0) and (k ==
-                                    self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
+            if (self.data.build.iohcl != 0) and (
+                k == self.data.pf_coil.n_pf_cs_plasma_circuits - 2
+            ):
                 rows.append([
-                        "CS",
-                        f"{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}",
-                        f"{cpft[k, 1] * nturn[k]:.3e}",
-                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
-                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
-                        f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}",
-                        f"{cpft[k, 5] * nturn[k]:.3e}"
-                    ])
+                    "CS",
+                    f"{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}",
+                    f"{cpft[k, 1] * nturn[k]:.3e}",
+                    f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
+                    f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
+                    f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}",
+                    f"{cpft[k, 5] * nturn[k]:.3e}"
+                ])
             else:
                 rows.append([
-                        f"PF {k + 1}",
-                        f"{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}",
-                        f"{cpft[k, 1] * nturn[k]:.3e}",
-                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
-                        f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
-                        f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}",
-                        f"{cpft[k, 5] * nturn[k]:.3e}"
-                    ])
+                    f"PF {k + 1}",
+                    f"{cpft[k, 0] * pf_d.n_pf_coil_turns[k]:.3e}",
+                    f"{cpft[k, 1] * nturn[k]:.3e}",
+                    f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
+                    f"{-cpft[k, 1] * nturn[k] * se_ft_eft:.3e}",
+                    f"{-cpft[k, 1] * nturn[k] * inv_st_pulse:.3e}",
+                    f"{cpft[k, 5] * nturn[k]:.3e}"
+                ])
 
         op.oblnkl(self.outfile)
-        op.write(self.outfile, tabulate(
-            rows,
-            headers=headers,
-            tablefmt="plain",
-            disable_numparse=True,
-        ))
+        op.write(
+            self.outfile,
+            tabulate(
+                rows,
+                headers=headers,
+                tablefmt="plain",
+                disable_numparse=True,
+            ),
+        )
 
         op.oblnkl(self.outfile)
         op.ocmmnt(self.outfile, "And: equilibrium field:")
         rows = []
         for k in range(pf_d.n_pf_cs_plasma_circuits - 1):
-            if (self.data.build.iohcl != 0) and (k ==
-                                    self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
+            if (self.data.build.iohcl != 0) and (
+                k == self.data.pf_coil.n_pf_cs_plasma_circuits - 2
+            ):
                 rows.append([
-                        "CS",
-                        f"{0.0:.3e}",
-                        f"{0.0:.3e}",
-                        f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
-                        f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
-                        f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}",
-                        "0.0e0"
-                    ])
+                    "CS",
+                    f"{0.0:.3e}",
+                    f"{0.0:.3e}",
+                    f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
+                    f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
+                    f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}",
+                    "0.0e0"
+                ])
             else:
                 rows.append([
-                        f"PF {k + 1}",
-                        f"{0.0:.3e}",
-                        f"{0.0:.3e}",
-                        f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
-                        f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
-                        f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}",
-                        "0.0e0"
+                    f"PF {k + 1}",
+                    f"{0.0:.3e}",
+                    f"{0.0:.3e}",
+                    f"{(cpft[k, 2] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
+                    f"{(cpft[k, 3] + cpft[k, 1] * se_ft_eft) * nturn[k]:.3e}",
+                    f"{(cpft[k, 4] + cpft[k, 1] * inv_st_pulse) * nturn[k]:.3e}",
+                    "0.0e0"
                 ])
 
         op.oblnkl(self.outfile)
-        op.write(self.outfile, tabulate(
-            rows,
-            headers=headers,
-            tablefmt="plain",
-            disable_numparse=True,
-        ))
+        op.write(
+            self.outfile,
+            tabulate(
+                rows,
+                headers=headers,
+                tablefmt="plain",
+                disable_numparse=True,
+            ),
+        )
 
         op.oblnkl(self.outfile)
         op.ovarre(
@@ -2902,8 +2925,9 @@ class PFCoil(Model):
                 if k == self.data.pf_coil.n_pf_cs_plasma_circuits - 1:
                     circuit_name = f"Plasma Time point {jjj} (A)"
                     circuit_var_name = f"(plasmat{jjj})"
-                elif (self.data.build.iohcl != 0) and (k ==
-                                        self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
+                elif (self.data.build.iohcl != 0) and (
+                    k == self.data.pf_coil.n_pf_cs_plasma_circuits - 2
+                ):
                     circuit_name = f"CS Circuit Time point {jjj} (A)"
                     circuit_var_name = f"(cs t{jjj})"
                 else:

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2765,11 +2765,10 @@ class PFCoil(Model):
         rows = []
         for k in range(pulse_timings.n_pf_active_points_total):
             rows += [f"{pulse_timings.pf_active_cumulative[k]:.2f}"]
-        rows = [rows]
         op.write(
             self.outfile,
             tabulate(
-                rows,
+                [rows],
                 headers=headers[1:],
                 tablefmt="plain",
                 disable_numparse=True,

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2666,8 +2666,7 @@ class PFCoil(Model):
 
         pf = self.data.pf_coil
         headers = ["", "Start-up (Vs)", "Burn (Vs)", "Total (Vs)"]
-        rows = []
-        rows.extend((
+        rows = [
             [
                 "PF coils",
                 f"{pf.vs_pf_coils_total_ramp:.2f}",
@@ -2686,7 +2685,7 @@ class PFCoil(Model):
                 f"{pf.vs_cs_pf_total_burn:.2f}",
                 f"{pf.vs_cs_pf_total_pulse:.2f}",
             ],
-        ))
+        ]
 
         op.oblnkl(self.outfile)
         op.write(
@@ -2763,10 +2762,10 @@ class PFCoil(Model):
         for k in range(pulse_timings.n_pf_active_points_total):
             label = pulse_timings.POINT_ABBREVIATIONS[k]
             headers.append(label)
-        line = []
+        rows = []
         for k in range(pulse_timings.n_pf_active_points_total):
-            line += [f"{pulse_timings.pf_active_cumulative[k]:.2f}"]
-        rows = [line]
+            rows += [f"{pulse_timings.pf_active_cumulative[k]:.2f}"]
+        rows = [rows]
         op.write(
             self.outfile,
             tabulate(

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2890,6 +2890,34 @@ class PFCoil(Model):
             "OP ",
         )
 
+        op.oshead(self.outfile, "PF Circuit Waveform Data")
+        op.ovarre(
+            self.outfile,
+            "Number of PF circuits including CS and plasma",
+            "(n_pf_cs_plasma_circuits)",
+            self.data.pf_coil.n_pf_cs_plasma_circuits,
+        )
+        for k in range(self.data.pf_coil.n_pf_cs_plasma_circuits):
+            for jjj in range(6):
+                if k == self.data.pf_coil.n_pf_cs_plasma_circuits - 1:
+                    circuit_name = f"Plasma Time point {jjj} (A)"
+                    circuit_var_name = f"(plasmat{jjj})"
+                elif (self.data.build.iohcl != 0) and (k ==
+                                        self.data.pf_coil.n_pf_cs_plasma_circuits - 2):
+                    circuit_name = f"CS Circuit Time point {jjj} (A)"
+                    circuit_var_name = f"(cs t{jjj})"
+                else:
+                    circuit_name = f"PF Circuit {k + 1} Time point {jjj} (A)"
+                    circuit_var_name = f"(pfc{k}t{jjj})"
+
+                op.ovarre(
+                    self.outfile,
+                    circuit_name,
+                    circuit_var_name,
+                    self.data.pf_coil.c_pf_coil_turn[k, jjj]
+                    * self.data.pf_coil.n_pf_coil_turns[k],
+                )
+
     @staticmethod
     def selfinductance(a, b, c, n):
         """Calculates the selfinductance using Bunet's formula.

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2913,7 +2913,7 @@ class PFCoil(Model):
             "OP ",
         )
 
-        op.oshead(self.mfile, "PF Circuit Waveform Data")
+        # Add output for the MFILE to parse
         op.ovarre(
             self.mfile,
             "Number of PF circuits including CS and plasma",

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2913,9 +2913,9 @@ class PFCoil(Model):
             "OP ",
         )
 
-        op.oshead(self.outfile, "PF Circuit Waveform Data")
+        op.oshead(self.mfile, "PF Circuit Waveform Data")
         op.ovarre(
-            self.outfile,
+            self.mfile,
             "Number of PF circuits including CS and plasma",
             "(n_pf_cs_plasma_circuits)",
             self.data.pf_coil.n_pf_cs_plasma_circuits,
@@ -2935,7 +2935,7 @@ class PFCoil(Model):
                     circuit_var_name = f"(pfc{k}t{jjj})"
 
                 op.ovarre(
-                    self.outfile,
+                    self.mfile,
                     circuit_name,
                     circuit_var_name,
                     self.data.pf_coil.c_pf_coil_turn[k, jjj]

--- a/process/models/pfcoil.py
+++ b/process/models/pfcoil.py
@@ -2808,7 +2808,6 @@ class PFCoil(Model):
             line += [f"{cpft[self.data.pf_coil.n_pf_cs_plasma_circuits - 1, jj]:.3e}"]
         rows.append(line)
 
-        # op.write(self.outfile, line)
         op.oblnkl(self.outfile)
         op.write(
             self.outfile,


### PR DESCRIPTION
## Description

closes #4502 

In MFILE.DAT and OUT.DAT there were many places where PF coils were numbered from 0. This has been updated to start from 1.

Also in places such as Volt Second Consumption and Waveforms all the circuits were numbers, the final number has now shows CS as that's what it is. However in the PF Circuit Waveform Data section I left the circuit_var_name as the original as it is a var not an output name.

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
