### PR TITLE
Impurity radiation corrections

### DIFF
--- a/process/core/caller.py
+++ b/process/core/caller.py
@@ -419,7 +419,7 @@ def finalise(models, data, ifail: int, non_idempotent_msg: str | None = None):
         po.oheadr(constants.NOUT, "Final UNFEASIBLE Point")
 
     # Output relevant to no optimisation
-    if data.numerics.ioptimz == PROCESSRunMode.EVALUATION:
+    if data.numerics.ioptimz in {PROCESSRunMode.EVALUATION, PROCESSRunMode.SOLUTION}:
         output_evaluation(data)
 
     # Print non-idempotence warning to OUT.DAT only

--- a/process/core/caller.py
+++ b/process/core/caller.py
@@ -206,9 +206,28 @@ class Caller:
                     OutputFileManager.close_idempotence_files(
                         self.data.globals.output_prefix
                     )
+
+                    # Now idempotent, return
+                    # Pass model caller and opt params for stability constraint evaluation
+                    con_residuals_normalised, _, con_residuals, _, _ = (
+                        constraints.constraint_eqns(
+                            self.data.numerics.neqns + self.data.numerics.nineqns,
+                            -1,
+                            self.data,
+                        )
+                    )
+                    # Evaluate constraints and store in numerics during solver iterations:
+                    # can be used in objective function 20. Hence evaluate before objective
+                    # calculated
+                    self.data.numerics.constraint_residuals_normalised = (
+                        con_residuals_normalised
+                    )
+                    self.data.numerics.constraint_residuals = con_residuals
+                    # Evaluate objective function and constraints
+                    objf = objective_function(self.data.numerics.minmax, self.data)
                     # Write final output file and mfile
                     finalise(self.models, self.data, ifail)
-                    return
+                    return objf, con_residuals_normalised
 
                 # Mfiles not yet idempotent: need to re-evaluate models
                 logger.debug("Mfiles not idempotent, evaluating models again")

--- a/process/data_structure/numerics.py
+++ b/process/data_structure/numerics.py
@@ -49,13 +49,15 @@ class PROCESSRunMode(IntEnum):
     """In this mode, the code will not perform any optimisation, and will instead
     simply evaluate the constraints for the given input parameters, which is useful
     for testing and for evaluating the performance of a given design point without
-    trying to optimise it. Internally, PROCESS uses `fsolve` (a Newton-Krylov/hybrd
+    trying to optimise it.
+    """
+    SOLUTION = (-1, "Solution mode (no optimisation)")
+    """Internally, PROCESS uses `fsolve` (a Newton-Krylov/hybrd
     root-finding method from `scipy.optimize`) to seek a *consistent* solution by
     varying a subset of the iteration variables until the consistency constraints
     (equality constraints whose residuals must be driven to zero) are simultaneously
     satisfied; no figure-of-merit is optimised, and the solver simply tries to find
-    a root of the constraint-residual vector.
-    """
+    a root of the constraint-residual vector."""
     OPTIMISATION = (1, "Optimisation mode (e.g. via VMCON)")
     """In this mode, the code will perform optimisation using the VMCON solver
     (or a custom solver if specified) to try to find a design point that optimises

--- a/process/data_structure/numerics.py
+++ b/process/data_structure/numerics.py
@@ -184,6 +184,14 @@ class NumericsData:
     nvar: int = 0
     """number of iteration variables to use"""
 
+    # Constraint residuals, updated on every iteration
+    constraint_residuals_normalised: list[float] = field(
+        default_factory=lambda: np.array([0] * IPEQNS)
+    )
+    constraint_residuals: list[float] = field(
+        default_factory=lambda: np.array([0] * IPEQNS)
+    )
+
     nviter: int = 0
     """number of optimisation iterations performed"""
 

--- a/process/data_structure/physics_variables.py
+++ b/process/data_structure/physics_variables.py
@@ -1078,6 +1078,9 @@ class PhysicsData:
     pden_plasma_core_rad_mw: float = 0.0
     """total core radiation power per volume (MW/m3)"""
 
+    pden_plasma_core_rad_tauE_mw: float = 0.0
+    """reduced total core radiation power for tauE calculation (MW/m3)"""
+
     p_dd_total_mw: float = 0.0
     """deuterium-deuterium fusion power (MW)"""
 

--- a/process/main.py
+++ b/process/main.py
@@ -119,6 +119,8 @@ from process.models.tfcoil.superconducting import (
 )
 from process.models.vacuum import Vacuum, VacuumVessel
 from process.models.water_use import WaterUse
+from process.core.caller import write_output_files
+from process.core.solver.iteration_variables import load_iteration_variables
 
 PACKAGE_LOGGING = True
 """Can be set False to disable package-level logging, e.g. in the test suite"""
@@ -449,10 +451,19 @@ class SingleRun:
         # ioptimz == 1: optimisation
         if self.data.numerics.ioptimz == PROCESSRunMode.OPTIMISATION:
             pass
-        elif self.data.numerics.ioptimz == PROCESSRunMode.EVALUATION:
-            # No optimisation:
-            # solve equality (consistency) constraints only using fsolve (HYBRD)
+        # ioptimz == -1: solution
+        elif self.data.numerics.ioptimz == PROCESSRunMode.SOLUTION:
+            # Solve equality (consistency) constraints only using fsolve (HYBRD)
             self.solver = "fsolve"
+        # ioptimz == -2: evaluation
+        elif self.data.numerics.ioptimz == PROCESSRunMode.EVALUATION:
+            # Evalutation only: compute the output variables now
+            # Get optimisation parameters x, evaluate models
+            load_iteration_variables(self.data)
+            self.ifail = 6
+            write_output_files(data=self.data, models=self.models, ifail=self.ifail)
+            self.show_errors()
+            return
         else:
             raise ValueError(
                 f"Invalid ioptimz value: {self.data.numerics.ioptimz}. Please "

--- a/process/models/costs/costs.py
+++ b/process/models/costs/costs.py
@@ -2854,7 +2854,8 @@ class Costs(Model):
 
         #  Capital recovery factor
 
-        crfcdr = (fefcdr * self.data.costs.discount_rate) / (fefcdr - 1.0e0)
+        # crfcdr = (fefcdr * self.data.costs.discount_rate) / (fefcdr - 1.0e0)
+        crfcdr = 1.0
 
         #  Annual cost of replacements
 

--- a/process/models/physics/confinement_time.py
+++ b/process/models/physics/confinement_time.py
@@ -18,6 +18,7 @@ from process.data_structure.physics_variables import (
     PlasmaIgnitionModel,
 )
 from process.models.physics.plasma_geometry import PlasmaGeom
+from process.models.physics import impurity_radiation
 
 logger = logging.getLogger(__name__)
 
@@ -166,8 +167,16 @@ class PlasmaConfinementTime(Model):
         try:
             model = ConfinementRadiationLossModel(int(self.data.physics.i_rad_loss))
 
+            # pden_plasma_core_rad_mw was reduced here, but if full radiation, not used!
+            # rad_reduction_for_tauE_only option allows full radiation model in PPB,
+            # but reduced radiation here in confinement time calculation
             if model == ConfinementRadiationLossModel.FULL_RADIATION:
-                p_plasma_loss_mw -= self.data.physics.pden_plasma_rad_mw * vol_plasma
+                if impurity_radiation.rad_reduction_for_tauE_only:
+                    # Reduced rad
+                    p_plasma_loss_mw -= pden_plasma_core_rad_mw * vol_plasma
+                else:
+                    # Not reduced rad
+                    p_plasma_loss_mw -= self.data.physics.pden_plasma_rad_mw * vol_plasma
             elif model == ConfinementRadiationLossModel.CORE_ONLY:
                 p_plasma_loss_mw -= pden_plasma_core_rad_mw * vol_plasma
             # NO_RADIATION: do not adjust p_plasma_loss_mw for radiation

--- a/process/models/physics/impurity_radiation.py
+++ b/process/models/physics/impurity_radiation.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 include_edge_radiation = False
+int_edge_rad = False
+rho_fix = False
 
 
 def initialise_imprad(data: DataStructure):
@@ -630,6 +632,12 @@ def element2index(element: str, data: DataStructure):
         ) from e
 
 
+# Globals for ease of extraction for investigation plotting only
+global pden_impurity_rad_profile
+global pden_impurity_core_rad_profile
+global pden_impurity_rad_edge_profile
+
+
 class ImpurityRadiation:
     """Calculates the impurity radiation losses for given temperature and
     density profiles. The considers the  total impurity radiation from the core
@@ -707,14 +715,24 @@ class ImpurityRadiation:
         values.
         """
         # Core region radiation profile
-        pden_impurity_core_rad_total = self.pden_impurity_radiation_profile * (
-            self.plasma_profile.neprofile.profile_x
-            * create_f_rad_core_profile(
-                rho=self.plasma_profile.neprofile.profile_x,
-                radius_plasma_core_norm=self.data.impurity_radiation.radius_plasma_core_norm,
-                f_p_plasma_core_rad_reduction=self.data.impurity_radiation.f_p_plasma_core_rad_reduction,
+        # Should this be multiplied by profile_x? Causes 0 power density at rho = 0
+        if rho_fix:
+            pden_impurity_core_rad_total = self.pden_impurity_radiation_profile * (
+                create_f_rad_core_profile(
+                    rho=self.plasma_profile.neprofile.profile_x,
+                    radius_plasma_core_norm=self.data.impurity_radiation.radius_plasma_core_norm,
+                    f_p_plasma_core_rad_reduction=self.data.impurity_radiation.f_p_plasma_core_rad_reduction,
+                )
             )
-        )
+        else:
+            pden_impurity_core_rad_total = self.pden_impurity_radiation_profile * (
+                self.plasma_profile.neprofile.profile_x
+                * create_f_rad_core_profile(
+                    rho=self.plasma_profile.neprofile.profile_x,
+                    radius_plasma_core_norm=self.data.impurity_radiation.radius_plasma_core_norm,
+                    f_p_plasma_core_rad_reduction=self.data.impurity_radiation.f_p_plasma_core_rad_reduction,
+                )
+            )
         if include_edge_radiation:
             # Explicitly include edge radiation
             # Edge region radiation profile
@@ -737,6 +755,7 @@ class ImpurityRadiation:
                 self.pden_impurity_rad_edge_profile, pden_impurity_rad_edge_total
             )
         else:
+            # Old case
             pden_impurity_rad_total = (
                 self.pden_impurity_radiation_profile
                 * self.plasma_profile.neprofile.profile_x
@@ -748,6 +767,14 @@ class ImpurityRadiation:
         self.pden_impurity_core_rad_profile = np.add(
             self.pden_impurity_core_rad_profile, pden_impurity_core_rad_total
         )
+
+        global pden_impurity_rad_profile
+        global pden_impurity_core_rad_profile
+        global pden_impurity_rad_edge_profile
+
+        pden_impurity_rad_profile = self.pden_impurity_rad_profile
+        pden_impurity_core_rad_profile = self.pden_impurity_core_rad_profile
+        pden_impurity_rad_edge_profile = self.pden_impurity_rad_edge_profile
 
     def integrate_radiation_loss_profiles(self):
         """Integrate the radiation loss profiles using the Simpson rule.

--- a/process/models/physics/impurity_radiation.py
+++ b/process/models/physics/impurity_radiation.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 include_edge_radiation = False
 int_edge_rad = False
 rho_fix = False
+rad_reduction_for_tauE_only = False
 
 
 def initialise_imprad(data: DataStructure):
@@ -669,6 +670,9 @@ class ImpurityRadiation:
         self.pden_impurity_core_rad_profile = np.zeros(
             self.data.physics.n_plasma_profile_elements
         )
+        self.pden_impurity_core_rad_profile_tauE = np.zeros(
+            self.data.physics.n_plasma_profile_elements
+        )
         self.pden_impurity_rad_edge_profile = np.zeros(
             self.data.physics.n_plasma_profile_elements
         )
@@ -676,6 +680,7 @@ class ImpurityRadiation:
         self.pden_impurity_rad_total_mw = 0.0
         self.pden_impurity_core_rad_total_mw = 0.0
         self.pden_impurity_rad_edge_total_mw = 0.0
+        self.pden_impurity_core_rad_total_tauE_mw = 0.0
 
     def run(self):
         """ImpurityRadiation model isn't run"""
@@ -719,22 +724,39 @@ class ImpurityRadiation:
         # wrong here: causes 0 power density at rho = 0. Should be performed in
         # power integral instead
         if rho_fix:
-            pden_impurity_core_rad_total = self.pden_impurity_radiation_profile * (
-                create_f_rad_core_profile(
-                    rho=self.plasma_profile.neprofile.profile_x,
-                    radius_plasma_core_norm=self.data.impurity_radiation.radius_plasma_core_norm,
-                    f_p_plasma_core_rad_reduction=self.data.impurity_radiation.f_p_plasma_core_rad_reduction,
-                )
-            )
+            rho = np.ones_like(self.plasma_profile.neprofile.profile_x)
         else:
-            pden_impurity_core_rad_total = self.pden_impurity_radiation_profile * (
-                self.plasma_profile.neprofile.profile_x
-                * create_f_rad_core_profile(
-                    rho=self.plasma_profile.neprofile.profile_x,
-                    radius_plasma_core_norm=self.data.impurity_radiation.radius_plasma_core_norm,
-                    f_p_plasma_core_rad_reduction=self.data.impurity_radiation.f_p_plasma_core_rad_reduction,
-                )
+            rho = self.plasma_profile.neprofile.profile_x
+
+        # Optionally treat core radiation reduction separately for tauE calculation and
+        # plasma power balance
+        f_p_plasma_core_rad_reduction_tauE = (
+            self.data.impurity_radiation.f_p_plasma_core_rad_reduction
+        )
+        if rad_reduction_for_tauE_only:
+            # Only reduce radiation for tauE calculation
+            f_p_plasma_core_rad_reduction = 1.0
+        else:
+            # Reduce radiation in PPB as well
+            f_p_plasma_core_rad_reduction = f_p_plasma_core_rad_reduction_tauE
+
+        pden_impurity_core_rad_total = self.pden_impurity_radiation_profile * (
+            rho
+            * create_f_rad_core_profile(
+                rho=self.plasma_profile.neprofile.profile_x,
+                radius_plasma_core_norm=self.data.impurity_radiation.radius_plasma_core_norm,
+                f_p_plasma_core_rad_reduction=f_p_plasma_core_rad_reduction,
             )
+        )
+        pden_impurity_core_rad_total_tauE = self.pden_impurity_radiation_profile * (
+            rho
+            * create_f_rad_core_profile(
+                rho=self.plasma_profile.neprofile.profile_x,
+                radius_plasma_core_norm=self.data.impurity_radiation.radius_plasma_core_norm,
+                f_p_plasma_core_rad_reduction=f_p_plasma_core_rad_reduction_tauE,
+            )
+        )
+
         if include_edge_radiation:
             # Explicitly include edge radiation
             # Edge region radiation profile
@@ -773,14 +795,18 @@ class ImpurityRadiation:
         self.pden_impurity_core_rad_profile = np.add(
             self.pden_impurity_core_rad_profile, pden_impurity_core_rad_total
         )
-
+        self.pden_impurity_core_rad_profile_tauE = np.add(
+            self.pden_impurity_core_rad_profile_tauE, pden_impurity_core_rad_total_tauE
+        )
         global pden_impurity_rad_profile
         global pden_impurity_core_rad_profile
         global pden_impurity_rad_edge_profile
+        global pden_impurity_core_rad_profile_tauE
 
         pden_impurity_rad_profile = self.pden_impurity_rad_profile
         pden_impurity_core_rad_profile = self.pden_impurity_core_rad_profile
         pden_impurity_rad_edge_profile = self.pden_impurity_rad_edge_profile
+        pden_impurity_core_rad_profile_tauE = self.pden_impurity_core_rad_profile_tauE
 
     def integrate_radiation_loss_profiles(self):
         """Integrate the radiation loss profiles using the Simpson rule.
@@ -806,6 +832,11 @@ class ImpurityRadiation:
         )
         self.pden_impurity_core_rad_total_mw = 2.0e-6 * integrate.simpson(
             self.pden_impurity_core_rad_profile * rho,
+            x=self.plasma_profile.neprofile.profile_x,
+            dx=self.plasma_profile.neprofile.profile_dx,
+        )
+        self.pden_impurity_core_rad_total_tauE_mw = 2.0e-6 * integrate.simpson(
+            self.pden_impurity_core_rad_profile_tauE * rho,
             x=self.plasma_profile.neprofile.profile_x,
             dx=self.plasma_profile.neprofile.profile_dx,
         )

--- a/process/models/physics/impurity_radiation.py
+++ b/process/models/physics/impurity_radiation.py
@@ -715,7 +715,9 @@ class ImpurityRadiation:
         values.
         """
         # Core region radiation profile
-        # Should this be multiplied by profile_x? Causes 0 power density at rho = 0
+        # Multiplication by "profile_x" (formerly rho, normalised minor radius)
+        # wrong here: causes 0 power density at rho = 0. Should be performed in
+        # power integral instead
         if rho_fix:
             pden_impurity_core_rad_total = self.pden_impurity_radiation_profile * (
                 create_f_rad_core_profile(
@@ -755,11 +757,15 @@ class ImpurityRadiation:
                 self.pden_impurity_rad_edge_profile, pden_impurity_rad_edge_total
             )
         else:
-            # Old case
-            pden_impurity_rad_total = (
-                self.pden_impurity_radiation_profile
-                * self.plasma_profile.neprofile.profile_x
-            )
+            # Old case: don't explicitly calculate edge radiation density
+            if rho_fix:
+                pden_impurity_rad_total = self.pden_impurity_radiation_profile
+
+            else:
+                pden_impurity_rad_total = (
+                    self.pden_impurity_radiation_profile
+                    * self.plasma_profile.neprofile.profile_x
+                )
 
         self.pden_impurity_rad_profile = np.add(
             self.pden_impurity_rad_profile, pden_impurity_rad_total
@@ -785,13 +791,21 @@ class ImpurityRadiation:
         # but are correct:
         # see github.com/ukaea/PROCESS/issues/3968#issuecomment-3491154712
         # and github.com/ukaea/PROCESS/issues/3968#issuecomment-4935567006
+
+        # Old case: rho multiplication already performed incorrectly in power
+        # density calculation: don't multiply again here
+        # New case (rho_fix): multiply correct power density here by rho
+        # for integration
+        rho = 1.0
+        if rho_fix:
+            rho = self.plasma_profile.neprofile.profile_x
         self.pden_impurity_rad_total_mw = 2.0e-6 * integrate.simpson(
-            self.pden_impurity_rad_profile,
+            self.pden_impurity_rad_profile * rho,
             x=self.plasma_profile.neprofile.profile_x,
             dx=self.plasma_profile.neprofile.profile_dx,
         )
         self.pden_impurity_core_rad_total_mw = 2.0e-6 * integrate.simpson(
-            self.pden_impurity_core_rad_profile,
+            self.pden_impurity_core_rad_profile * rho,
             x=self.plasma_profile.neprofile.profile_x,
             dx=self.plasma_profile.neprofile.profile_dx,
         )
@@ -799,7 +813,7 @@ class ImpurityRadiation:
         if include_edge_radiation:
             # Integrate edge explicitly
             self.pden_impurity_rad_edge_total_mw = 2.0e-6 * integrate.simpson(
-                self.pden_impurity_rad_edge_profile,
+                self.pden_impurity_rad_edge_profile * rho,
                 x=self.plasma_profile.neprofile.profile_x,
                 dx=self.plasma_profile.neprofile.profile_dx,
             )

--- a/process/models/physics/impurity_radiation.py
+++ b/process/models/physics/impurity_radiation.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from process.models.physics.plasma_profiles import PlasmaProfile
 
 logger = logging.getLogger(__name__)
+include_edge_radiation = False
 
 
 def initialise_imprad(data: DataStructure):
@@ -705,10 +706,7 @@ class ImpurityRadiation:
         radiation  (pden_impurity_rad_total_mw). Update the stored arrays with the
         values.
         """
-        pden_impurity_rad_total = (
-            self.pden_impurity_radiation_profile
-            * self.plasma_profile.neprofile.profile_x
-        )
+        # Core region radiation profile
         pden_impurity_core_rad_total = self.pden_impurity_radiation_profile * (
             self.plasma_profile.neprofile.profile_x
             * create_f_rad_core_profile(
@@ -717,6 +715,32 @@ class ImpurityRadiation:
                 f_p_plasma_core_rad_reduction=self.data.impurity_radiation.f_p_plasma_core_rad_reduction,
             )
         )
+        if include_edge_radiation:
+            # Explicitly include edge radiation
+            # Edge region radiation profile
+            fradedge_profile = np.zeros_like(self.plasma_profile.neprofile.profile_x)
+            edge_mask = (
+                self.plasma_profile.neprofile.profile_x
+                >= self.data.impurity_radiation.radius_plasma_core_norm
+            )
+            fradedge_profile[edge_mask] = 1.0  # Edge region gets full value
+            pden_impurity_rad_edge_total = (
+                self.pden_impurity_radiation_profile * fradedge_profile
+            )
+
+            # Total radiation profile (core + edge)
+            pden_impurity_rad_total = (
+                pden_impurity_core_rad_total + pden_impurity_rad_edge_total
+            )
+
+            self.pden_impurity_rad_edge_profile = np.add(
+                self.pden_impurity_rad_edge_profile, pden_impurity_rad_edge_total
+            )
+        else:
+            pden_impurity_rad_total = (
+                self.pden_impurity_radiation_profile
+                * self.plasma_profile.neprofile.profile_x
+            )
 
         self.pden_impurity_rad_profile = np.add(
             self.pden_impurity_rad_profile, pden_impurity_rad_total
@@ -744,6 +768,14 @@ class ImpurityRadiation:
             x=self.plasma_profile.neprofile.profile_x,
             dx=self.plasma_profile.neprofile.profile_dx,
         )
+
+        if include_edge_radiation:
+            # Integrate edge explicitly
+            self.pden_impurity_rad_edge_total_mw = 2.0e-6 * integrate.simpson(
+                self.pden_impurity_rad_edge_profile,
+                x=self.plasma_profile.neprofile.profile_x,
+                dx=self.plasma_profile.neprofile.profile_dx,
+            )
 
     def calculate_imprad(self):
         """Call the map function to calculate impurity radiation parameters for each

--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -751,6 +751,9 @@ class Physics(Model):
         self.data.physics.pden_plasma_core_rad_mw = radpwrdata.pden_plasma_core_rad_mw
         self.data.physics.pden_plasma_outer_rad_mw = radpwrdata.pden_plasma_outer_rad_mw
         self.data.physics.pden_plasma_rad_mw = radpwrdata.pden_plasma_rad_mw
+        self.data.physics.pden_plasma_core_rad_tauE_mw = (
+            radpwrdata.pden_plasma_core_rad_tauE_mw
+        )
 
         self.data.physics.p_plasma_sync_mw = (
             self.data.physics.pden_plasma_sync_mw * self.data.physics.vol_plasma
@@ -871,6 +874,10 @@ class Physics(Model):
 
         # Calculate transport losses and energy confinement time using the
         # chosen scaling law
+        # Reduce pden to effectively modify the highly radiative regime confinement
+        # time scaling
+        reduced_pden = self.data.physics.pden_plasma_core_rad_tauE_mw
+
         confinement_time_data = self.confinement.calculate_confinement_time(
             m_fuel_amu=self.data.physics.m_fuel_amu,
             p_alpha_total_mw=self.data.physics.p_alpha_total_mw,
@@ -887,7 +894,7 @@ class Physics(Model):
             p_non_alpha_charged_mw=self.data.physics.p_non_alpha_charged_mw,
             p_hcd_injected_total_mw=self.data.current_drive.p_hcd_injected_total_mw,
             plasma_current=self.data.physics.plasma_current,
-            pden_plasma_core_rad_mw=self.data.physics.pden_plasma_core_rad_mw,
+            pden_plasma_core_rad_mw=reduced_pden,
             rmajor=self.data.physics.rmajor,
             rminor=self.data.physics.rminor,
             temp_plasma_electron_density_weighted_kev=self.data.physics.temp_plasma_electron_density_weighted_kev,

--- a/process/models/physics/radiation_power.py
+++ b/process/models/physics/radiation_power.py
@@ -104,7 +104,7 @@ def calculate_radiation_powers(
     imp_rad = impurity.ImpurityRadiation(plasma_profile, data_structure)
     imp_rad.calculate_imprad()
 
-    if include_edge_radiation:
+    if impurity.include_edge_radiation:
         # Use calculated edge radiation
         pden_plasma_outer_rad_mw = imp_rad.pden_impurity_rad_edge_total_mw
     else:

--- a/process/models/physics/radiation_power.py
+++ b/process/models/physics/radiation_power.py
@@ -14,6 +14,7 @@ from process.core.model import DataStructure
 from process.models.physics.plasma_profiles import PlasmaProfile
 
 logger = logging.getLogger(__name__)
+include_edge_radiation = False
 
 
 @dataclass
@@ -103,9 +104,14 @@ def calculate_radiation_powers(
     imp_rad = impurity.ImpurityRadiation(plasma_profile, data_structure)
     imp_rad.calculate_imprad()
 
-    pden_plasma_outer_rad_mw = (
-        imp_rad.pden_impurity_rad_total_mw - imp_rad.pden_impurity_core_rad_total_mw
-    )
+    if include_edge_radiation:
+        # Use calculated edge radiation
+        pden_plasma_outer_rad_mw = imp_rad.pden_impurity_rad_edge_total_mw
+    else:
+        # Use difference between total and core radiation
+        pden_plasma_outer_rad_mw = (
+            imp_rad.pden_impurity_rad_total_mw - imp_rad.pden_impurity_core_rad_total_mw
+        )
 
     # Synchrotron radiation power/volume; assumed to be from core only.
     pden_plasma_sync_mw = psync_albajar_fidone(

--- a/process/models/physics/radiation_power.py
+++ b/process/models/physics/radiation_power.py
@@ -25,6 +25,7 @@ class RadpwrData:
     pden_plasma_core_rad_mw: float
     pden_plasma_outer_rad_mw: float
     pden_plasma_rad_mw: float
+    pden_plasma_core_rad_tauE_mw: float
 
 
 def calculate_radiation_powers(
@@ -133,6 +134,9 @@ def calculate_radiation_powers(
     pden_plasma_core_rad_mw = (
         imp_rad.pden_impurity_core_rad_total_mw + pden_plasma_sync_mw
     )
+    pden_plasma_core_rad_tauE_mw = (
+        imp_rad.pden_impurity_core_rad_total_tauE_mw + pden_plasma_sync_mw
+    )
 
     # Total radiation power/volume.
     pden_plasma_rad_mw = imp_rad.pden_impurity_rad_total_mw + pden_plasma_sync_mw
@@ -142,6 +146,7 @@ def calculate_radiation_powers(
         pden_plasma_core_rad_mw,
         pden_plasma_outer_rad_mw,
         pden_plasma_rad_mw,
+        pden_plasma_core_rad_tauE_mw,
     )
 
 


### PR DESCRIPTION
Demonstrates the effect of various options for impurity radiation and allows their plotting: this is not intended to be merged in its current form, but as an investigation. Primarily, this demonstrates the importance of separating the reduced core radiation used for the confinement time calculation and the total radiation considered in the plasma power balance, which I currently believe is incorrect.

I hope the following figures highlight a few things and justify the actual changes I want to make. They are all made with the DEMO LAR solution point and varying tungsten fractions. Deliberate horizontal "jitter" is applied to the scatter plots to ensure overlapping points are discernable.

## Impurity radiation profiles
<img width="1509" height="499" alt="rad_profiles" src="https://github.com/user-attachments/assets/40e1ae46-4881-4921-b525-08e9e31d1b1f" />
The current impurity power densities are incorrect because they are multiplied prematurely by the normalised minor radius $\rho$ in preparation for the power integral. This has the effect of the power density dropping to 0 for $\rho = 0$, which is incorrect. The core radiation reduction is also evident outside of the confinement time scaling calculation, where it is only intended to be used. This is corrected. The edge integral is now performed explicitly in the 4th subfigure, which is used later subsequently.

## Radiation power
<img width="1168" height="485" alt="rad_totals" src="https://github.com/user-attachments/assets/0f6c5638-36e6-499c-9382-b83a7f574b1a" />

When the core radiation reduction is removed, the core radiation obviously increases, but the edge radiation decreases, due to the "edge = total - core" calculation that is currently used. The edge is optionally now integrated explicitly. The total radiation is the same in all cases.

## Separate radiation reduction for confinement time scaling only
<img width="1284" height="633" alt="pden_core_tauE" src="https://github.com/user-attachments/assets/8dbb7dc1-cc72-481f-bd84-1cfcb8ed9986" />


Two plasma core radiation power densities are now calculated: one for the confinement time scaling only, the other for the rest of the code. They only differ when the `tau E rad reduction` option is selected (brown), which is the only difference between the plots. This separates the radiation calculated for the rest of the models from the reduced value required by the scaling.

## Effect on plasma power balance (PPB)
<img width="984" height="654" alt="ppb" src="https://github.com/user-attachments/assets/9be8bb79-c4f7-4f0f-a14c-b9c8ab02b0c0" />

The effect of these various options on the absolute plasma power balance constraint residual in MW (i.e. MW m^-3,  then multiplied by plasma volume ) is shown. The "original" point being slightly above zero is probably due to using a slightly out-of-date solution vector relative to the current Process version. One real difference occurs from using the edge radiation in the PPB (purple) which should always be done in my view: the plasma is not in thermal equilibrium if the edge radiation is ignored. The second, larger, difference is due to the use of the reduced core radiation in the confinement time calculation only, rather than globally (i.e. in the PPB too). This is how this "correction" was originally intended to be used I believe: as a way of effectively changing the confinement time scaling for highly-radiative regimes. It should not affect the actual calculated radiation elsewhere in the models. Around 100 MW for low tungsten values is fairly significant.


I would like to always use the un-reduced total radiation (core and edge) in the plasma power balance calculation, and the reduced core radiation in the confinement time calculation only. This would mean that `i_rad_loss` and `f_p_plasma_core_rad_reduction` would only apply to the the confinement time calculation. I'm keen to hear your thoughts.