### PR TITLE
move st_init into set_device_type

### DIFF
--- a/process/core/init.py
+++ b/process/core/init.py
@@ -74,9 +74,6 @@ def init_process(data: DataStructure):
     # set the device type (icase)
     set_device_type(data)
 
-    # Initialise the Stellarator
-    st_init(data)
-
     # Check input data for errors/ambiguities
     check_process(inputs, data)
 
@@ -1343,3 +1340,4 @@ def set_device_type(data: DataStructure):
         data.globals.icase = "Inertial Fusion model"
     elif data.stellarator.istell != StellaratorModel.DISABLED:
         data.globals.icase = "Stellarator model"
+        st_init(data)

--- a/process/models/stellarator/initialization.py
+++ b/process/models/stellarator/initialization.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from process.data_structure.stellarator_variables import StellaratorModel
-
 if TYPE_CHECKING:
     from process.core.data_structure.base import DataStructure
 
@@ -17,9 +15,6 @@ def st_init(data: DataStructure):
     Many of these may override the values set in routine
 
     """
-    if data.stellarator.istell == StellaratorModel.DISABLED:
-        return
-
     data.numerics.boundu[0] = 40.0  # allow higher aspect ratio
 
     # These lines switch off tokamak specifics (solenoid, pf coils, pulses etc.).


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

Since set_device_type checks if the device is a stellarator, it makes sense to move st_init in here 

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
