### PR TITLE
Allow pdb to be used in pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,11 +248,12 @@ def process_models():
 @pytest.fixture
 def cli_runner():
     def _cli_runner(command, args: list[str] | None = None, exit_code=0):
-        result = CliRunner().invoke(command, args=args or [])
 
+        result = CliRunner(catch_exceptions=False).invoke(command, args=args or [])
         assert result.exit_code == exit_code, (
             f"{result.exception} "
             f"{''.join(traceback.format_exception(result.exc_info[1]))}"
         )
+        return result
 
     return _cli_runner


### PR DESCRIPTION
## Description

<!-- What does this PR do? Please list any issue that these changes address and how you have gone about implementing the changes -->
CliRunner catches all errors by default. Now it only catches sys exit. This means that `--pdb` now works as expected for pytest args `-s` still doesnt function the same but now we return the result object which has captured stdout and stderror on it. This doesnt effect capsys etc as they already accomodate that.

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
