### PR TITLE
Added logger warning for building variables when setting them to 0

### DIFF
--- a/process/core/init.py
+++ b/process/core/init.py
@@ -395,6 +395,13 @@ def check_process(inputs, data):  # noqa: ARG001
     if data.physics.f_plasma_fuel_tritium < 1.0e-3:  # tritium fraction is negligible
         data.buildings.triv = 0.0
         data.heat_transport.p_tritium_plant_electric_mw = 0.0
+        logger.warning(
+            "Due to negligible tritium fraction both 'data.buildings.triv'"
+            "(volume of tritium building) and "
+            "'data.heat_transport.p_tritium_plant_electric_mw'"
+            "(power required for tritium processing) are set to 0",
+            stacklevel=2,
+        )
 
     if data.impurity_radiation.f_nd_impurity_electrons[1] != 0.1:  # noqa: RUF069
         raise ProcessValidationError(


### PR DESCRIPTION
closes #4544 

## Description

Added warning when setting tritium building variables to 0 when tritium fraction negligible.

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
