### PR TITLE
Fix Newman-Raju G22 term in surface crack SIF for a > c

### DIFF
--- a/process/models/cs_fatigue.py
+++ b/process/models/cs_fatigue.py
@@ -241,7 +241,7 @@ class CsFatigue(Model):
             H2 = (
                 1.0e0
                 + (-2.11e0 + 0.77e0 * c_a) * a_t  # G21 * a / t
-                + (0.55e0 - 0.72e0 * c_a**0.75e0 + 0.14e0 * c_a * 1.5e0) * a_t_2  # G22
+                + (0.55e0 - 0.72e0 * c_a**0.75e0 + 0.14e0 * c_a**1.5e0) * a_t_2  # G22
             )
 
         # compute the unitless geometric correction

--- a/tests/unit/models/test_cs_fatigue.py
+++ b/tests/unit/models/test_cs_fatigue.py
@@ -116,7 +116,36 @@ def test_embedded_stress_intensity_factor(
             0.0026699999999999996,
             1.5707963267948966,
             35.744426954844926,
-        )
+        ),
+        # a > c branch, phi = pi/2 and phi = 0. Expected values computed
+        # independently from the Newman-Raju surface-crack equations
+        # (NASA TM, "Stress-Intensity Factor Equations for Cracks in
+        # Three-Dimensional Finite Bodies Subjected to Tension and Bending
+        # Loads") for a/c > 1 with zero bending:
+        # Q = 1 + 1.464(c/a)^1.65, M1 = sqrt(c/a)(1 + 0.04 c/a),
+        # M2 = 0.2(c/a)^4, M3 = -0.11(c/a)^4,
+        # g = 1 + [0.1 + 0.35 (c/a)(a/t)^2](1 - sin(phi))^2,
+        # f_phi = [(c/a)^2 sin^2(phi) + cos^2(phi)]^0.25,
+        # f_w = sec[pi c/(2w) sqrt(a/t)]^0.5,
+        # K = sigma (M1 + M2 (a/t)^2 + M3 (a/t)^4) g f_phi f_w sqrt(pi a / Q)
+        (
+            659.99351867335338,
+            0.0063104538380405924,
+            0.0063104538380405924,
+            0.0026699999999999996,
+            0.00088999999999999995,
+            1.5707963267948966,
+            18.451605120658158,
+        ),
+        (
+            659.99351867335338,
+            0.0063104538380405924,
+            0.0063104538380405924,
+            0.0026699999999999996,
+            0.00088999999999999995,
+            0.0,
+            35.82251644569079,
+        ),
     ],
 )
 def test_surface_stress_intensity_factor(


### PR DESCRIPTION
Closes #4530

## Overview
One-token fix in `process/models/cs_fatigue.py`: the a > c branch of `surface_stress_intensity_factor` computed G22 as `0.14e0 * c_a * 1.5e0` where the Newman-Raju equation (and the a <= c branch) requires `0.14e0 * c_a**1.5e0`.

## Changes
- `process/models/cs_fatigue.py`: `*` → `**` in the G22 term.
- `tests/unit/models/test_cs_fatigue.py`: add two a > c parametrised cases (phi = pi/2 and phi = 0) to `test_surface_stress_intensity_factor`, with expected K values computed independently from the Newman-Raju equations (derivation in the test comment). The a > c branch previously had zero test coverage.

## Notes for reviewers
- **No output changes**: `bending_stress` is hardcoded to 0 inside the function, so H2 (which contains G22) never reaches the returned K today — the existing golden values are untouched and regression outputs are unaffected. The fix removes a landmine for whenever bending is parameterised.
- If there is interest, a follow-up could lift `bending_stress` to a parameter (default 0) so H1/H2 become testable directly.
- Unit suite passes locally (Python 3.12).

Found during an independent audit of v3.4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)