### PR TITLE
Remove fortran indexing in Reinke output

### DIFF
--- a/process/models/physics/physics.py
+++ b/process/models/physics/physics.py
@@ -1115,11 +1115,14 @@ class Physics(Model):
                     " is at least notable"
                 )
 
+            impurity_frac = self.data.impurity_radiation.f_nd_impurity_electron_array[
+                self.data.reinke.impvardiv - 1
+            ]
             po.write(
                 self.outfile,
                 (
                     f" 'fzactual, frac, impvardiv = {self.data.reinke.fzactual},"
-                    f" {self.data.impurity_radiation.f_nd_impurity_electron_array(self.data.reinke.impvardiv)},"  # noqa: E501
+                    f" {impurity_frac},"
                     f" {self.data.reinke.impvardiv}"
                 ),
             )


### PR DESCRIPTION
Also checked the rest of the code for such indexing using regex, no other cases can be found