### PR TITLE
4558 error message for n divertors 12

### DIFF
--- a/process/models/build.py
+++ b/process/models/build.py
@@ -420,7 +420,7 @@ class Build(Model):
         Raises
         ------
         ProcessValueError
-            If constraint 39 is being used with i_pulsed_plant=0
+            Only 1 or 2 divertors are supported
 
         """
         if self.data.divertor.n_divertors not in {1, 2}:

--- a/process/models/build.py
+++ b/process/models/build.py
@@ -8,6 +8,7 @@ from tabulate import tabulate
 
 from process.core import constants
 from process.core import process_output as po
+from process.core.exceptions import ProcessValueError
 from process.core.model import Model
 from process.data_structure.build_variables import (
     CSPrecompressionConfiguration,
@@ -415,7 +416,19 @@ class Build(Model):
         ----------
         output : bool
             Flag indicating whether to output results
+
+        Raises
+        ------
+        ProcessValueError
+            If constraint 39 is being used with i_pulsed_plant=0
+
         """
+        if self.data.divertor.n_divertors not in {1, 2}:
+            raise ProcessValueError(
+                f"n_divertors = {self.data.divertor.n_divertors} is invalid. "
+                "Only 1 or 2 divertors are supported."
+            )
+
         # Set the X-point heights for the top and bottom of the plasma
         # Assumes top-down plasma symmetry
         self.data.build.z_plasma_xpoint_upper = (
@@ -819,13 +832,6 @@ class Build(Model):
                 ("Calculated maximum divertor height (m)", "(divht)", divht),
             ]:
                 po.ovarre(self.outfile, desc, name, var, "OP ")
-        else:
-            po.oheadr(self.outfile, "Divertor build and plasma position")
-            po.ocmmnt(
-                self.outfile,
-                "ERROR: null value not supported, check i_single_null value.",
-            )
-
         po.ovarre(
             self.outfile,
             "Divertor poloidal angle subtended by plasma (degrees)",

--- a/tests/unit/models/test_build.py
+++ b/tests/unit/models/test_build.py
@@ -2,6 +2,8 @@ from typing import Any, NamedTuple
 
 import pytest
 
+from process.core.exceptions import ProcessValueError
+
 
 @pytest.fixture
 def build(process_models):
@@ -385,3 +387,13 @@ def test_plasma_outboard_edge_toroidal_ripple_additional(param, build):
         # Results should be finite and positive
         assert ripple > 0.0
         assert r_tf_outboard_midmin > 0.0
+
+
+def test_invalid_n_divertors_raises(build, monkeypatch):
+    monkeypatch.setattr(build.data.divertor, "n_divertors", 3)
+
+    with pytest.raises(
+        ProcessValueError,
+        match="n_divertors = 3 is invalid",
+    ):
+        build.calculate_vertical_build(output=False)


### PR DESCRIPTION
## Description

Validate n_divertors before performing the vertical-build calculations and remove the error-handling branch from divertor_geom_output(). Added a test to check this validation is working.

## Checklist

I confirm that I have completed the following checks:

- [ ] My changes follow the [PROCESS style guide](https://ukaea.github.io/PROCESS/development/standards/)
- [ ] I have justified any large differences in the regression tests caused by this pull request in the comments.
- [ ] I have added new tests where appropriate for the changes I have made.
- [ ] If I have had to change any existing unit or integration tests, I have justified this change in the pull request comments.
- [ ] If I have made documentation changes, I have checked they render correctly.
- [ ] I have added documentation for my change, if appropriate.
