### PR TITLE
Change set_filenames in single_run fixture to use file name instead of folder path

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -36,7 +36,7 @@ def single_run(monkeypatch, input_file, tmp_path):
     single_run.filepath = tmp_path
     single_run.models = None
     single_run.data = DataStructure()
-    single_run.set_filenames(tmp_path)
+    single_run.set_filenames(temp_input_file)
     single_run.initialise()
     return single_run
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -36,7 +36,7 @@ def single_run(monkeypatch, input_file, tmp_path):
     single_run.filepath = tmp_path
     single_run.models = None
     single_run.data = DataStructure()
-    single_run.set_filenames(temp_input_file)
+    single_run.set_filenames(None)
     single_run.initialise()
     return single_run
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->

Previously this test was using the `tmp_path` in `set_filenames`, leading to files being created with the name of the test inside a folder of the same name:
<img width="721" height="292" alt="image" src="https://github.com/user-attachments/assets/0e346924-3178-437c-92b3-89b142ca0c95" />


This change means the files created during a run of pytest now have the name of the file preserved:
<img width="721" height="292" alt="image" src="https://github.com/user-attachments/assets/2e5ccb34-e7d4-4ff8-8468-8250b0c320b3" />


## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
